### PR TITLE
fix: wrap address default updates in transactions (#178)

### DIFF
--- a/src/app/api/direcciones/[id]/route.ts
+++ b/src/app/api/direcciones/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
+import { clearOtherDefaults, promoteOldestAsDefault } from '@/lib/address-defaults'
 
 const addressSchema = z.object({
   label: z.string().max(50).optional(),
@@ -41,21 +42,19 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Dirección no encontrada' }, { status: 404 })
     }
 
-    // If setting as default, clear isDefault for all other addresses
-    if (validated.isDefault && !existingAddress.isDefault) {
-      await db.address.updateMany({
-        where: { userId: session.user.id, id: { not: id } },
-        data: { isDefault: false },
-      })
-    }
+    const address = await db.$transaction(async (tx) => {
+      if (validated.isDefault && !existingAddress.isDefault) {
+        await clearOtherDefaults(tx, session.user.id, id)
+      }
 
-    const address = await db.address.update({
-      where: { id },
-      data: {
-        ...validated,
-        label: validated.label || undefined,
-        line2: validated.line2 || undefined,
-      },
+      return tx.address.update({
+        where: { id },
+        data: {
+          ...validated,
+          label: validated.label || undefined,
+          line2: validated.line2 || undefined,
+        },
+      })
     })
 
     return NextResponse.json(address)
@@ -96,23 +95,11 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Dirección no encontrada' }, { status: 404 })
     }
 
-    // If it was default, set another as default
-    if (address.isDefault) {
-      const nextDefault = await db.address.findFirst({
-        where: { userId: session.user.id, id: { not: id } },
-        orderBy: { createdAt: 'asc' },
-      })
-
-      if (nextDefault) {
-        await db.address.update({
-          where: { id: nextDefault.id },
-          data: { isDefault: true },
-        })
+    await db.$transaction(async (tx) => {
+      await tx.address.delete({ where: { id } })
+      if (address.isDefault) {
+        await promoteOldestAsDefault(tx, session.user.id)
       }
-    }
-
-    await db.address.delete({
-      where: { id },
     })
 
     return NextResponse.json({ success: true })

--- a/src/app/api/direcciones/route.ts
+++ b/src/app/api/direcciones/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
+import { clearOtherDefaults } from '@/lib/address-defaults'
 
 const addressSchema = z.object({
   label: z.string().max(50).optional(),
@@ -49,21 +50,19 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const validated = addressSchema.parse(body)
 
-    // If setting as default, clear isDefault for all other addresses
-    if (validated.isDefault) {
-      await db.address.updateMany({
-        where: { userId: session.user.id },
-        data: { isDefault: false },
-      })
-    }
+    const address = await db.$transaction(async (tx) => {
+      if (validated.isDefault) {
+        await clearOtherDefaults(tx, session.user.id)
+      }
 
-    const address = await db.address.create({
-      data: {
-        ...validated,
-        userId: session.user.id,
-        label: validated.label || undefined,
-        line2: validated.line2 || undefined,
-      },
+      return tx.address.create({
+        data: {
+          ...validated,
+          userId: session.user.id,
+          label: validated.label || undefined,
+          line2: validated.line2 || undefined,
+        },
+      })
     })
 
     return NextResponse.json(address, { status: 201 })

--- a/src/lib/address-defaults.ts
+++ b/src/lib/address-defaults.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers for managing the "default address" invariant atomically.
+ *
+ * The invariant: at most one address per user has isDefault = true.
+ * These helpers are designed to run inside a Prisma `$transaction` so that
+ * clearing the previous default and setting the new one happen atomically.
+ */
+
+type AddressDelegate = {
+  updateMany: (args: {
+    where: { userId: string; isDefault: boolean; id?: { not: string } }
+    data: { isDefault: boolean }
+  }) => Promise<{ count: number }>
+  findFirst: (args: {
+    where: { userId: string; id?: { not: string } }
+    orderBy: { createdAt: 'asc' | 'desc' }
+  }) => Promise<{ id: string } | null>
+  update: (args: {
+    where: { id: string }
+    data: { isDefault: boolean }
+  }) => Promise<unknown>
+}
+
+export type AddressTxClient = { address: AddressDelegate }
+
+export async function clearOtherDefaults(
+  tx: AddressTxClient,
+  userId: string,
+  exceptId?: string
+): Promise<number> {
+  const where: { userId: string; isDefault: boolean; id?: { not: string } } = {
+    userId,
+    isDefault: true,
+  }
+  if (exceptId) where.id = { not: exceptId }
+
+  const result = await tx.address.updateMany({ where, data: { isDefault: false } })
+  return result.count
+}
+
+export async function promoteOldestAsDefault(
+  tx: AddressTxClient,
+  userId: string
+): Promise<string | null> {
+  const next = await tx.address.findFirst({
+    where: { userId },
+    orderBy: { createdAt: 'asc' },
+  })
+  if (!next) return null
+  await tx.address.update({ where: { id: next.id }, data: { isDefault: true } })
+  return next.id
+}

--- a/test/address-defaults.test.ts
+++ b/test/address-defaults.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  clearOtherDefaults,
+  promoteOldestAsDefault,
+  type AddressTxClient,
+} from '@/lib/address-defaults'
+
+type Call = { method: string; args: unknown }
+
+function createMockTx(options: {
+  findFirstResult?: { id: string } | null
+} = {}): { tx: AddressTxClient; calls: Call[] } {
+  const calls: Call[] = []
+  const tx: AddressTxClient = {
+    address: {
+      updateMany: async (args) => {
+        calls.push({ method: 'updateMany', args })
+        return { count: 1 }
+      },
+      findFirst: async (args) => {
+        calls.push({ method: 'findFirst', args })
+        return options.findFirstResult ?? null
+      },
+      update: async (args) => {
+        calls.push({ method: 'update', args })
+        return {}
+      },
+    },
+  }
+  return { tx, calls }
+}
+
+test('clearOtherDefaults clears defaults for the user', async () => {
+  const { tx, calls } = createMockTx()
+  await clearOtherDefaults(tx, 'user-1')
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.method, 'updateMany')
+  assert.deepEqual(calls[0]!.args, {
+    where: { userId: 'user-1', isDefault: true },
+    data: { isDefault: false },
+  })
+})
+
+test('clearOtherDefaults excludes the address being promoted', async () => {
+  const { tx, calls } = createMockTx()
+  await clearOtherDefaults(tx, 'user-1', 'addr-keep')
+
+  assert.deepEqual(calls[0]!.args, {
+    where: { userId: 'user-1', isDefault: true, id: { not: 'addr-keep' } },
+    data: { isDefault: false },
+  })
+})
+
+test('promoteOldestAsDefault returns null when no addresses remain', async () => {
+  const { tx, calls } = createMockTx({ findFirstResult: null })
+  const result = await promoteOldestAsDefault(tx, 'user-1')
+
+  assert.equal(result, null)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.method, 'findFirst')
+})
+
+test('promoteOldestAsDefault sets the oldest remaining address as default', async () => {
+  const { tx, calls } = createMockTx({ findFirstResult: { id: 'addr-2' } })
+  const result = await promoteOldestAsDefault(tx, 'user-1')
+
+  assert.equal(result, 'addr-2')
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0]!.method, 'findFirst')
+  assert.deepEqual(calls[0]!.args, {
+    where: { userId: 'user-1' },
+    orderBy: { createdAt: 'asc' },
+  })
+  assert.equal(calls[1]!.method, 'update')
+  assert.deepEqual(calls[1]!.args, {
+    where: { id: 'addr-2' },
+    data: { isDefault: true },
+  })
+})
+
+test('promoteOldestAsDefault picks ascending createdAt order', async () => {
+  const { tx, calls } = createMockTx({ findFirstResult: { id: 'addr-x' } })
+  await promoteOldestAsDefault(tx, 'user-9')
+
+  const findCall = calls.find((c) => c.method === 'findFirst')!
+  assert.deepEqual((findCall.args as { orderBy: unknown }).orderBy, { createdAt: 'asc' })
+})


### PR DESCRIPTION
Closes #178

## Summary
- Wraps address `POST`, `PUT`, and `DELETE` handlers in `db.$transaction` so the "at most one default per user" invariant cannot drift if a query mid-flow fails
- Extracts the shared logic to `src/lib/address-defaults.ts` (`clearOtherDefaults` and `promoteOldestAsDefault`) so it is unit-testable without spinning up Prisma
- Adds 5 unit tests covering both helpers (with and without `exceptId`, empty / populated remaining sets, ordering)

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 365/365 pass, including 5 new tests for `address-defaults`
- [ ] Manual: create / update / delete addresses through the buyer account UI and confirm only one is marked default at any time

🤖 Generated with [Claude Code](https://claude.com/claude-code)