### PR TITLE
[codex] Add native Next 16 robots.txt and sitemap.xml

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next'
+import { getServerEnv } from '@/lib/env'
+
+const siteUrl = new URL(getServerEnv().appUrl)
+const sitemapUrl = new URL('/sitemap.xml', siteUrl).toString()
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/_next',
+        '/_next/',
+        '/api',
+        '/api/',
+        '/admin',
+        '/admin/',
+        '/vendor',
+        '/vendor/',
+        '/cuenta',
+        '/cuenta/',
+        '/carrito',
+        '/checkout',
+        '/checkout/',
+        '/login',
+        '/register',
+        '/forgot-password',
+        '/recuperar-contrasena',
+        '/reset-password',
+        '/reset-password/',
+        '/buscar',
+      ],
+    },
+    sitemap: sitemapUrl,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,77 @@
+import type { MetadataRoute } from 'next'
+import { db } from '@/lib/db'
+import { getAvailableProductWhere } from '@/domains/catalog/availability'
+import { getServerEnv } from '@/lib/env'
+
+export const revalidate = 300
+
+const siteUrl = new URL(getServerEnv().appUrl)
+
+const toAbsoluteUrl = (path: string) => new URL(path, siteUrl).toString()
+
+const staticRoutes: MetadataRoute.Sitemap = [
+  { url: toAbsoluteUrl('/'), changeFrequency: 'weekly', priority: 1 },
+  { url: toAbsoluteUrl('/productos'), changeFrequency: 'daily', priority: 0.9 },
+  { url: toAbsoluteUrl('/productores'), changeFrequency: 'weekly', priority: 0.85 },
+  { url: toAbsoluteUrl('/sobre-nosotros'), changeFrequency: 'monthly', priority: 0.4 },
+  { url: toAbsoluteUrl('/como-funciona'), changeFrequency: 'monthly', priority: 0.55 },
+  { url: toAbsoluteUrl('/como-vender'), changeFrequency: 'monthly', priority: 0.55 },
+  { url: toAbsoluteUrl('/faq'), changeFrequency: 'monthly', priority: 0.35 },
+  { url: toAbsoluteUrl('/contacto'), changeFrequency: 'monthly', priority: 0.35 },
+  { url: toAbsoluteUrl('/privacidad'), changeFrequency: 'yearly', priority: 0.2 },
+]
+
+async function getActiveProductRoutes() {
+  const products = await db.product.findMany({
+    where: getAvailableProductWhere(),
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      slug: true,
+      updatedAt: true,
+    },
+  })
+
+  return products.map(product => ({
+    url: toAbsoluteUrl(`/productos/${product.slug}`),
+    lastModified: product.updatedAt,
+    changeFrequency: 'weekly' as const,
+    priority: 0.8,
+  }))
+}
+
+async function getActiveVendorRoutes() {
+  const vendors = await db.vendor.findMany({
+    where: { status: 'ACTIVE' },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      slug: true,
+      updatedAt: true,
+    },
+  })
+
+  return vendors.map(vendor => ({
+    url: toAbsoluteUrl(`/productores/${vendor.slug}`),
+    lastModified: vendor.updatedAt,
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }))
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const entries: MetadataRoute.Sitemap = [...staticRoutes]
+
+  const [productsResult, vendorsResult] = await Promise.allSettled([
+    getActiveProductRoutes(),
+    getActiveVendorRoutes(),
+  ])
+
+  if (productsResult.status === 'fulfilled') {
+    entries.push(...productsResult.value)
+  }
+
+  if (vendorsResult.status === 'fulfilled') {
+    entries.push(...vendorsResult.value)
+  }
+
+  return entries
+}


### PR DESCRIPTION
## What changed
- added native App Router metadata handlers for `robots.txt` and `sitemap.xml`
- configured `robots.txt` with absolute sitemap URL and disallow rules for private and technical areas
- generated `sitemap.xml` for public static pages plus active products and active vendors

## Why
The storefront was not exposing crawler guidance or a discoverable sitemap, which weakens indexing and crawl prioritization.

## Impact
- search engines get explicit crawl rules
- public catalog and vendor pages are easier to discover
- private areas stay out of crawl scope

## Validation
- implementation follows the local Next 16 docs for `robots.ts` and `sitemap.ts`
- reviewed generated paths and exclusions against the current route tree

Closes #143
