### PR TITLE
fix: validate JWT role claim against UserRole enum (#182)

### DIFF
--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,8 +1,7 @@
 // Auth config shared between middleware (edge) and server code.
 // Must NOT import Prisma or any Node.js-only module.
 import type { NextAuthConfig } from 'next-auth'
-import type { UserRole } from '@/generated/prisma/enums'
-import { isAdmin, isVendor } from '@/lib/roles'
+import { coerceUserRole, isAdmin, isVendor } from '@/lib/roles'
 
 export const authConfig: NextAuthConfig = {
   pages: {
@@ -35,14 +34,14 @@ export const authConfig: NextAuthConfig = {
     jwt({ token, user }) {
       if (user) {
         token.id = user.id ?? ''
-        token.role = user.role as UserRole
+        token.role = coerceUserRole(user.role)
       }
       return token
     },
     session({ session, token }) {
       if (session.user) {
         session.user.id = token.id as string
-        session.user.role = token.role as UserRole
+        session.user.role = coerceUserRole(token.role)
       }
       return session
     },

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,5 +1,28 @@
 import { UserRole } from '@/generated/prisma/enums'
 
+export const ALL_USER_ROLES: readonly UserRole[] = [
+  UserRole.CUSTOMER,
+  UserRole.VENDOR,
+  UserRole.ADMIN_SUPPORT,
+  UserRole.ADMIN_CATALOG,
+  UserRole.ADMIN_FINANCE,
+  UserRole.ADMIN_OPS,
+  UserRole.SUPERADMIN,
+]
+
+/**
+ * Narrows an unknown value to a valid UserRole, returning CUSTOMER as a
+ * safe fallback for anything we do not recognise. Intended for trust
+ * boundaries (JWT claims, session tokens) where the incoming role string
+ * must be validated before being used for authorization decisions.
+ */
+export function coerceUserRole(role: unknown): UserRole {
+  if (typeof role !== 'string') return UserRole.CUSTOMER
+  return (ALL_USER_ROLES as readonly string[]).includes(role)
+    ? (role as UserRole)
+    : UserRole.CUSTOMER
+}
+
 export const ADMIN_ROLES: readonly UserRole[] = [
   UserRole.ADMIN_SUPPORT,
   UserRole.ADMIN_CATALOG,

--- a/test/roles.test.ts
+++ b/test/roles.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import { UserRole } from '@/generated/prisma/enums'
 import {
   ADMIN_ROLES,
+  ALL_USER_ROLES,
+  coerceUserRole,
   FINANCE_ADMIN_ROLES,
   OPS_ADMIN_ROLES,
   hasRole,
@@ -73,4 +75,33 @@ test('isFinanceAdminRole returns true for finance and ops-level roles', () => {
   assert.equal(isFinanceAdminRole(UserRole.VENDOR), false)
   assert.equal(isFinanceAdminRole(undefined), false)
   assert.equal(isFinanceAdminRole(null), false)
+})
+
+test('ALL_USER_ROLES contains every UserRole enum value', () => {
+  const enumValues = Object.values(UserRole)
+  assert.equal(ALL_USER_ROLES.length, enumValues.length)
+  for (const value of enumValues) {
+    assert.equal(ALL_USER_ROLES.includes(value), true, `${value} missing from ALL_USER_ROLES`)
+  }
+})
+
+test('coerceUserRole returns the role for every valid enum member', () => {
+  for (const role of Object.values(UserRole)) {
+    assert.equal(coerceUserRole(role), role)
+  }
+})
+
+test('coerceUserRole falls back to CUSTOMER for unknown strings', () => {
+  assert.equal(coerceUserRole('ROOT'), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole('admin'), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole(''), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole('GOD_MODE'), UserRole.CUSTOMER)
+})
+
+test('coerceUserRole falls back to CUSTOMER for non-string inputs', () => {
+  assert.equal(coerceUserRole(undefined), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole(null), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole(42), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole({ role: 'SUPERADMIN' }), UserRole.CUSTOMER)
+  assert.equal(coerceUserRole(true), UserRole.CUSTOMER)
 })


### PR DESCRIPTION
Closes #182

## Summary
- Adds `coerceUserRole(unknown): UserRole` and `ALL_USER_ROLES` in `src/lib/roles.ts`
- `coerceUserRole` narrows any unknown value to a valid `UserRole`, falling back to `CUSTOMER` for non-string inputs or unrecognised strings
- `authConfig.jwt` and `authConfig.session` callbacks now route the raw role through this helper so downstream `isAdmin` / `isVendor` checks can only ever see a known enum value — tampered tokens with a forged `role` claim fall back to `CUSTOMER`
- Adds 4 unit tests: `ALL_USER_ROLES` parity with the enum, coercion of valid members, fallback for unknown strings, fallback for non-string inputs

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 380/380 pass (4 new tests)
- [ ] Manual: log in as vendor / admin / customer and verify session still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)