### PR TITLE
fix: enforce single default address invariant + prefill UX

### DIFF
--- a/src/app/(buyer)/checkout/page.tsx
+++ b/src/app/(buyer)/checkout/page.tsx
@@ -1,16 +1,31 @@
 import { CheckoutPageClient } from '@/components/buyer/CheckoutPageClient'
 import { getShippingConfigurationSnapshot } from '@/domains/shipping/calculator'
 import { getServerEnv } from '@/lib/env'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
 
 export default async function CheckoutPage() {
   const shippingConfig = await getShippingConfigurationSnapshot()
   const { paymentProvider } = getServerEnv()
+  const session = await auth()
+  let userFirstName = ''
+  let userLastName = ''
+  if (session?.user?.id) {
+    const user = await db.user.findUnique({
+      where: { id: session.user.id },
+      select: { firstName: true, lastName: true },
+    })
+    userFirstName = user?.firstName ?? ''
+    userLastName = user?.lastName ?? ''
+  }
   return (
     <CheckoutPageClient
       shippingZones={shippingConfig.zones}
       shippingRates={shippingConfig.rates}
       fallbackShippingCost={shippingConfig.fallbackCost}
       showDemoNotice={paymentProvider === 'mock'}
+      userFirstName={userFirstName}
+      userLastName={userLastName}
     />
   )
 }

--- a/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
@@ -36,7 +36,15 @@ const SPANISH_PROVINCES = [
   'Teruel', 'Toledo', 'Valencia', 'Valladolid', 'Vizcaya', 'Zamora', 'Zaragoza', 'Ceuta', 'Melilla',
 ]
 
-export function DireccionesClient() {
+interface DireccionesClientProps {
+  userFirstName?: string
+  userLastName?: string
+}
+
+export function DireccionesClient({
+  userFirstName = '',
+  userLastName = '',
+}: DireccionesClientProps = {}) {
   const [addresses, setAddresses] = useState<Address[]>([])
   const [loading, setLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
@@ -138,6 +146,38 @@ export function DireccionesClient() {
     }
   }
 
+  const startNewAddress = () => {
+    setEditingId(null)
+    reset({
+      label: '',
+      firstName: userFirstName,
+      lastName: userLastName,
+      line1: '',
+      line2: '',
+      city: '',
+      province: '',
+      postalCode: '',
+      isDefault: addresses.length === 0,
+    })
+    setShowForm(true)
+  }
+
+  const handleCopyFromDefault = () => {
+    const source = addresses.find(a => a.isDefault) ?? addresses[0]
+    if (!source) return
+    reset({
+      label: '',
+      firstName: source.firstName,
+      lastName: source.lastName,
+      line1: source.line1,
+      line2: source.line2 ?? '',
+      city: source.city,
+      province: source.province,
+      postalCode: source.postalCode,
+      isDefault: false,
+    })
+  }
+
   const handleSetDefault = async (id: string) => {
     try {
       const res = await fetch(`/api/direcciones/${id}/predeterminada`, {
@@ -170,9 +210,20 @@ export function DireccionesClient() {
       {/* Form */}
       {showForm && (
         <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-semibold text-[var(--foreground)]">
-            {editingId ? t('account.editAddress') : t('account.newAddress')}
-          </h2>
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-[var(--foreground)]">
+              {editingId ? t('account.editAddress') : t('account.newAddress')}
+            </h2>
+            {!editingId && addresses.length > 0 && (
+              <button
+                type="button"
+                onClick={handleCopyFromDefault}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-emerald-50/60 px-3 py-1.5 text-xs font-medium text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+              >
+                {t('account.copyFromDefault')}
+              </button>
+            )}
+          </div>
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
@@ -375,10 +426,7 @@ export function DireccionesClient() {
       {/* Add Button */}
       {!showForm && (
         <button
-          onClick={() => {
-            setShowForm(true)
-            reset()
-          }}
+          onClick={startNewAddress}
           className="rounded-lg bg-emerald-600 dark:bg-emerald-500 px-4 py-2 font-medium text-white hover:bg-emerald-700 dark:hover:bg-emerald-600 transition"
         >
           {t('account.addAddress')}

--- a/src/app/(buyer)/cuenta/direcciones/page.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import { requireAuth } from '@/lib/auth-guard'
+import { db } from '@/lib/db'
 import { DireccionesClient } from './DireccionesClient'
 
 export const metadata: Metadata = {
@@ -8,7 +9,11 @@ export const metadata: Metadata = {
 }
 
 export default async function Direcciones() {
-  await requireAuth()
+  const session = await requireAuth()
+  const user = await db.user.findUnique({
+    where: { id: session.user.id },
+    select: { firstName: true, lastName: true },
+  })
 
   return (
     <main className="space-y-6 max-w-3xl mx-auto px-4 py-10 sm:px-6 lg:px-8">
@@ -20,7 +25,10 @@ export default async function Direcciones() {
       </div>
 
       <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
-        <DireccionesClient />
+        <DireccionesClient
+          userFirstName={user?.firstName ?? ''}
+          userLastName={user?.lastName ?? ''}
+        />
       </div>
     </main>
   )

--- a/src/app/api/direcciones/[id]/route.ts
+++ b/src/app/api/direcciones/[id]/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { clearOtherDefaults, promoteOldestAsDefault } from '@/lib/address-defaults'
+import {
+  clearOtherDefaults,
+  enforceSingleDefault,
+  promoteOldestAsDefault,
+} from '@/lib/address-defaults'
 
 const addressSchema = z.object({
   label: z.string().max(50).optional(),
@@ -43,7 +47,9 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     }
 
     const address = await db.$transaction(async (tx) => {
-      if (validated.isDefault && !existingAddress.isDefault) {
+      if (validated.isDefault) {
+        // Always heal — the existing address may already be default while
+        // another stale row is *also* flagged default (legacy/race state).
         await clearOtherDefaults(tx, session.user.id, id)
       }
 
@@ -100,6 +106,7 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
       if (address.isDefault) {
         await promoteOldestAsDefault(tx, session.user.id)
       }
+      await enforceSingleDefault(tx, session.user.id)
     })
 
     return NextResponse.json({ success: true })

--- a/src/app/api/direcciones/route.ts
+++ b/src/app/api/direcciones/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { clearOtherDefaults } from '@/lib/address-defaults'
+import { clearOtherDefaults, enforceSingleDefault } from '@/lib/address-defaults'
 
 const addressSchema = z.object({
   label: z.string().max(50).optional(),
@@ -25,10 +25,23 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
-    const addresses = await db.address.findMany({
+    let addresses = await db.address.findMany({
       where: { userId: session.user.id },
       orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
     })
+
+    // Self-heal: if multiple defaults exist (legacy/race state), keep the
+    // most recently updated one and clear the rest, then re-fetch.
+    const defaultCount = addresses.reduce((n, a) => n + (a.isDefault ? 1 : 0), 0)
+    if (defaultCount > 1) {
+      await db.$transaction(async (tx) => {
+        await enforceSingleDefault(tx, session.user.id)
+      })
+      addresses = await db.address.findMany({
+        where: { userId: session.user.id },
+        orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+      })
+    }
 
     return NextResponse.json(addresses)
   } catch (error) {

--- a/src/components/buyer/CheckoutPageClient.tsx
+++ b/src/components/buyer/CheckoutPageClient.tsx
@@ -44,6 +44,8 @@ interface Props {
   shippingRates: ShippingRateLike[]
   fallbackShippingCost: number
   showDemoNotice: boolean
+  userFirstName?: string
+  userLastName?: string
 }
 
 export function CheckoutPageClient({
@@ -51,6 +53,8 @@ export function CheckoutPageClient({
   shippingRates,
   fallbackShippingCost,
   showDemoNotice,
+  userFirstName = '',
+  userLastName = '',
 }: Props) {
   const router = useRouter()
   const { items, subtotal, clearCart } = useCartStore()
@@ -172,8 +176,8 @@ export function CheckoutPageClient({
     setSelectedAddressId(null)
     setShowNewAddressForm(true)
     reset({
-      firstName: '',
-      lastName: '',
+      firstName: userFirstName,
+      lastName: userLastName,
       line1: '',
       line2: '',
       city: '',
@@ -181,6 +185,19 @@ export function CheckoutPageClient({
       postalCode: '',
       phone: '',
       saveAddress: savedAddresses.length === 0,
+      selectedAddressId: undefined,
+    })
+  }
+
+  function handleCopyFromDefault() {
+    const defaultAddress =
+      savedAddresses.find(a => a.isDefault) ?? savedAddresses[0]
+    if (!defaultAddress) return
+    setSelectedAddressId(null)
+    setShowNewAddressForm(true)
+    reset({
+      ...toCheckoutFormAddress(defaultAddress),
+      saveAddress: true,
       selectedAddressId: undefined,
     })
   }
@@ -292,6 +309,15 @@ export function CheckoutPageClient({
               <input type="hidden" value={selectedAddressId ?? ''} {...register('selectedAddressId')} />
               {(showNewAddressForm || (!loadingAddresses && savedAddresses.length === 0)) && (
                 <div className="space-y-4">
+                  {showNewAddressForm && savedAddresses.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={handleCopyFromDefault}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-emerald-50/60 px-3 py-1.5 text-xs font-medium text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+                    >
+                      {t('checkout.copyFromDefault')}
+                    </button>
+                  )}
                   <div className="grid grid-cols-2 gap-3">
                     <Input label={t('checkout.firstName')} error={errors.firstName?.message} {...register('firstName')} />
                     <Input label={t('checkout.lastName')} error={errors.lastName?.message} {...register('lastName')} />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -202,6 +202,7 @@ const en: Record<TranslationKeys, string> = {
   'checkout.savedAddressesLoading': 'Loading your saved addresses...',
   'checkout.savedAddressesError': 'We could not load your saved addresses. You can continue with a new one.',
   'checkout.useNewAddress': 'Use a new address',
+  'checkout.copyFromDefault': 'Copy from my default address',
   'checkout.firstName': 'First name',
   'checkout.lastName': 'Last name',
   'checkout.line1': 'Address',
@@ -334,6 +335,7 @@ const en: Record<TranslationKeys, string> = {
   'account.defaultBadge': 'Default',
   'account.noAddresses': 'You have no saved addresses.',
   'account.addAddress': '+ Add address',
+  'account.copyFromDefault': 'Copy from my default address',
   'account.edit': 'Edit',
   'account.delete': 'Delete',
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -200,6 +200,7 @@ const es = {
   'checkout.savedAddressesLoading': 'Cargando tus direcciones guardadas...',
   'checkout.savedAddressesError': 'No hemos podido cargar tus direcciones guardadas. Puedes seguir con una nueva.',
   'checkout.useNewAddress': 'Usar una dirección nueva',
+  'checkout.copyFromDefault': 'Copiar de mi dirección por defecto',
   'checkout.firstName': 'Nombre',
   'checkout.lastName': 'Apellidos',
   'checkout.line1': 'Dirección',
@@ -332,6 +333,7 @@ const es = {
   'account.defaultBadge': 'Predeterminada',
   'account.noAddresses': 'No tienes direcciones guardadas.',
   'account.addAddress': '+ Añadir dirección',
+  'account.copyFromDefault': 'Copiar de mi dirección por defecto',
   'account.edit': 'Editar',
   'account.delete': 'Eliminar',
 

--- a/src/lib/address-defaults.ts
+++ b/src/lib/address-defaults.ts
@@ -15,6 +15,11 @@ type AddressDelegate = {
     where: { userId: string; id?: { not: string } }
     orderBy: { createdAt: 'asc' | 'desc' }
   }) => Promise<{ id: string } | null>
+  findMany: (args: {
+    where: { userId: string; isDefault: true }
+    orderBy: { updatedAt: 'asc' | 'desc' }
+    select: { id: true }
+  }) => Promise<{ id: string }[]>
   update: (args: {
     where: { id: string }
     data: { isDefault: boolean }
@@ -49,4 +54,33 @@ export async function promoteOldestAsDefault(
   if (!next) return null
   await tx.address.update({ where: { id: next.id }, data: { isDefault: true } })
   return next.id
+}
+
+/**
+ * Heal the "single default" invariant for a user.
+ *
+ * When the database somehow ended up with multiple addresses marked as
+ * default (legacy data, race conditions, or past bugs), this picks the most
+ * recently updated one as the canonical default and clears the rest.
+ *
+ * Returns the id of the surviving default, or null if the user has no
+ * default-flagged addresses.
+ */
+export async function enforceSingleDefault(
+  tx: AddressTxClient,
+  userId: string
+): Promise<string | null> {
+  const defaults = await tx.address.findMany({
+    where: { userId, isDefault: true },
+    orderBy: { updatedAt: 'desc' },
+    select: { id: true },
+  })
+  if (defaults.length <= 1) return defaults[0]?.id ?? null
+
+  const keepId = defaults[0]!.id
+  await tx.address.updateMany({
+    where: { userId, isDefault: true, id: { not: keepId } },
+    data: { isDefault: false },
+  })
+  return keepId
 }

--- a/test/address-defaults.test.ts
+++ b/test/address-defaults.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   clearOtherDefaults,
+  enforceSingleDefault,
   promoteOldestAsDefault,
   type AddressTxClient,
 } from '@/lib/address-defaults'
@@ -10,6 +11,7 @@ type Call = { method: string; args: unknown }
 
 function createMockTx(options: {
   findFirstResult?: { id: string } | null
+  findManyResult?: { id: string }[]
 } = {}): { tx: AddressTxClient; calls: Call[] } {
   const calls: Call[] = []
   const tx: AddressTxClient = {
@@ -21,6 +23,10 @@ function createMockTx(options: {
       findFirst: async (args) => {
         calls.push({ method: 'findFirst', args })
         return options.findFirstResult ?? null
+      },
+      findMany: async (args) => {
+        calls.push({ method: 'findMany', args })
+        return options.findManyResult ?? []
       },
       update: async (args) => {
         calls.push({ method: 'update', args })
@@ -86,4 +92,62 @@ test('promoteOldestAsDefault picks ascending createdAt order', async () => {
 
   const findCall = calls.find((c) => c.method === 'findFirst')!
   assert.deepEqual((findCall.args as { orderBy: unknown }).orderBy, { createdAt: 'asc' })
+})
+
+test('enforceSingleDefault returns null when user has no defaults', async () => {
+  const { tx, calls } = createMockTx({ findManyResult: [] })
+  const result = await enforceSingleDefault(tx, 'user-1')
+
+  assert.equal(result, null)
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.method, 'findMany')
+  // Must order by updatedAt desc so the most recent wins.
+  assert.deepEqual((calls[0]!.args as { orderBy: unknown }).orderBy, {
+    updatedAt: 'desc',
+  })
+})
+
+test('enforceSingleDefault no-ops when exactly one default exists', async () => {
+  const { tx, calls } = createMockTx({ findManyResult: [{ id: 'addr-only' }] })
+  const result = await enforceSingleDefault(tx, 'user-1')
+
+  assert.equal(result, 'addr-only')
+  // Only the read happens — no updateMany when invariant already holds.
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.method, 'findMany')
+})
+
+test('enforceSingleDefault keeps newest and clears the rest when multiple defaults', async () => {
+  const { tx, calls } = createMockTx({
+    findManyResult: [
+      { id: 'addr-newest' },
+      { id: 'addr-mid' },
+      { id: 'addr-oldest' },
+    ],
+  })
+  const result = await enforceSingleDefault(tx, 'user-1')
+
+  assert.equal(result, 'addr-newest')
+  assert.equal(calls.length, 2)
+  assert.equal(calls[1]!.method, 'updateMany')
+  assert.deepEqual(calls[1]!.args, {
+    where: { userId: 'user-1', isDefault: true, id: { not: 'addr-newest' } },
+    data: { isDefault: false },
+  })
+})
+
+test('PUT-style flow heals when editing an already-default address', async () => {
+  // Reproduces the bug: Address A is already default, but Address B is *also*
+  // stuck as default in DB (legacy/race state). The PUT route now always
+  // calls clearOtherDefaults when validated.isDefault is true, so editing A
+  // (with isDefault still true) should still demote any other defaults.
+  const { tx, calls } = createMockTx()
+  await clearOtherDefaults(tx, 'user-7', 'addr-A')
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.method, 'updateMany')
+  assert.deepEqual(calls[0]!.args, {
+    where: { userId: 'user-7', isDefault: true, id: { not: 'addr-A' } },
+    data: { isDefault: false },
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes the bug where two saved addresses could both be badged **Default** in the checkout sidebar. The PUT route only cleared other defaults when the edited address was *not* already default, so corrupted state (legacy rows, races) was never healed.
- Adds an `enforceSingleDefault` helper that keeps the most recently updated default and clears the rest.
- `GET /api/direcciones` self-heals on read when it sees more than one default.
- `DELETE /api/direcciones/[id]` runs `enforceSingleDefault` after promoting the next default, so deletes can never leave duplicates behind.
- Improves "new address" UX in **checkout** and **/cuenta/direcciones**: prefills `firstName`/`lastName` from the user profile and adds a "Copy from my default address" button so users can reuse an existing address as a starting point without losing the option to save as a new entry.

## Test plan
- [x] `npm test` — all 422 tests pass, including new `enforceSingleDefault` cases (no defaults / single / multiple) and a PUT-style heal scenario
- [x] `npm run typecheck` — clean
- [ ] Manual: with a user who has two corrupted defaults, load `/checkout` and confirm the sidebar shows only one Default badge after the first GET
- [ ] Manual: in `/checkout`, click "Use a new address" and confirm name fields are prefilled; click "Copy from my default address" and confirm all address fields populate
- [ ] Manual: in `/cuenta/direcciones`, click "Add address" and verify name prefill + "Copy from default" behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)