### PR TITLE
perf: tighten GDPR export selects and add explicit ordering (#183)

### DIFF
--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -68,24 +68,88 @@ export async function GET() {
       }),
       db.order.findMany({
         where: { customerId: userId },
-        include: {
-          lines: true,
-          payments: true,
-          fulfillments: true,
+        orderBy: { placedAt: 'desc' },
+        select: {
+          id: true,
+          orderNumber: true,
+          status: true,
+          paymentStatus: true,
+          subtotal: true,
+          shippingCost: true,
+          taxAmount: true,
+          grandTotal: true,
+          notes: true,
+          placedAt: true,
+          updatedAt: true,
+          lines: {
+            select: {
+              id: true,
+              productId: true,
+              variantId: true,
+              quantity: true,
+              unitPrice: true,
+              taxRate: true,
+              productSnapshot: true,
+              createdAt: true,
+            },
+          },
+          payments: {
+            select: {
+              id: true,
+              provider: true,
+              status: true,
+              amount: true,
+              currency: true,
+              createdAt: true,
+            },
+          },
+          fulfillments: {
+            select: {
+              id: true,
+              status: true,
+              trackingNumber: true,
+              carrier: true,
+              shippedAt: true,
+              deliveredAt: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
         },
       }),
       db.review.findMany({
         where: { customerId: userId },
-        include: {
-          product: { select: { name: true, id: true } },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          rating: true,
+          body: true,
+          createdAt: true,
+          product: { select: { id: true, name: true } },
           order: { select: { orderNumber: true } },
         },
       }),
       db.incident.findMany({
         where: { customerId: userId },
-        include: {
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          type: true,
+          status: true,
+          description: true,
+          resolution: true,
+          resolvedAt: true,
+          createdAt: true,
+          updatedAt: true,
           order: { select: { orderNumber: true } },
-          messages: true,
+          messages: {
+            select: {
+              id: true,
+              authorId: true,
+              body: true,
+              createdAt: true,
+            },
+          },
         },
       }),
     ])


### PR DESCRIPTION
Closes #183

## Summary
On closer inspection, the export endpoint was already paralleled with `Promise.all` and did not actually cause N+1 queries — Prisma's `include: { relation: true }` issues a single JOIN per relation. The real concern was that `include: true` pulls **every column**, so any internal field later added to `Order`, `OrderLine`, `VendorFulfillment`, `Review`, or `Incident` would silently leak into the export payload.

- Converts the nested `include: true` clauses in `/api/account/export` to explicit `select` allow-lists per relation (orders → lines/payments/fulfillments; reviews → product/order; incidents → order/messages)
- Adds `orderBy` on the top-level `order`, `review`, and `incident` queries so the exported JSON is deterministic (most-recent first)

## Test plan
- [x] `npm run typecheck` — validates every `select` against the generated Prisma types
- [x] `npm test` — 380/380 pass (no regressions)
- [ ] Manual: hit `/api/account/export` as a test user and confirm the payload still contains all the fields UI/legal expects

No new unit test — the route is DB-backed and the existing DB-backed `gdpr-compliance.test.ts` integration test already exercises the updated shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)