### PR TITLE
[codex] Ignore wiki source docs in app repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# Local wiki source is published to the GitHub wiki repo separately
+docs/wiki/


### PR DESCRIPTION
## What changed
- ignored `docs/wiki/` in the repo-level `.gitignore`

## Why
The wiki source is published to the GitHub wiki repository separately, so keeping it untracked in this repo avoids repeated local status noise.

## Impact
- local checkouts stop surfacing `docs/wiki` as untracked once synced
- the wiki publication workflow stays separated from the application repo

## Validation
- `git diff --check`
- verified `docs/wiki` disappears from local `git status` after excluding it
