### PR TITLE
feat: dead-letter queue for orphan Stripe webhook events (#185)

### DIFF
--- a/prisma/migrations/20260412150000_add_webhook_dead_letter/migration.sql
+++ b/prisma/migrations/20260412150000_add_webhook_dead_letter/migration.sql
@@ -1,0 +1,18 @@
+-- WebhookDeadLetter: orphan / unresolvable webhook events for manual replay (#185).
+CREATE TABLE "WebhookDeadLetter" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL DEFAULT 'stripe',
+    "eventId" TEXT,
+    "eventType" TEXT NOT NULL,
+    "providerRef" TEXT,
+    "reason" TEXT NOT NULL,
+    "payload" JSONB,
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDeadLetter_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "WebhookDeadLetter_resolvedAt_idx" ON "WebhookDeadLetter"("resolvedAt");
+CREATE INDEX "WebhookDeadLetter_provider_eventType_idx" ON "WebhookDeadLetter"("provider", "eventType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,6 +451,27 @@ model OrderEvent {
   @@index([orderId])
 }
 
+/// Dead-letter queue for webhook events that could not be reconciled to an
+/// existing order/payment (e.g. Stripe sent a payment_intent.succeeded for a
+/// providerRef we have no Payment row for). An operator can query the
+/// unresolved rows and replay them from the Stripe dashboard once the
+/// underlying issue is fixed.
+model WebhookDeadLetter {
+  id          String    @id @default(cuid())
+  provider    String    @default("stripe")
+  eventId     String?
+  eventType   String
+  providerRef String?
+  reason      String
+  payload     Json?
+  resolvedAt  DateTime?
+  resolvedBy  String?
+  createdAt   DateTime  @default(now())
+
+  @@index([resolvedAt])
+  @@index([provider, eventType])
+}
+
 // ─── Payments ─────────────────────────────────────────────────────────────────
 
 model Payment {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -15,6 +15,7 @@ import {
   createPaymentFailedEventPayload,
   createPaymentMismatchEventPayload,
 } from '@/domains/orders/order-event-payload'
+import { recordWebhookDeadLetter } from '@/domains/payments/webhook-dlq'
 import { getServerEnv } from '@/lib/env'
 import type Stripe from 'stripe'
 
@@ -118,7 +119,16 @@ async function handlePaymentSucceeded(providerRef: string, amount?: number, curr
       }),
     { operationName: 'load payment for succeeded webhook' }
   )
-  if (!payment) return
+  if (!payment) {
+    await recordWebhookDeadLetter(db, {
+      eventId,
+      eventType: 'payment_intent.succeeded',
+      providerRef,
+      reason: 'payment_not_found',
+      payload: { providerRef, amount, currency },
+    })
+    return
+  }
   assertProviderRefForPaymentStatus({
     providerRef: payment.providerRef,
     nextStatus: 'SUCCEEDED',
@@ -218,7 +228,16 @@ async function handlePaymentFailed(providerRef: string, eventId?: string) {
       }),
     { operationName: 'load payment for failed webhook' }
   )
-  if (!payment) return
+  if (!payment) {
+    await recordWebhookDeadLetter(db, {
+      eventId,
+      eventType: 'payment_intent.payment_failed',
+      providerRef,
+      reason: 'payment_not_found',
+      payload: { providerRef },
+    })
+    return
+  }
 
   if (!shouldApplyPaymentFailed({
     paymentStatus: payment.status,

--- a/src/domains/payments/webhook-dlq.ts
+++ b/src/domains/payments/webhook-dlq.ts
@@ -1,0 +1,63 @@
+/**
+ * Dead-letter helper for Stripe webhook events that cannot be reconciled
+ * to an existing Payment/Order row. Used by the webhook route handler as
+ * a last resort so orphan events can be replayed manually by an operator.
+ */
+
+type WebhookDeadLetterInput = {
+  provider?: string
+  eventId?: string
+  eventType: string
+  providerRef?: string
+  reason: string
+  payload?: unknown
+}
+
+type WebhookDeadLetterRecord = {
+  provider: string
+  eventId: string | null
+  eventType: string
+  providerRef: string | null
+  reason: string
+  payload: unknown
+}
+
+// Loose structural type so the real Prisma delegate (which has generics we
+// don't care about) and simple in-memory mocks both satisfy it.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type WebhookDeadLetterDelegate = { create: (args: any) => Promise<any> }
+
+export type WebhookDlqClient = { webhookDeadLetter: WebhookDeadLetterDelegate }
+
+export function buildWebhookDeadLetterRecord(input: WebhookDeadLetterInput): WebhookDeadLetterRecord {
+  return {
+    provider: input.provider ?? 'stripe',
+    eventId: input.eventId ?? null,
+    eventType: input.eventType,
+    providerRef: input.providerRef ?? null,
+    reason: input.reason,
+    payload: input.payload ?? null,
+  }
+}
+
+/**
+ * Persist an orphan webhook event. Swallows errors (and logs them) so the
+ * caller can still acknowledge the webhook with a 200 — otherwise Stripe
+ * would keep retrying an event we cannot process anyway.
+ */
+export async function recordWebhookDeadLetter(
+  client: WebhookDlqClient,
+  input: WebhookDeadLetterInput
+): Promise<boolean> {
+  try {
+    await client.webhookDeadLetter.create({ data: buildWebhookDeadLetterRecord(input) })
+    return true
+  } catch (err) {
+    console.error('[stripe-webhook][dead-letter-write-failed]', {
+      eventId: input.eventId ?? null,
+      eventType: input.eventType,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}

--- a/test/webhook-dlq.test.ts
+++ b/test/webhook-dlq.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildWebhookDeadLetterRecord,
+  recordWebhookDeadLetter,
+  type WebhookDlqClient,
+} from '@/domains/payments/webhook-dlq'
+
+function createMockClient(options: { throwOnCreate?: boolean } = {}): {
+  client: WebhookDlqClient
+  writes: unknown[]
+} {
+  const writes: unknown[] = []
+  const client: WebhookDlqClient = {
+    webhookDeadLetter: {
+      create: async (args: { data: unknown }) => {
+        if (options.throwOnCreate) throw new Error('db down')
+        writes.push(args.data)
+        return args.data
+      },
+    },
+  }
+  return { client, writes }
+}
+
+test('buildWebhookDeadLetterRecord defaults provider to stripe and null-fills optional fields', () => {
+  const record = buildWebhookDeadLetterRecord({
+    eventType: 'payment_intent.succeeded',
+    reason: 'payment_not_found',
+  })
+  assert.deepEqual(record, {
+    provider: 'stripe',
+    eventId: null,
+    eventType: 'payment_intent.succeeded',
+    providerRef: null,
+    reason: 'payment_not_found',
+    payload: null,
+  })
+})
+
+test('buildWebhookDeadLetterRecord preserves provided fields', () => {
+  const record = buildWebhookDeadLetterRecord({
+    provider: 'paypal',
+    eventId: 'evt_123',
+    eventType: 'payment.captured',
+    providerRef: 'pi_abc',
+    reason: 'payment_not_found',
+    payload: { foo: 'bar' },
+  })
+  assert.equal(record.provider, 'paypal')
+  assert.equal(record.eventId, 'evt_123')
+  assert.equal(record.providerRef, 'pi_abc')
+  assert.deepEqual(record.payload, { foo: 'bar' })
+})
+
+test('recordWebhookDeadLetter writes to the delegate and returns true on success', async () => {
+  const { client, writes } = createMockClient()
+  const ok = await recordWebhookDeadLetter(client, {
+    eventId: 'evt_1',
+    eventType: 'payment_intent.payment_failed',
+    providerRef: 'pi_xyz',
+    reason: 'payment_not_found',
+  })
+  assert.equal(ok, true)
+  assert.equal(writes.length, 1)
+  assert.equal((writes[0] as { eventId: string }).eventId, 'evt_1')
+  assert.equal((writes[0] as { provider: string }).provider, 'stripe')
+})
+
+test('recordWebhookDeadLetter swallows errors and returns false', async () => {
+  const originalError = console.error
+  console.error = () => undefined
+  try {
+    const { client } = createMockClient({ throwOnCreate: true })
+    const ok = await recordWebhookDeadLetter(client, {
+      eventType: 'payment_intent.succeeded',
+      reason: 'payment_not_found',
+    })
+    assert.equal(ok, false)
+  } finally {
+    console.error = originalError
+  }
+})


### PR DESCRIPTION
Closes #185

## Summary
The Stripe webhook route previously silently returned when it received a `payment_intent.succeeded` or `payment_intent.payment_failed` for a `providerRef` with no matching `Payment` row. Stripe would ack the event and it would be lost forever — a legitimate mismatch, race, or delayed replica could result in permanently stuck orders.

- Adds `WebhookDeadLetter` Prisma model (+ migration): `provider`, `eventId`, `eventType`, `providerRef`, `reason`, `payload`, `resolvedAt`, `resolvedBy`
- Adds `recordWebhookDeadLetter` helper in `src/domains/payments/webhook-dlq.ts` that fire-and-forgets to the table and never throws (the route still needs to return 200 to Stripe)
- Wires both `payment_not_found` branches of the Stripe webhook route to persist an entry before returning
- 4 unit tests covering record building, success write, and swallowed-error path

## Operator workflow
```sql
SELECT * FROM "WebhookDeadLetter" WHERE "resolvedAt" IS NULL ORDER BY "createdAt";
```
Each row contains enough context (`providerRef`, `eventId`, `reason`) to replay the event from the Stripe dashboard. Once replayed, `UPDATE "WebhookDeadLetter" SET "resolvedAt" = NOW(), "resolvedBy" = '<op>' WHERE id = ...`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 413/413 pass (4 new tests)
- [ ] Manual: send a mock webhook for an unknown providerRef and verify a row appears in `WebhookDeadLetter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)