### PR TITLE
fix: stop catalog title collapsing to 'F…' on mobile

### DIFF
--- a/src/app/(public)/productos/page.tsx
+++ b/src/app/(public)/productos/page.tsx
@@ -70,9 +70,9 @@ export default async function ProductosPage({ searchParams }: Props) {
 
         {/* Main */}
         <div className="flex-1 min-w-0">
-          <div className="mb-6 flex flex-wrap items-center justify-between gap-2">
-            <div className="min-w-0 flex-1">
-              <h1 className="truncate text-2xl font-bold text-[var(--foreground)]">{pageTitle}</h1>
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-2">
+            <div className="min-w-0 sm:flex-1">
+              <h1 className="break-words text-2xl font-bold text-[var(--foreground)] sm:truncate">{pageTitle}</h1>
               <p className="mt-0.5 text-sm text-[var(--muted)]">{copy.page.results(products.length, hasNext)}</p>
             </div>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
On narrow screens the catalog header was a single flex row shared between the page title and the controls (Filters button + sort select). The controls hogged the row, leaving the truncated h1 with just enough space for one letter ('F…' instead of 'Frutas' / 'Fruits').

- Switch the header to a vertical stack on mobile (\`flex-col\`), collapsing back to a single justified row at \`sm\` and up
- The h1 drops the unconditional \`truncate\` in favour of \`break-words\` on mobile, keeping the existing truncate behaviour on wider screens

Single-file change in [productos/page.tsx](src/app/(public)/productos/page.tsx).

## Test plan
- [ ] Open /productos on a ~320px viewport — page title should render in full, with the Filtros / sort controls on a separate row underneath
- [ ] Open /productos on \`sm\` and up — header should render exactly as before (single row, justified)
- [ ] Search results page (/productos?q=foo) — quoted query renders without truncation on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)