### PR TITLE
feat: canonical api-response helpers (#190)

### DIFF
--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Canonical error-response helpers for /api routes.
+ *
+ * Previously every route shaped its errors slightly differently
+ * (`{ error }`, `{ message }`, `{ error, message, details }` etc.) and
+ * clients had to handle each one. Migrate new routes to these helpers so
+ * the client can rely on a single shape:
+ *
+ *   { error: string, code: ApiErrorCode, details?: unknown }
+ *
+ * `error` is the human-readable (localized) message, `code` is the
+ * stable machine-readable identifier, `details` is optional structured
+ * context (e.g. Zod issues list).
+ */
+
+export type ApiErrorCode =
+  | 'BAD_REQUEST'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'VALIDATION_ERROR'
+  | 'RATE_LIMITED'
+  | 'INTERNAL_ERROR'
+
+export interface ApiErrorBody {
+  error: string
+  code: ApiErrorCode
+  details?: unknown
+}
+
+export function apiError(
+  message: string,
+  status: number,
+  code: ApiErrorCode = 'INTERNAL_ERROR',
+  details?: unknown,
+  extraHeaders?: Record<string, string>
+): NextResponse<ApiErrorBody> {
+  const body: ApiErrorBody = { error: message, code }
+  if (details !== undefined) body.details = details
+  return NextResponse.json(body, { status, headers: extraHeaders })
+}
+
+export const apiBadRequest = (message: string, details?: unknown) =>
+  apiError(message, 400, 'BAD_REQUEST', details)
+
+export const apiUnauthorized = (message = 'No autorizado') =>
+  apiError(message, 401, 'UNAUTHORIZED')
+
+export const apiForbidden = (message = 'Acción no permitida') =>
+  apiError(message, 403, 'FORBIDDEN')
+
+export const apiNotFound = (message = 'Recurso no encontrado') =>
+  apiError(message, 404, 'NOT_FOUND')
+
+export const apiConflict = (message: string, details?: unknown) =>
+  apiError(message, 409, 'CONFLICT', details)
+
+export const apiValidationError = (message: string, details?: unknown) =>
+  apiError(message, 422, 'VALIDATION_ERROR', details)
+
+export const apiRateLimited = (
+  message: string,
+  retryAfterSeconds: number,
+  limit?: number
+) =>
+  apiError(message, 429, 'RATE_LIMITED', undefined, {
+    'Retry-After': String(Math.max(0, Math.ceil(retryAfterSeconds))),
+    ...(limit !== undefined ? { 'X-RateLimit-Limit': String(limit) } : {}),
+  })
+
+export const apiInternalError = (message = 'Error interno') =>
+  apiError(message, 500, 'INTERNAL_ERROR')

--- a/test/api-response.test.ts
+++ b/test/api-response.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  apiBadRequest,
+  apiConflict,
+  apiError,
+  apiForbidden,
+  apiInternalError,
+  apiNotFound,
+  apiRateLimited,
+  apiUnauthorized,
+  apiValidationError,
+} from '@/lib/api-response'
+
+async function readBody(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>
+}
+
+test('apiError returns the canonical shape and status', async () => {
+  const res = apiError('boom', 500, 'INTERNAL_ERROR', { trace: 'abc' })
+  assert.equal(res.status, 500)
+  const body = await readBody(res)
+  assert.equal(body.error, 'boom')
+  assert.equal(body.code, 'INTERNAL_ERROR')
+  assert.deepEqual(body.details, { trace: 'abc' })
+})
+
+test('apiError omits details when not provided', async () => {
+  const res = apiError('nope', 400, 'BAD_REQUEST')
+  const body = await readBody(res)
+  assert.equal('details' in body, false)
+})
+
+test('shorthands map to the expected status and code', async () => {
+  const cases: Array<[Response, number, string]> = [
+    [apiBadRequest('x'), 400, 'BAD_REQUEST'],
+    [apiUnauthorized(), 401, 'UNAUTHORIZED'],
+    [apiForbidden(), 403, 'FORBIDDEN'],
+    [apiNotFound(), 404, 'NOT_FOUND'],
+    [apiConflict('dup'), 409, 'CONFLICT'],
+    [apiValidationError('bad'), 422, 'VALIDATION_ERROR'],
+    [apiInternalError(), 500, 'INTERNAL_ERROR'],
+  ]
+  for (const [res, status, code] of cases) {
+    assert.equal(res.status, status)
+    const body = await readBody(res)
+    assert.equal(body.code, code)
+    assert.equal(typeof body.error, 'string')
+  }
+})
+
+test('apiRateLimited sets Retry-After header and optional limit', async () => {
+  const res = apiRateLimited('slow down', 120, 5)
+  assert.equal(res.status, 429)
+  assert.equal(res.headers.get('Retry-After'), '120')
+  assert.equal(res.headers.get('X-RateLimit-Limit'), '5')
+  const body = await readBody(res)
+  assert.equal(body.code, 'RATE_LIMITED')
+})
+
+test('apiRateLimited floors negative retry-after to zero', () => {
+  const res = apiRateLimited('slow down', -4)
+  assert.equal(res.headers.get('Retry-After'), '0')
+})


### PR DESCRIPTION
Closes #190

## Summary
Introduces `src/lib/api-response.ts` so future `/api` routes can return a consistent shape instead of each route shaping errors slightly differently (`{ error }`, `{ message }`, `{ error, message, details }`).

Canonical shape:
\`\`\`ts
{ error: string, code: ApiErrorCode, details?: unknown }
\`\`\`

Shorthands:
- `apiBadRequest`, `apiUnauthorized`, `apiForbidden`, `apiNotFound`, `apiConflict`, `apiValidationError`, `apiRateLimited`, `apiInternalError`
- `apiRateLimited` auto-sets `Retry-After` (floored to zero) and `X-RateLimit-Limit`

## Migration strategy
This PR does **not** migrate the existing routes — keeping the scope tight. New routes should use these helpers; existing ones can be migrated opportunistically.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 457/457 pass (5 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)