### PR TITLE
fix: rely on P2002 for duplicate-email detection at register (#180)

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -16,6 +16,8 @@ const schema = z.object({
   password: z.string().min(8).max(100),
 })
 
+import { isUniqueConstraintViolation } from '@/lib/prisma-errors'
+
 export async function POST(req: NextRequest) {
   let createdUser: { id: string; firstName: string; email: string } | null = null
 
@@ -42,23 +44,26 @@ export async function POST(req: NextRequest) {
     const body = await req.json()
     const data = schema.parse(body)
 
-    const existing = await db.user.findUnique({ where: { email: data.email } })
-    if (existing) {
-      return NextResponse.json({ message: 'Este email ya está registrado' }, { status: 409 })
-    }
-
     const passwordHash = await bcrypt.hash(data.password, 12)
 
-    createdUser = await db.user.create({
-      data: {
-        firstName: data.firstName,
-        lastName: data.lastName,
-        email: data.email,
-        passwordHash,
-        role: 'CUSTOMER',
-        emailVerified: null, // Require email verification before access
-      },
-    })
+    try {
+      createdUser = await db.user.create({
+        data: {
+          firstName: data.firstName,
+          lastName: data.lastName,
+          email: data.email,
+          passwordHash,
+          role: 'CUSTOMER',
+          emailVerified: null, // Require email verification before access
+        },
+        select: { id: true, firstName: true, email: true },
+      })
+    } catch (createErr) {
+      if (isUniqueConstraintViolation(createErr)) {
+        return NextResponse.json({ message: 'Este email ya está registrado' }, { status: 409 })
+      }
+      throw createErr
+    }
 
     const token = await createEmailVerificationToken(createdUser.id)
     const verificationLink = new URL('/api/auth/verify-email', getServerEnv().appUrl)
@@ -93,3 +98,4 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message: 'Error interno' }, { status: 500 })
   }
 }
+

--- a/src/lib/prisma-errors.ts
+++ b/src/lib/prisma-errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Duck-typed Prisma error inspectors. We avoid importing
+ * `Prisma.PrismaClientKnownRequestError` directly so this module stays cheap
+ * to load and easy to unit-test in isolation.
+ */
+
+function getErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const code = (err as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}
+
+/** Prisma `P2002` — unique constraint violation. */
+export function isUniqueConstraintViolation(err: unknown): boolean {
+  return getErrorCode(err) === 'P2002'
+}
+
+/** Prisma `P2025` — record required by an operation was not found. */
+export function isRecordNotFoundError(err: unknown): boolean {
+  return getErrorCode(err) === 'P2025'
+}

--- a/test/prisma-errors.test.ts
+++ b/test/prisma-errors.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { isUniqueConstraintViolation, isRecordNotFoundError } from '@/lib/prisma-errors'
+
+test('isUniqueConstraintViolation matches Prisma P2002 errors', () => {
+  assert.equal(isUniqueConstraintViolation({ code: 'P2002' }), true)
+  assert.equal(
+    isUniqueConstraintViolation({ code: 'P2002', meta: { target: ['email'] } }),
+    true
+  )
+})
+
+test('isUniqueConstraintViolation rejects unrelated errors', () => {
+  assert.equal(isUniqueConstraintViolation({ code: 'P2025' }), false)
+  assert.equal(isUniqueConstraintViolation(new Error('boom')), false)
+  assert.equal(isUniqueConstraintViolation({ code: 1234 }), false)
+  assert.equal(isUniqueConstraintViolation(null), false)
+  assert.equal(isUniqueConstraintViolation(undefined), false)
+  assert.equal(isUniqueConstraintViolation('P2002'), false)
+})
+
+test('isRecordNotFoundError matches Prisma P2025 errors only', () => {
+  assert.equal(isRecordNotFoundError({ code: 'P2025' }), true)
+  assert.equal(isRecordNotFoundError({ code: 'P2002' }), false)
+  assert.equal(isRecordNotFoundError(null), false)
+})


### PR DESCRIPTION
Closes #180

## Summary
- Removes the racy `findUnique` pre-check in `/api/auth/register`
- Catches Prisma `P2002` from `db.user.create` and returns `409` instead — concurrent registrations with the same email can no longer both pass the pre-check
- Adds `src/lib/prisma-errors.ts` with duck-typed `isUniqueConstraintViolation` and `isRecordNotFoundError` (no direct import of `Prisma.PrismaClientKnownRequestError`, keeps the helper cheap)
- Adds 3 unit tests covering matching, rejection of unrelated codes, and null/undefined safety

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 374/374 pass (3 new tests)
- [ ] Manual: register a user, then attempt to register the same email again — verify a 409 is returned with a friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)