### PR TITLE
[codex] Stripe: retry transient webhook failures

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -5,6 +5,7 @@ import {
   doesWebhookPaymentMatchStoredPayment,
   getWebhookIdempotencyKey,
   isMockWebhookAllowed,
+  retryWebhookOperation,
   shouldApplyPaymentFailed,
   shouldApplyPaymentSucceeded,
 } from '@/domains/payments/webhook'
@@ -116,10 +117,14 @@ export async function POST(req: NextRequest) {
 }
 
 async function handlePaymentSucceeded(providerRef: string, amount?: number, currency?: string, eventId?: string) {
-  const payment = await db.payment.findUnique({
-    where: { providerRef },
-    include: { order: true },
-  })
+  const payment = await retryWebhookOperation(
+    () =>
+      db.payment.findUnique({
+        where: { providerRef },
+        include: { order: true },
+      }),
+    { operationName: 'load payment for succeeded webhook' }
+  )
   if (!payment) return
   assertProviderRefForPaymentStatus({
     providerRef: payment.providerRef,
@@ -140,20 +145,24 @@ async function handlePaymentSucceeded(providerRef: string, amount?: number, curr
       eventId,
     })
 
-    await db.orderEvent.create({
-      data: {
-        orderId: payment.orderId,
-        type: 'PAYMENT_MISMATCH',
-        payload: createPaymentMismatchEventPayload({
-          providerRef,
-          amount,
-          currency,
-          eventId,
-          expectedAmount: Number(payment.amount),
-          expectedCurrency: payment.currency,
+    await retryWebhookOperation(
+      () =>
+        db.orderEvent.create({
+          data: {
+            orderId: payment.orderId,
+            type: 'PAYMENT_MISMATCH',
+            payload: createPaymentMismatchEventPayload({
+              providerRef,
+              amount,
+              currency,
+              eventId,
+              expectedAmount: Number(payment.amount),
+              expectedCurrency: payment.currency,
+            }),
+          },
         }),
-      },
-    })
+      { operationName: 'record payment mismatch' }
+    )
 
     // DO NOT confirm this order - amount verification failed
     return
@@ -165,40 +174,57 @@ async function handlePaymentSucceeded(providerRef: string, amount?: number, curr
     orderStatus: payment.order.status,
   })) return
 
-  await db.$transaction(async tx => {
-    const paymentUpdate = await tx.payment.updateMany({
-      where: { providerRef, status: { not: 'SUCCEEDED' } },
-      data: { status: 'SUCCEEDED' },
-    })
+  await retryWebhookOperation(
+    () =>
+      db.$transaction(async tx => {
+        const paymentUpdate = await tx.payment.updateMany({
+          where: { providerRef, status: { not: 'SUCCEEDED' } },
+          data: { status: 'SUCCEEDED' },
+        })
 
-    const orderUpdate = await tx.order.updateMany({
-      where: {
-        id: payment.orderId,
-        OR: [
-          { paymentStatus: { not: 'SUCCEEDED' } },
-          { status: { not: 'PAYMENT_CONFIRMED' } },
-        ],
-      },
-      data: { status: 'PAYMENT_CONFIRMED', paymentStatus: 'SUCCEEDED' },
-    })
+        const orderUpdate = await tx.order.updateMany({
+          where: {
+            id: payment.orderId,
+            OR: [
+              { paymentStatus: { not: 'SUCCEEDED' } },
+              { status: { not: 'PAYMENT_CONFIRMED' } },
+            ],
+          },
+          data: { status: 'PAYMENT_CONFIRMED', paymentStatus: 'SUCCEEDED' },
+        })
 
-    if (paymentUpdate.count > 0 || orderUpdate.count > 0) {
-      await tx.orderEvent.create({
-        data: {
-          orderId: payment.orderId,
-          type: 'PAYMENT_CONFIRMED',
-          payload: createPaymentConfirmedEventPayload({ providerRef, amount, eventId }),
-        },
-      })
-    }
+        if (paymentUpdate.count > 0 || orderUpdate.count > 0) {
+          await tx.orderEvent.create({
+            data: {
+              orderId: payment.orderId,
+              type: 'PAYMENT_CONFIRMED',
+              payload: createPaymentConfirmedEventPayload({ providerRef, amount, eventId }),
+            },
+          })
+        }
+      }),
+    { operationName: 'confirm payment webhook' }
+  ).catch(async error => {
+    await recordWebhookRetryExhaustion({
+      orderId: payment.orderId,
+      stage: 'confirm_payment',
+      providerRef,
+      eventId,
+      error,
+    })
+    throw error
   })
 }
 
 async function handlePaymentFailed(providerRef: string, eventId?: string) {
-  const payment = await db.payment.findUnique({
-    where: { providerRef },
-    include: { order: true },
-  })
+  const payment = await retryWebhookOperation(
+    () =>
+      db.payment.findUnique({
+        where: { providerRef },
+        include: { order: true },
+      }),
+    { operationName: 'load payment for failed webhook' }
+  )
   if (!payment) return
 
   if (!shouldApplyPaymentFailed({
@@ -207,25 +233,70 @@ async function handlePaymentFailed(providerRef: string, eventId?: string) {
     orderStatus: payment.order.status,
   })) return
 
-  await db.$transaction(async tx => {
-    const paymentUpdate = await tx.payment.updateMany({
-      where: { providerRef, status: 'PENDING' },
-      data: { status: 'FAILED' },
-    })
+  await retryWebhookOperation(
+    () =>
+      db.$transaction(async tx => {
+        const paymentUpdate = await tx.payment.updateMany({
+          where: { providerRef, status: 'PENDING' },
+          data: { status: 'FAILED' },
+        })
 
-    const orderUpdate = await tx.order.updateMany({
-      where: { id: payment.orderId, paymentStatus: 'PENDING' },
-      data: { paymentStatus: 'FAILED' },
-    })
+        const orderUpdate = await tx.order.updateMany({
+          where: { id: payment.orderId, paymentStatus: 'PENDING' },
+          data: { paymentStatus: 'FAILED' },
+        })
 
-    if (paymentUpdate.count > 0 || orderUpdate.count > 0) {
-      await tx.orderEvent.create({
-        data: {
-          orderId: payment.orderId,
-          type: 'PAYMENT_FAILED',
-          payload: createPaymentFailedEventPayload({ providerRef, eventId }),
-        },
-      })
-    }
+        if (paymentUpdate.count > 0 || orderUpdate.count > 0) {
+          await tx.orderEvent.create({
+            data: {
+              orderId: payment.orderId,
+              type: 'PAYMENT_FAILED',
+              payload: createPaymentFailedEventPayload({ providerRef, eventId }),
+            },
+          })
+        }
+      }),
+    { operationName: 'mark payment as failed' }
+  ).catch(async error => {
+    await recordWebhookRetryExhaustion({
+      orderId: payment.orderId,
+      stage: 'mark_failed',
+      providerRef,
+      eventId,
+      error,
+    })
+    throw error
   })
+}
+
+async function recordWebhookRetryExhaustion({
+  orderId,
+  stage,
+  providerRef,
+  eventId,
+  error,
+}: {
+  orderId: string
+  stage: string
+  providerRef: string
+  eventId?: string
+  error: unknown
+}) {
+  try {
+    await db.orderEvent.create({
+      data: {
+        orderId,
+        type: 'PAYMENT_WEBHOOK_RETRY_EXHAUSTED',
+        payload: {
+          providerRef,
+          eventId,
+          stage,
+          error: error instanceof Error ? error.message : String(error),
+          recordedAt: new Date().toISOString(),
+        },
+      },
+    })
+  } catch (recordError) {
+    console.error('[stripe-webhook][dead-letter-record-failed]', recordError)
+  }
 }

--- a/src/domains/payments/webhook.ts
+++ b/src/domains/payments/webhook.ts
@@ -21,6 +21,35 @@ interface PaymentStatusTransitionInput {
   nextStatus: PaymentStatus
 }
 
+interface RetryWebhookOperationOptions {
+  operationName: string
+  maxAttempts?: number
+  baseDelayMs?: number
+  sleep?: (delayMs: number) => Promise<void>
+  onRetry?: (context: { attempt: number; delayMs: number; error: unknown }) => void | Promise<void>
+}
+
+const RETRYABLE_PRISMA_ERROR_CODES = new Set(['P1001', 'P1002', 'P1008', 'P1017', 'P2024'])
+const RETRYABLE_NODE_ERROR_CODES = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+])
+
+function getWebhookErrorCode(error: unknown) {
+  if (!error || typeof error !== 'object') return undefined
+  const code = 'code' in error ? (error as { code?: unknown }).code : undefined
+  return typeof code === 'string' ? code : undefined
+}
+
+function getWebhookErrorMessage(error: unknown) {
+  if (!error || typeof error !== 'object') return ''
+  const message = 'message' in error ? (error as { message?: unknown }).message : undefined
+  return typeof message === 'string' ? message : ''
+}
+
 /**
  * Returns true if the mock webhook path is safe to use.
  * In production, mock processing must be blocked to prevent spoofed events.
@@ -64,6 +93,63 @@ export function assertProviderRefForPaymentStatus({
   if (nextStatus === 'SUCCEEDED' && (!providerRef || providerRef.trim().length === 0)) {
     throw new Error('providerRef requerido para marcar pago como completado')
   }
+}
+
+export function isRetryableWebhookError(error: unknown) {
+  const code = getWebhookErrorCode(error)
+  if (code && (RETRYABLE_PRISMA_ERROR_CODES.has(code) || RETRYABLE_NODE_ERROR_CODES.has(code))) {
+    return true
+  }
+
+  const message = getWebhookErrorMessage(error).toLowerCase()
+  return (
+    message.includes('timeout') ||
+    message.includes('temporarily unavailable') ||
+    message.includes('connection reset') ||
+    message.includes('connection refused') ||
+    message.includes('server closed the connection')
+  )
+}
+
+export async function retryWebhookOperation<T>(
+  operation: () => Promise<T>,
+  {
+    operationName,
+    maxAttempts = 3,
+    baseDelayMs = 100,
+    sleep = delayMs => new Promise(resolve => setTimeout(resolve, delayMs)),
+    onRetry,
+  }: RetryWebhookOperationOptions
+): Promise<T> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      if (!isRetryableWebhookError(error) || attempt === maxAttempts) {
+        if (attempt === maxAttempts) {
+          console.error('[stripe-webhook][retry-exhausted]', {
+            operation: operationName,
+            attempts: maxAttempts,
+            error,
+          })
+        }
+        throw error
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1)
+      console.warn('[stripe-webhook][retry]', {
+        operation: operationName,
+        attempt,
+        nextAttempt: attempt + 1,
+        delayMs,
+        error,
+      })
+      await onRetry?.({ attempt, delayMs, error })
+      await sleep(delayMs)
+    }
+  }
+
+  throw new Error(`Webhook retry loop failed unexpectedly for ${operationName}`)
 }
 
 /**

--- a/test/payments-webhook.test.ts
+++ b/test/payments-webhook.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import {
   assertProviderRefForPaymentStatus,
   doesWebhookPaymentMatchStoredPayment,
+  isRetryableWebhookError,
+  retryWebhookOperation,
   shouldApplyPaymentFailed,
   shouldApplyPaymentSucceeded,
 } from '@/domains/payments/webhook'
@@ -152,4 +154,37 @@ test('doesWebhookPaymentMatchStoredPayment handles rounding correctly for amount
     ),
     true
   )
+})
+
+test('isRetryableWebhookError detects transient database failures', () => {
+  const error = Object.assign(new Error('database timeout'), { code: 'P1002' })
+  assert.equal(isRetryableWebhookError(error), true)
+  assert.equal(isRetryableWebhookError(new Error('invalid signature')), false)
+})
+
+test('retryWebhookOperation retries transient failures with exponential backoff', async () => {
+  const delays: number[] = []
+  let attempts = 0
+
+  const result = await retryWebhookOperation(
+    async () => {
+      attempts += 1
+      if (attempts < 3) {
+        const error = Object.assign(new Error('temporary database timeout'), { code: 'P1002' })
+        throw error
+      }
+
+      return 'ok'
+    },
+    {
+      operationName: 'test retry',
+      sleep: async delayMs => {
+        delays.push(delayMs)
+      },
+    }
+  )
+
+  assert.equal(result, 'ok')
+  assert.equal(attempts, 3)
+  assert.deepEqual(delays, [100, 200])
 })


### PR DESCRIPTION
## What changed
- Added retry/backoff helpers for webhook operations that hit transient database or network failures.
- Wrapped Stripe webhook reads and writes in retry logic with exponential backoff.
- Added a lightweight dead-letter style `PAYMENT_WEBHOOK_RETRY_EXHAUSTED` order event when retries are exhausted.
- Added unit coverage for retry classification and backoff behavior.

## Why
- A temporary DB outage could previously drop a Stripe webhook on the floor and leave payment state inconsistent.
- The new logic retries transient failures a few times before surfacing the error to Stripe for its own retry cycle.

## Validation
- `git diff --check`
- `node --import /home/whisper/worktrees/marketplace-135/node_modules/tsx/dist/loader.mjs --test test/payments-webhook.test.ts`
- `NODE_ENV=test node --env-file=/home/whisper/marketplace/.env --env-file-if-exists=/home/whisper/marketplace/.env.test --import /home/whisper/worktrees/marketplace-135/node_modules/tsx/dist/loader.mjs --test --test-name-pattern='stripe webhook' test/integration/stripe-webhook.test.ts`
