### PR TITLE
fix: dedupe in-flight favorite toggles (#187)

### DIFF
--- a/src/lib/favorites-store.ts
+++ b/src/lib/favorites-store.ts
@@ -4,16 +4,24 @@ import { create } from 'zustand'
 
 interface FavoritesStore {
   productIds: Set<string>
+  pending: Set<string>
   loaded: boolean
   loading: boolean
   loadFavorites: () => Promise<void>
   toggle: (productId: string) => Promise<void>
   has: (productId: string) => boolean
+  isPending: (productId: string) => boolean
   remove: (productId: string) => void
 }
 
+// Module-scoped dedup map so a rapid double-tap of the favourite button
+// coalesces into a single in-flight request instead of firing two API
+// calls whose responses can arrive out of order.
+const inflightToggles = new Map<string, Promise<void>>()
+
 export const useFavoritesStore = create<FavoritesStore>()((set, get) => ({
   productIds: new Set<string>(),
+  pending: new Set<string>(),
   loaded: false,
   loading: false,
 
@@ -34,6 +42,9 @@ export const useFavoritesStore = create<FavoritesStore>()((set, get) => ({
   },
 
   toggle: async (productId: string) => {
+    const existing = inflightToggles.get(productId)
+    if (existing) return existing
+
     const current = get().productIds
     const isFav = current.has(productId)
 
@@ -44,27 +55,40 @@ export const useFavoritesStore = create<FavoritesStore>()((set, get) => ({
     } else {
       next.add(productId)
     }
-    set({ productIds: next })
+    const nextPending = new Set(get().pending)
+    nextPending.add(productId)
+    set({ productIds: next, pending: nextPending })
 
-    try {
-      if (isFav) {
-        const res = await fetch(`/api/favoritos/${productId}`, { method: 'DELETE' })
-        if (!res.ok) throw new Error()
-      } else {
-        const res = await fetch('/api/favoritos', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ productId }),
-        })
-        if (!res.ok) throw new Error()
+    const request = (async () => {
+      try {
+        if (isFav) {
+          const res = await fetch(`/api/favoritos/${productId}`, { method: 'DELETE' })
+          if (!res.ok) throw new Error()
+        } else {
+          const res = await fetch('/api/favoritos', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ productId }),
+          })
+          if (!res.ok) throw new Error()
+        }
+      } catch {
+        // Rollback on failure
+        set({ productIds: current })
+      } finally {
+        const done = new Set(get().pending)
+        done.delete(productId)
+        set({ pending: done })
+        inflightToggles.delete(productId)
       }
-    } catch {
-      // Rollback on failure
-      set({ productIds: current })
-    }
+    })()
+
+    inflightToggles.set(productId, request)
+    return request
   },
 
   has: (productId: string) => get().productIds.has(productId),
+  isPending: (productId: string) => get().pending.has(productId),
 
   remove: (productId: string) => {
     const next = new Set(get().productIds)
@@ -72,3 +96,8 @@ export const useFavoritesStore = create<FavoritesStore>()((set, get) => ({
     set({ productIds: next })
   },
 }))
+
+// Test-only: clear the dedup map between tests. Not used in app code.
+export function __resetFavoritesInflight() {
+  inflightToggles.clear()
+}

--- a/test/favorites-store.test.ts
+++ b/test/favorites-store.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { useFavoritesStore, __resetFavoritesInflight } from '@/lib/favorites-store'
+
+type FetchCall = { url: string; method: string }
+
+function mockFetch(options: { fail?: boolean; delayMs?: number } = {}) {
+  const calls: FetchCall[] = []
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: string, init?: { method?: string }) => {
+    calls.push({ url: String(input), method: init?.method ?? 'GET' })
+    if (options.delayMs) {
+      await new Promise((r) => setTimeout(r, options.delayMs))
+    }
+    if (options.fail) {
+      return { ok: false } as unknown as Response
+    }
+    return { ok: true, json: async () => ({}) } as unknown as Response
+  }) as typeof fetch
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original
+    },
+  }
+}
+
+function resetStore() {
+  useFavoritesStore.setState({
+    productIds: new Set<string>(),
+    pending: new Set<string>(),
+    loaded: true,
+    loading: false,
+  })
+  __resetFavoritesInflight()
+}
+
+test('toggle adds a favorite optimistically and POSTs to the API', async () => {
+  resetStore()
+  const fx = mockFetch()
+  try {
+    await useFavoritesStore.getState().toggle('p-1')
+    assert.equal(useFavoritesStore.getState().has('p-1'), true)
+    assert.equal(fx.calls.length, 1)
+    assert.equal(fx.calls[0]!.method, 'POST')
+    assert.equal(useFavoritesStore.getState().isPending('p-1'), false)
+  } finally {
+    fx.restore()
+  }
+})
+
+test('toggle removes a favorite optimistically and DELETEs via the API', async () => {
+  resetStore()
+  useFavoritesStore.setState({ productIds: new Set(['p-2']) })
+  const fx = mockFetch()
+  try {
+    await useFavoritesStore.getState().toggle('p-2')
+    assert.equal(useFavoritesStore.getState().has('p-2'), false)
+    assert.equal(fx.calls[0]!.method, 'DELETE')
+    assert.match(fx.calls[0]!.url, /p-2/)
+  } finally {
+    fx.restore()
+  }
+})
+
+test('toggle rolls back the optimistic update when the request fails', async () => {
+  resetStore()
+  useFavoritesStore.setState({ productIds: new Set(['p-3']) })
+  const fx = mockFetch({ fail: true })
+  try {
+    await useFavoritesStore.getState().toggle('p-3')
+    assert.equal(useFavoritesStore.getState().has('p-3'), true, 'should roll back to the original value')
+  } finally {
+    fx.restore()
+  }
+})
+
+test('concurrent toggle calls on the same product dedupe into one request', async () => {
+  resetStore()
+  const fx = mockFetch({ delayMs: 25 })
+  try {
+    const store = useFavoritesStore.getState()
+    const promises = [store.toggle('p-4'), store.toggle('p-4'), store.toggle('p-4')]
+    await Promise.all(promises)
+    assert.equal(fx.calls.length, 1, 'rapid double/triple-tap should produce only one HTTP call')
+    assert.equal(useFavoritesStore.getState().has('p-4'), true)
+    assert.equal(useFavoritesStore.getState().isPending('p-4'), false)
+  } finally {
+    fx.restore()
+  }
+})
+
+test('toggle exposes pending state while the request is in flight', async () => {
+  resetStore()
+  const fx = mockFetch({ delayMs: 20 })
+  try {
+    const store = useFavoritesStore.getState()
+    const promise = store.toggle('p-5')
+    // Synchronous optimistic pending flip
+    assert.equal(useFavoritesStore.getState().isPending('p-5'), true)
+    await promise
+    assert.equal(useFavoritesStore.getState().isPending('p-5'), false)
+  } finally {
+    fx.restore()
+  }
+})


### PR DESCRIPTION
Closes #187

## Summary
Rapid double-taps on the heart button used to fire two `fetch` requests whose responses could land in the opposite order, leaving the server and the UI disagreeing about whether the product was favourited.

- Adds a module-level `inflightToggles` map so concurrent `toggle()` calls for the same `productId` return the same promise
- Adds a `pending` `Set<string>` on the store (plus `isPending(id)` selector) so the button can render a busy/disabled state while the request is inflight
- Optimistic update + rollback-on-failure logic is preserved verbatim
- 5 unit tests: add (POST), remove (DELETE), rollback on failure, concurrent 3× dedup into one request, and pending-flag lifecycle

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 418/418 pass (5 new tests)
- [ ] Manual: spam the favourite heart and verify a single request in the network panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)