### PR TITLE
fix(search): translate English query terms to Spanish equivalents

### DIFF
--- a/src/domains/catalog/queries.ts
+++ b/src/domains/catalog/queries.ts
@@ -4,6 +4,7 @@ import { PAGINATION_DEFAULTS } from '@/lib/constants'
 import { getAvailableProductWhere } from '@/domains/catalog/availability'
 import { CACHE_TAGS } from '@/lib/cache-tags'
 import { getDemoProductImages } from '@/lib/demo-product-images'
+import { expandSearchQuery } from '@/lib/search-translation'
 
 export interface ProductFilters {
   categorySlug?: string
@@ -71,13 +72,18 @@ async function getProductsUncached(filters: ProductFilters = {}) {
     ...(certifications?.length && { certifications: { hasSome: certifications } }),
     ...(minPrice !== undefined && { basePrice: { gte: minPrice } }),
     ...(maxPrice !== undefined && { basePrice: { lte: maxPrice } }),
-    ...(q && {
-      OR: [
-        { name: { contains: q, mode: 'insensitive' as const } },
-        { description: { contains: q, mode: 'insensitive' as const } },
-        { tags: { has: q.toLowerCase() } },
-      ],
-    }),
+    ...(q && (() => {
+      // Expand the query with EN→ES translations so an English-locale buyer
+      // typing "honey" / "olive oil" matches Spanish "miel" / "aceite de oliva".
+      const terms = expandSearchQuery(q)
+      return {
+        OR: terms.flatMap(term => [
+          { name: { contains: term, mode: 'insensitive' as const } },
+          { description: { contains: term, mode: 'insensitive' as const } },
+          { tags: { has: term.toLowerCase() } },
+        ]),
+      }
+    })()),
   }
 
   // Stable compound sort: primary sort field + id tiebreaker ensures

--- a/src/lib/search-translation.ts
+++ b/src/lib/search-translation.ts
@@ -1,0 +1,195 @@
+/**
+ * English → Spanish search-term expansion for the product catalog.
+ *
+ * The catalog stores product names and descriptions in Spanish. When a buyer
+ * types an English query like "honey" or "olive oil", the substring search
+ * over `name`/`description`/`tags` finds nothing because the rows say "miel"
+ * and "aceite de oliva".
+ *
+ * `expandSearchQuery` looks each query token (and 2-/3-word phrases) up in a
+ * focused EN→ES food/grocery dictionary and returns the original query plus
+ * any Spanish equivalents. The query layer ORs all returned terms together,
+ * so a search for "olive oil" hits both "Aceite de oliva virgen extra" and
+ * any product with "olive" in the name (e.g. an English-named import).
+ *
+ * Why locale-agnostic: a Spanish-speaking buyer who types an English word
+ * (because they saw it on a label) gets the same benefit, and we keep the
+ * Prisma cache key untouched.
+ */
+
+const EN_TO_ES: Record<string, string> = {
+  // Top-level categories
+  honey: 'miel',
+  oil: 'aceite',
+  oils: 'aceites',
+  'olive oil': 'aceite de oliva',
+  'extra virgin olive oil': 'aceite de oliva virgen extra',
+  olive: 'oliva',
+  olives: 'aceitunas',
+  wine: 'vino',
+  wines: 'vinos',
+  cheese: 'queso',
+  cheeses: 'quesos',
+  bread: 'pan',
+  bakery: 'panadería',
+  vegetable: 'verdura',
+  vegetables: 'verduras',
+  veggies: 'verduras',
+  fruit: 'fruta',
+  fruits: 'frutas',
+  meat: 'carne',
+  meats: 'carnes',
+  milk: 'leche',
+  dairy: 'lácteos',
+
+  // Meats / charcuterie
+  beef: 'ternera',
+  pork: 'cerdo',
+  chicken: 'pollo',
+  lamb: 'cordero',
+  fish: 'pescado',
+  ham: 'jamón',
+  'cured ham': 'jamón curado',
+  'iberian ham': 'jamón ibérico',
+  iberian: 'ibérico',
+  sausage: 'embutido',
+  sausages: 'embutidos',
+  chorizo: 'chorizo',
+
+  // Fruits
+  apple: 'manzana',
+  apples: 'manzanas',
+  orange: 'naranja',
+  oranges: 'naranjas',
+  lemon: 'limón',
+  lemons: 'limones',
+  strawberry: 'fresa',
+  strawberries: 'fresas',
+  grape: 'uva',
+  grapes: 'uvas',
+  peach: 'melocotón',
+  peaches: 'melocotones',
+  pear: 'pera',
+  pears: 'peras',
+  watermelon: 'sandía',
+  melon: 'melón',
+  fig: 'higo',
+  figs: 'higos',
+  cherry: 'cereza',
+  cherries: 'cerezas',
+
+  // Vegetables
+  tomato: 'tomate',
+  tomatoes: 'tomates',
+  potato: 'patata',
+  potatoes: 'patatas',
+  garlic: 'ajo',
+  onion: 'cebolla',
+  onions: 'cebollas',
+  pepper: 'pimiento',
+  peppers: 'pimientos',
+  carrot: 'zanahoria',
+  carrots: 'zanahorias',
+  lettuce: 'lechuga',
+  cucumber: 'pepino',
+  spinach: 'espinaca',
+  zucchini: 'calabacín',
+  pumpkin: 'calabaza',
+  artichoke: 'alcachofa',
+  artichokes: 'alcachofas',
+  asparagus: 'espárrago',
+
+  // Dairy
+  yogurt: 'yogur',
+  yoghurt: 'yogur',
+  butter: 'mantequilla',
+  cream: 'nata',
+
+  // Pantry
+  rice: 'arroz',
+  flour: 'harina',
+  salt: 'sal',
+  sugar: 'azúcar',
+  vinegar: 'vinagre',
+  beans: 'judías',
+  lentils: 'lentejas',
+  chickpeas: 'garbanzos',
+  almond: 'almendra',
+  almonds: 'almendras',
+  nuts: 'frutos secos',
+  jam: 'mermelada',
+  marmalade: 'mermelada',
+  pasta: 'pasta',
+  saffron: 'azafrán',
+
+  // Wine descriptors (only safe in wine context, but harmless as extra OR clauses)
+  'red wine': 'vino tinto',
+  'white wine': 'vino blanco',
+  'rosé wine': 'vino rosado',
+  'rose wine': 'vino rosado',
+  'sparkling wine': 'vino espumoso',
+  cava: 'cava',
+
+  // Quality / certifications
+  organic: 'ecológico',
+  ecological: 'ecológico',
+  bio: 'bio',
+  artisan: 'artesano',
+  artisanal: 'artesanal',
+  homemade: 'casero',
+  handmade: 'hecho a mano',
+  fresh: 'fresco',
+  cured: 'curado',
+  smoked: 'ahumado',
+  'extra virgin': 'virgen extra',
+  virgin: 'virgen',
+  'gluten free': 'sin gluten',
+  'lactose free': 'sin lactosa',
+}
+
+function normalize(input: string): string {
+  return input.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/**
+ * Expand a search query into the original term plus any English→Spanish
+ * translations of phrases or individual tokens it contains. Always returns
+ * at least the normalized original query (when non-empty).
+ *
+ * Multi-word phrases are matched first (longest n-gram wins per position),
+ * then per-token translations are added. Duplicates are deduped via Set.
+ */
+export function expandSearchQuery(query: string): string[] {
+  const q = normalize(query)
+  if (!q) return []
+
+  const results = new Set<string>([q])
+
+  const fullPhrase = EN_TO_ES[q]
+  if (fullPhrase) results.add(fullPhrase)
+
+  const words = q.split(' ')
+
+  if (words.length >= 3) {
+    for (let i = 0; i <= words.length - 3; i++) {
+      const trigram = words.slice(i, i + 3).join(' ')
+      const m = EN_TO_ES[trigram]
+      if (m) results.add(m)
+    }
+  }
+
+  if (words.length >= 2) {
+    for (let i = 0; i <= words.length - 2; i++) {
+      const bigram = words.slice(i, i + 2).join(' ')
+      const m = EN_TO_ES[bigram]
+      if (m) results.add(m)
+    }
+  }
+
+  for (const word of words) {
+    const m = EN_TO_ES[word]
+    if (m) results.add(m)
+  }
+
+  return Array.from(results)
+}

--- a/test/search-translation.test.ts
+++ b/test/search-translation.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { expandSearchQuery } from '@/lib/search-translation'
+
+test('expandSearchQuery returns empty array for empty / whitespace input', () => {
+  assert.deepEqual(expandSearchQuery(''), [])
+  assert.deepEqual(expandSearchQuery('   '), [])
+})
+
+test('expandSearchQuery normalizes case and whitespace', () => {
+  const out = expandSearchQuery('  HoNeY  ')
+  // Original is normalized; Spanish equivalent is added.
+  assert.ok(out.includes('honey'))
+  assert.ok(out.includes('miel'))
+})
+
+test('expandSearchQuery translates a single English term to Spanish', () => {
+  const out = expandSearchQuery('honey')
+  assert.deepEqual(out.sort(), ['honey', 'miel'].sort())
+})
+
+test('expandSearchQuery translates multi-word English phrases', () => {
+  // "olive oil" is a 2-gram entry; the per-word fallbacks also fire.
+  const out = expandSearchQuery('olive oil')
+  assert.ok(out.includes('olive oil'))
+  assert.ok(out.includes('aceite de oliva'))
+  assert.ok(out.includes('aceite'))
+  assert.ok(out.includes('oliva'))
+})
+
+test('expandSearchQuery handles 3-gram phrases (extra virgin olive oil)', () => {
+  const out = expandSearchQuery('extra virgin olive oil')
+  assert.ok(out.includes('extra virgin olive oil'))
+  assert.ok(out.includes('aceite de oliva virgen extra'))
+  // It should also pick up shorter sub-phrases.
+  assert.ok(out.includes('aceite de oliva'))
+  assert.ok(out.includes('virgen extra'))
+})
+
+test('expandSearchQuery leaves Spanish queries untouched (no false expansion)', () => {
+  const out = expandSearchQuery('miel')
+  assert.deepEqual(out, ['miel'])
+})
+
+test('expandSearchQuery deduplicates repeated translations', () => {
+  // "marmalade" and "jam" both map to "mermelada"; ensure no duplicate.
+  const out = expandSearchQuery('jam marmalade')
+  const mermeladaCount = out.filter(t => t === 'mermelada').length
+  assert.equal(mermeladaCount, 1)
+})
+
+test('expandSearchQuery covers main category terms', () => {
+  const cases: Array<[string, string]> = [
+    ['wine', 'vino'],
+    ['cheese', 'queso'],
+    ['bread', 'pan'],
+    ['vegetables', 'verduras'],
+    ['fruits', 'frutas'],
+    ['meat', 'carne'],
+    ['dairy', 'lácteos'],
+  ]
+  for (const [en, es] of cases) {
+    const out = expandSearchQuery(en)
+    assert.ok(out.includes(es), `expected "${en}" → "${es}", got ${JSON.stringify(out)}`)
+  }
+})
+
+test('expandSearchQuery always includes the original query as a search term', () => {
+  // Even untranslatable / brand-name queries should still hit the DB as-is.
+  const out = expandSearchQuery('riojano artesano')
+  assert.ok(out.includes('riojano artesano'))
+})


### PR DESCRIPTION
## Summary
The product catalog stores names and descriptions in Spanish. When a buyer on the English locale typed words like **honey**, **olive oil**, or **extra virgin olive oil**, the substring search in `getProducts` found nothing because the DB rows say *miel*, *aceite de oliva*, *aceite de oliva virgen extra*.

This PR adds a small EN→ES food/grocery dictionary and expands every query into the original term plus its Spanish equivalents before hitting Prisma. The query layer ORs all expanded terms across `name` / `description` / `tags`.

### What's in the box
- **`src/lib/search-translation.ts`** — ~120 curated entries covering categories, fruits, vegetables, dairy, meats, pantry, wine descriptors, certifications. Multi-word phrases (e.g. *extra virgin olive oil → aceite de oliva virgen extra*) are matched as 3- or 2-grams before falling back to per-word translation.
- **`src/domains/catalog/queries.ts`** — `getProductsUncached` now `flatMap`s the expanded terms into the existing OR clause. Cache key untouched (same `q` → same expansion → same result set).
- Locale-agnostic on purpose: a Spanish buyer who types an English word from a product label also benefits, and we don't have to thread `locale` through the query API.

### Examples
- `honey` → matches *Miel*, *Miel de azahar*, etc.
- `olive oil` → matches *Aceite de oliva virgen extra*
- `red wine` → matches *Vino tinto*
- `miel` (Spanish query) → unchanged behavior

## Test plan
- [x] `npm test` — 439 tests pass, including 9 new cases in `test/search-translation.test.ts`
- [x] `npm run typecheck` — clean
- [ ] Manual: switch UI to English, search **honey** / **olive oil** / **wine** in the header buscador, confirm Spanish products appear
- [ ] Manual: search **miel** in Spanish UI, confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)