### PR TITLE
[codex] DB: add vendor review timeline indexes

### DIFF
--- a/prisma/migrations/20260411093000_add_vendor_created_at_indexes/migration.sql
+++ b/prisma/migrations/20260411093000_add_vendor_created_at_indexes/migration.sql
@@ -1,0 +1,3 @@
+-- Add composite indexes for vendor timelines and review feeds.
+CREATE INDEX "OrderLine_vendorId_createdAt_idx" ON "OrderLine"("vendorId", "createdAt");
+CREATE INDEX "Review_vendorId_createdAt_idx" ON "Review"("vendorId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -391,6 +391,7 @@ model OrderLine {
 
   @@index([orderId])
   @@index([vendorId])
+  @@index([vendorId, createdAt])
 }
 
 model Review {
@@ -411,6 +412,7 @@ model Review {
   @@unique([orderId, productId])
   @@index([productId])
   @@index([vendorId])
+  @@index([vendorId, createdAt])
   @@index([customerId])
 }
 


### PR DESCRIPTION
## What changed
- Added composite indexes on `OrderLine(vendorId, createdAt)` and `Review(vendorId, createdAt)`.
- Added the corresponding Prisma migration so the database gets the new indexes.

## Why
- Vendor review feeds and timeline-style queries sort by `createdAt` after filtering by `vendorId`.
- The previous schema already had simple vendor indexes, but these composite indexes better match the hottest query pattern.

## Validation
- `git diff --check`
- `npm --prefix /home/whisper/marketplace exec prisma validate --schema /home/whisper/worktrees/marketplace-134/prisma/schema.prisma`
