### PR TITLE
perf: support fine-grained cache tags for single-entity invalidation (#189)

### DIFF
--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,13 +1,22 @@
 // Public catalog cache tags.
+//
+// Coarse tags (flush everything in that bucket):
 // - `catalog`: filtered listing pages and featured product collections.
 // - `products`: product detail queries and static params.
 // - `vendors`: public vendor profile queries and vendor listings.
 // - `categories`: category navigation and counts.
 // - `home`: the storefront landing snapshot.
+//
+// Fine-grained tag builders (flush a single entity only). Attach these
+// next to the coarse tag when wiring an unstable_cache so a mutation
+// can choose the narrowest possible invalidation.
 export const CACHE_TAGS = {
   catalog: 'catalog',
   products: 'products',
   vendors: 'vendors',
   categories: 'categories',
   home: 'home',
+  product: (slugOrId: string) => `product:${slugOrId}`,
+  vendor: (slugOrId: string) => `vendor:${slugOrId}`,
+  category: (slugOrId: string) => `category:${slugOrId}`,
 } as const

--- a/src/lib/revalidate.ts
+++ b/src/lib/revalidate.ts
@@ -11,25 +11,42 @@ export function safeRevalidateTag(tag: string) {
   updateTag(tag)
 }
 
-export function revalidateCatalogExperience(input: {
+export interface RevalidateCatalogInput {
   productSlug?: string | null
   vendorSlug?: string | null
+  categorySlug?: string | null
   includeHome?: boolean
-} = {}) {
-  safeRevalidateTag(CACHE_TAGS.catalog)
-  safeRevalidateTag(CACHE_TAGS.products)
-  safeRevalidateTag(CACHE_TAGS.vendors)
-  safeRevalidateTag(CACHE_TAGS.categories)
+  /**
+   * When true, flush the coarse `catalog`/`products`/`vendors`/
+   * `categories` buckets in addition to any fine-grained tags. Leave
+   * false when you know exactly one entity changed — you get the same
+   * visible effect with far less cache churn across unrelated pages.
+   */
+  flushAll?: boolean
+}
 
-  safeRevalidatePath('/productos')
-  safeRevalidatePath('/productores')
+export function revalidateCatalogExperience(input: RevalidateCatalogInput = {}) {
+  const { productSlug, vendorSlug, categorySlug, flushAll = true } = input
 
-  if (input.productSlug) {
-    safeRevalidatePath(`/productos/${input.productSlug}`)
+  if (productSlug) {
+    safeRevalidateTag(CACHE_TAGS.product(productSlug))
+    safeRevalidatePath(`/productos/${productSlug}`)
+  }
+  if (vendorSlug) {
+    safeRevalidateTag(CACHE_TAGS.vendor(vendorSlug))
+    safeRevalidatePath(`/productores/${vendorSlug}`)
+  }
+  if (categorySlug) {
+    safeRevalidateTag(CACHE_TAGS.category(categorySlug))
   }
 
-  if (input.vendorSlug) {
-    safeRevalidatePath(`/productores/${input.vendorSlug}`)
+  if (flushAll) {
+    safeRevalidateTag(CACHE_TAGS.catalog)
+    safeRevalidateTag(CACHE_TAGS.products)
+    safeRevalidateTag(CACHE_TAGS.vendors)
+    safeRevalidateTag(CACHE_TAGS.categories)
+    safeRevalidatePath('/productos')
+    safeRevalidatePath('/productores')
   }
 
   if (input.includeHome ?? true) {

--- a/test/cache-tags.test.ts
+++ b/test/cache-tags.test.ts
@@ -2,16 +2,46 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { CACHE_TAGS } from '@/lib/cache-tags'
 
-test('CACHE_TAGS documents stable public cache buckets', () => {
-  assert.deepEqual(CACHE_TAGS, {
-    catalog: 'catalog',
-    products: 'products',
-    vendors: 'vendors',
-    categories: 'categories',
-    home: 'home',
-  })
+test('CACHE_TAGS documents stable coarse-grained public buckets', () => {
+  assert.equal(CACHE_TAGS.catalog, 'catalog')
+  assert.equal(CACHE_TAGS.products, 'products')
+  assert.equal(CACHE_TAGS.vendors, 'vendors')
+  assert.equal(CACHE_TAGS.categories, 'categories')
+  assert.equal(CACHE_TAGS.home, 'home')
 })
 
-test('CACHE_TAGS values are unique to avoid cross-invalidating unrelated caches', () => {
-  assert.equal(new Set(Object.values(CACHE_TAGS)).size, Object.keys(CACHE_TAGS).length)
+test('coarse CACHE_TAGS string values are unique', () => {
+  const strings = [
+    CACHE_TAGS.catalog,
+    CACHE_TAGS.products,
+    CACHE_TAGS.vendors,
+    CACHE_TAGS.categories,
+    CACHE_TAGS.home,
+  ]
+  assert.equal(new Set(strings).size, strings.length)
+})
+
+test('fine-grained tag builders namespace entities to avoid collisions', () => {
+  assert.equal(CACHE_TAGS.product('tomate-rf'), 'product:tomate-rf')
+  assert.equal(CACHE_TAGS.vendor('casa-rosa'), 'vendor:casa-rosa')
+  assert.equal(CACHE_TAGS.category('verduras'), 'category:verduras')
+})
+
+test('fine-grained tags never collide with coarse tags', () => {
+  const coarse: ReadonlySet<string> = new Set<string>([
+    CACHE_TAGS.catalog,
+    CACHE_TAGS.products,
+    CACHE_TAGS.vendors,
+    CACHE_TAGS.categories,
+    CACHE_TAGS.home,
+  ])
+  assert.equal(coarse.has(CACHE_TAGS.product('x')), false)
+  assert.equal(coarse.has(CACHE_TAGS.vendor('x')), false)
+  assert.equal(coarse.has(CACHE_TAGS.category('x')), false)
+})
+
+test('fine-grained tags for different entities never collide', () => {
+  assert.notEqual(CACHE_TAGS.product('x'), CACHE_TAGS.vendor('x'))
+  assert.notEqual(CACHE_TAGS.product('x'), CACHE_TAGS.category('x'))
+  assert.notEqual(CACHE_TAGS.vendor('x'), CACHE_TAGS.category('x'))
 })


### PR DESCRIPTION
Closes #189

## Summary
Adds entity-scoped tag builders alongside the existing coarse tags so a mutation can invalidate exactly one product/vendor/category without flushing every other cached query.

- `CACHE_TAGS` gains `product(slug)`, `vendor(slug)`, `category(slug)` helpers producing namespaced tags like `product:tomate-rf`
- `revalidateCatalogExperience` now:
  - Emits the fine-grained tag + path when the caller supplies a slug
  - Accepts a new `flushAll` flag (default `true` for backwards-compat) so narrow callers can opt out of the coarse fan-out
  - Accepts `categorySlug` for targeted category invalidation

## Backwards compatibility
All existing callers keep identical behavior because `flushAll` defaults to `true`. Individual routes and cache sites can migrate opportunistically: attach `CACHE_TAGS.product(slug)` in their `unstable_cache` tags array, then pass `flushAll: false` when revalidating.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 466/466 pass (5 tests in cache-tags.test.ts, up from 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)