### PR TITLE
fix: guard checkout against variant prices below Stripe minimum (#196)

### DIFF
--- a/src/domains/catalog/variants.ts
+++ b/src/domains/catalog/variants.ts
@@ -37,11 +37,42 @@ export function getDefaultVariant(product: PurchasableProduct) {
   return activeVariants.find(variant => !product.trackStock || variant.stock > 0) ?? activeVariants[0] ?? null
 }
 
+/**
+ * Stripe's minimum charge amount is 0.50 EUR. A variant whose base price
+ * plus priceModifier lands below this threshold cannot actually be
+ * charged — checkout will explode late and confusingly.
+ */
+export const MINIMUM_CHARGEABLE_PRICE_EUR = 0.5
+
 export function getVariantAdjustedPrice(
   basePrice: number,
   variant?: Pick<ProductVariantOption, 'priceModifier'> | null
-) {
+): number {
   return Math.round((basePrice + Number(variant?.priceModifier ?? 0)) * 100) / 100
+}
+
+export function isVariantPriceChargeable(price: number): boolean {
+  return Number.isFinite(price) && price >= MINIMUM_CHARGEABLE_PRICE_EUR
+}
+
+/**
+ * Throws when the variant-adjusted price is below the minimum chargeable
+ * amount. Call this from vendor-facing product validation and from the
+ * checkout action just before creating the order — display code (product
+ * card, product detail) should keep using getVariantAdjustedPrice directly
+ * so the UI can still render an informative "no disponible" state instead
+ * of a 500 error.
+ */
+export function assertVariantPriceChargeable(
+  price: number,
+  productName?: string
+): void {
+  if (!isVariantPriceChargeable(price)) {
+    const label = productName ? `"${productName}" ` : ''
+    throw new Error(
+      `El precio de ${label}(${price.toFixed(2)} EUR) es inferior al mínimo cobrable (${MINIMUM_CHARGEABLE_PRICE_EUR.toFixed(2)} EUR)`
+    )
+  }
 }
 
 export function getVariantAdjustedCompareAtPrice(

--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -18,6 +18,7 @@ import { assertProviderRefForPaymentStatus, shouldApplyPaymentSucceeded } from '
 import { getServerEnv } from '@/lib/env'
 import { getAvailableProductWhere } from '@/domains/catalog/availability'
 import {
+  assertVariantPriceChargeable,
   getAvailableStockForPurchase,
   getDefaultVariant,
   getSelectedVariant,
@@ -157,12 +158,15 @@ export async function createOrder(
 
     // NOTE: Stock validation moved to transaction to prevent race condition
 
+    const unitPrice = getVariantAdjustedPrice(Number(product.basePrice), selectedVariant)
+    assertVariantPriceChargeable(unitPrice, product.name)
+
     return {
       productId: product.id,
       vendorId: product.vendor.id,
       variantId: selectedVariant?.id ?? null,
       quantity: item.quantity,
-      unitPrice: getVariantAdjustedPrice(Number(product.basePrice), selectedVariant),
+      unitPrice,
       taxRate: product.taxRate,
       productSnapshot: orderLineSnapshotSchema.parse({
         id: product.id,

--- a/test/catalog-variants.test.ts
+++ b/test/catalog-variants.test.ts
@@ -2,11 +2,14 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import {
+  MINIMUM_CHARGEABLE_PRICE_EUR,
+  assertVariantPriceChargeable,
   getAvailableStockForPurchase,
   getDefaultVariant,
   getSelectedVariant,
   getVariantAdjustedCompareAtPrice,
   getVariantAdjustedPrice,
+  isVariantPriceChargeable,
   productRequiresVariantSelection,
   type PurchasableProduct,
 } from '@/domains/catalog/variants'
@@ -113,4 +116,40 @@ test('variant-aware product UI defaults to a concrete variant before adding to c
   assert.match(purchasePanel, /useState<string>\(defaultVariant\?\.id \?\? ''\)/)
   assert.match(productCard, /variantId=\{defaultVariant\?\.id\}/)
   assert.match(productCard, /variantName=\{defaultVariant\?\.name\}/)
+})
+
+test('MINIMUM_CHARGEABLE_PRICE_EUR matches the Stripe minimum charge', () => {
+  assert.equal(MINIMUM_CHARGEABLE_PRICE_EUR, 0.5)
+})
+
+test('isVariantPriceChargeable accepts prices at or above the minimum', () => {
+  assert.equal(isVariantPriceChargeable(0.5), true)
+  assert.equal(isVariantPriceChargeable(1), true)
+  assert.equal(isVariantPriceChargeable(1999.99), true)
+})
+
+test('isVariantPriceChargeable rejects zero, negative, NaN and Infinity', () => {
+  assert.equal(isVariantPriceChargeable(0), false)
+  assert.equal(isVariantPriceChargeable(0.49), false)
+  assert.equal(isVariantPriceChargeable(-5), false)
+  assert.equal(isVariantPriceChargeable(Number.NaN), false)
+  assert.equal(isVariantPriceChargeable(Number.POSITIVE_INFINITY), false)
+})
+
+test('assertVariantPriceChargeable is a no-op for chargeable prices', () => {
+  assert.doesNotThrow(() => assertVariantPriceChargeable(0.5))
+  assert.doesNotThrow(() => assertVariantPriceChargeable(42))
+})
+
+test('assertVariantPriceChargeable throws including the product name and minimum', () => {
+  assert.throws(
+    () => assertVariantPriceChargeable(0.1, 'Miel de romero'),
+    /Miel de romero.*0\.10.*0\.50/
+  )
+})
+
+test('getVariantAdjustedPrice still returns display prices below the minimum (no throw)', () => {
+  const price = getVariantAdjustedPrice(1, { priceModifier: -0.9 })
+  assert.equal(price, 0.1)
+  assert.equal(isVariantPriceChargeable(price), false)
 })


### PR DESCRIPTION
Closes #196

## Summary
`ProductVariant.priceModifier` is a signed decimal, so `base 1.00 + modifier -0.90 = 0.10 EUR` — below Stripe's 0.50 EUR minimum charge. Checkout used to explode late with a cryptic Stripe error and leave a half-built order.

- Adds `MINIMUM_CHARGEABLE_PRICE_EUR`, `isVariantPriceChargeable(price)` and `assertVariantPriceChargeable(price, productName?)` in `src/domains/catalog/variants.ts`
- Wires `assertVariantPriceChargeable` into `createOrder` right after the unit price is computed, so the checkout fails early with a localised Spanish message instead of deep inside Stripe
- `getVariantAdjustedPrice` stays pure (no throw) so display components (ProductCard, ProductPurchasePanel) keep rendering the unchargeable price as a UI state instead of crashing with a 500
- 6 new unit tests

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 439/439 pass (6 new tests)
- [ ] Manual: create a variant with a large negative `priceModifier`, attempt checkout, verify the Spanish error surfaces in the cart

🤖 Generated with [Claude Code](https://claude.com/claude-code)