### PR TITLE
fix(reviews): compact star picker in review modal

### DIFF
--- a/src/components/reviews/ReviewFormButton.tsx
+++ b/src/components/reviews/ReviewFormButton.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { StarIcon as StarOutlineIcon } from '@heroicons/react/24/outline'
+import { StarIcon as StarSolidIcon } from '@heroicons/react/24/solid'
 import { Button } from '@/components/ui/button'
 import { Modal } from '@/components/ui/modal'
-import { StarRating } from '@/components/reviews/StarRating'
 import { createReview } from '@/domains/reviews/actions'
 import { useT } from '@/i18n'
 
@@ -19,6 +20,7 @@ export function ReviewFormButton({ orderId, productId, productName }: Props) {
   const t = useT()
   const [open, setOpen] = useState(false)
   const [rating, setRating] = useState(5)
+  const [hoverRating, setHoverRating] = useState(0)
   const [body, setBody] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
@@ -51,10 +53,15 @@ export function ReviewFormButton({ orderId, productId, productName }: Props) {
         <div className="space-y-5 p-5">
           <div>
             <p className="text-sm font-medium text-[var(--foreground)]">{t('reviews.yourRating')}</p>
-            <div className="mt-3 flex gap-2">
+            <div
+              className="mt-3 flex items-center gap-1"
+              onMouseLeave={() => setHoverRating(0)}
+            >
               {Array.from({ length: 5 }, (_, index) => {
                 const value = index + 1
-                const active = value <= rating
+                const displayed = hoverRating || rating
+                const active = value <= displayed
+                const Icon = active ? StarSolidIcon : StarOutlineIcon
                 const ariaLabel =
                   value === 1
                     ? t('reviews.starAriaOne')
@@ -65,14 +72,20 @@ export function ReviewFormButton({ orderId, productId, productName }: Props) {
                     key={value}
                     type="button"
                     onClick={() => setRating(value)}
-                    className={`rounded-xl border px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)] ${
-                      active
-                        ? 'border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-600 dark:bg-amber-950/40 dark:text-amber-50'
-                        : 'border-[var(--border)] bg-[var(--surface)] hover:border-amber-200 hover:bg-[var(--surface-raised)] dark:hover:border-amber-800'
-                    }`}
+                    onMouseEnter={() => setHoverRating(value)}
+                    onFocus={() => setHoverRating(value)}
+                    onBlur={() => setHoverRating(0)}
                     aria-label={ariaLabel}
+                    aria-pressed={value === rating}
+                    className="rounded-lg p-1 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40"
                   >
-                    <StarRating rating={value} size="sm" />
+                    <Icon
+                      className={`h-8 w-8 transition-colors ${
+                        active
+                          ? 'text-amber-400 dark:text-amber-300'
+                          : 'text-[var(--border-strong)] hover:text-amber-300'
+                      }`}
+                    />
                   </button>
                 )
               })}


### PR DESCRIPTION
## Summary

Fixes the broken rating picker in the "Leave a review" modal reported on #215.

### Bug

The rating picker rendered **five** buttons, each containing a **full five-star row**, for a total of ~450 px of horizontal content inside a `max-w-md` (448 px) modal. The container clipped the controls on the right, and because the modal uses \`overflow-hidden\`, the stars could not even be horizontally scrolled. The squeezed layout also made the textarea hard to focus and the submit button partially unreachable on small viewports — users reported they could not type a comment.

### Fix

Replace the five fat buttons with a single row of five individual star toggles. Click the N-th star to set rating N, with hover / focus preview (the classic pattern). Fits any viewport width, keeps every existing i18n key (`reviews.starAriaOne`, `reviews.starAriaOther`, etc.), and preserves keyboard navigation + `aria-pressed`.

### Before / after

Before: 5 × (padding + 5-star row) → ~450 px, clipped.
After: 5 × single star button → ~220 px, comfortable margin even on 375 px viewports.

## Test plan

- [x] `npm run typecheck:app`
- [x] `npm run test:parallel` — 430 tests passing
- [ ] Manual: open the modal on mobile width (375 px), click each star, verify rating updates
- [ ] Manual: type a comment, submit, verify review appears on the product page

🤖 Generated with [Claude Code](https://claude.com/claude-code)