### PR TITLE
[codex] Noindex internal search results

### DIFF
--- a/src/app/(public)/buscar/page.tsx
+++ b/src/app/(public)/buscar/page.tsx
@@ -24,6 +24,10 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   return {
     title: `Buscar: ${query} | Mercado Productor`,
     description: `Resultados de búsqueda para "${query}" en Mercado Productor`,
+    robots: {
+      index: false,
+      follow: true,
+    },
   }
 }
 


### PR DESCRIPTION
## What changed
- added `robots: { index: false, follow: true }` to the search page metadata

## Why
Internal search results should not be indexed by search engines, even when query params vary.

## Impact
- `/buscar` and its query variants emit `noindex`
- crawler guidance now matches the intended SEO policy for internal search

## Validation
- reviewed page metadata output at the route level
- change is scoped to the search page only

Closes #145
