### PR TITLE
perf: add composite indexes for frequent buyer/vendor queries (#184)

### DIFF
--- a/prisma/migrations/20260412140000_add_query_indexes/migration.sql
+++ b/prisma/migrations/20260412140000_add_query_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- Add composite indexes for frequent buyer/vendor query patterns (#184).
+CREATE INDEX "CartItem_userId_createdAt_idx" ON "CartItem"("userId", "createdAt");
+CREATE INDEX "Review_productId_createdAt_idx" ON "Review"("productId", "createdAt");
+CREATE INDEX "Incident_customerId_status_idx" ON "Incident"("customerId", "status");
+CREATE INDEX "IncidentMessage_incidentId_createdAt_idx" ON "IncidentMessage"("incidentId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -318,6 +318,7 @@ model CartItem {
 
   @@unique([cartId, productId, variantId])
   @@index([cartId])
+  @@index([userId, createdAt])
 }
 
 // ─── Orders ───────────────────────────────────────────────────────────────────
@@ -412,6 +413,7 @@ model Review {
 
   @@unique([orderId, productId])
   @@index([productId])
+  @@index([productId, createdAt])
   @@index([vendorId])
   @@index([vendorId, createdAt])
   @@index([customerId])
@@ -506,6 +508,7 @@ model Incident {
 
   @@index([status, slaDeadline])
   @@index([customerId])
+  @@index([customerId, status])
 }
 
 model IncidentMessage {
@@ -520,6 +523,7 @@ model IncidentMessage {
   incident Incident @relation(fields: [incidentId], references: [id])
 
   @@index([incidentId])
+  @@index([incidentId, createdAt])
 }
 
 // ─── Finance ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #184

## Summary
Adds four composite indexes to cover query patterns that previously fall back to sequential scans as the dataset grows:

| Table | Index | Used by |
|-------|-------|---------|
| `CartItem` | `(userId, createdAt)` | user cart listing + abandoned-cart cleanup jobs |
| `Review` | `(productId, createdAt)` | product-detail review pagination |
| `Incident` | `(customerId, status)` | buyer incident filter |
| `IncidentMessage` | `(incidentId, createdAt)` | ordered message history per incident |

Note: several indexes suggested in the issue (`Review.createdAt` alone, `OrderLine.createdAt`) were skipped because existing composite indexes (`vendorId, createdAt`) already cover the typical query shapes and adding more would just increase write overhead without a corresponding read win.

## Files
- `prisma/schema.prisma` — adds `@@index` directives
- `prisma/migrations/20260412140000_add_query_indexes/migration.sql` — new migration

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 409/409 pass (no regressions)
- [ ] Manual: run `EXPLAIN ANALYZE` on the target queries in staging and confirm they now use the new indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)