### PR TITLE
fix: rate-limit forgot-password, account-export, account-delete (#181)

### DIFF
--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -8,6 +8,7 @@
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
+import { checkRateLimit } from '@/lib/ratelimit'
 
 export async function DELETE() {
   const session = await auth()
@@ -17,6 +18,22 @@ export async function DELETE() {
   }
 
   const userId = session.user.id
+
+  const rateLimitResult = await checkRateLimit('account-delete', userId, 3, 3600)
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: rateLimitResult.message ?? 'Demasiadas solicitudes' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000).toString(),
+          'X-RateLimit-Limit': '3',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': rateLimitResult.resetAt.toString(),
+        },
+      }
+    )
+  }
 
   try {
     await db.$transaction([

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -8,6 +8,7 @@
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
+import { checkRateLimit } from '@/lib/ratelimit'
 
 export async function GET() {
   const session = await auth()
@@ -17,6 +18,22 @@ export async function GET() {
   }
 
   const userId = session.user.id
+
+  const rateLimitResult = await checkRateLimit('account-export', userId, 3, 3600)
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: rateLimitResult.message ?? 'Demasiadas solicitudes' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000).toString(),
+          'X-RateLimit-Limit': '3',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': rateLimitResult.resetAt.toString(),
+        },
+      }
+    )
+  }
 
   try {
     const [user, addresses, orders, reviews, incidents] = await Promise.all([

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createPasswordResetToken } from '@/domains/auth/email-verification'
+import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
 
 const schema = z.object({
   email: z.string().email('Email inválido'),
@@ -8,6 +9,23 @@ const schema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    const clientIP = getClientIP(req)
+    const rateLimitResult = await checkRateLimit('forgot-password', clientIP, 5, 3600)
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { message: rateLimitResult.message ?? 'Demasiadas solicitudes' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': Math.ceil((rateLimitResult.resetAt - Date.now()) / 1000).toString(),
+            'X-RateLimit-Limit': '5',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': rateLimitResult.resetAt.toString(),
+          },
+        }
+      )
+    }
+
     const body = await req.json()
     const data = schema.parse(body)
     await createPasswordResetToken(data.email)

--- a/test/ratelimit.test.ts
+++ b/test/ratelimit.test.ts
@@ -245,3 +245,31 @@ test('checkRateLimit Upstash path fails open when fetch throws', async () => {
     }
   }
 })
+
+test('forgot-password rate limit allows 5 then rejects (#181)', async () => {
+  const ip = '10.0.0.181'
+  for (let i = 0; i < 5; i += 1) {
+    const ok = await checkRateLimit('forgot-password', ip, 5, 3600)
+    assert.equal(ok.success, true, `attempt ${i + 1} should succeed`)
+  }
+  const blocked = await checkRateLimit('forgot-password', ip, 5, 3600)
+  assert.equal(blocked.success, false)
+  assert.equal(blocked.remaining, 0)
+})
+
+test('account-export and account-delete keep independent counters per user (#181)', async () => {
+  const userA = 'user-aaaaaa'
+  const userB = 'user-bbbbbb'
+
+  for (let i = 0; i < 3; i += 1) {
+    await checkRateLimit('account-export', userA, 3, 3600)
+  }
+  const blockedA = await checkRateLimit('account-export', userA, 3, 3600)
+  assert.equal(blockedA.success, false)
+
+  const okB = await checkRateLimit('account-export', userB, 3, 3600)
+  assert.equal(okB.success, true)
+
+  const okDelete = await checkRateLimit('account-delete', userA, 3, 3600)
+  assert.equal(okDelete.success, true)
+})


### PR DESCRIPTION
Closes #181

## Summary
- Adds `checkRateLimit` + `getClientIP` wiring to three previously uncapped endpoints:
  - `POST /api/auth/forgot-password` — 5 req/hour per IP
  - `GET /api/account/export` — 3 req/hour per authenticated user id
  - `DELETE /api/account/delete` — 3 req/hour per authenticated user id
- All three return HTTP 429 with `Retry-After` and `X-RateLimit-*` headers
- Adds 2 regression tests confirming the new action buckets trip at their configured limits and remain independent across users

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 376/376 pass (2 new tests)
- [ ] Manual: spam the three endpoints with curl and verify 429 after the configured limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)