### PR TITLE
fix: translate buyer account + legal pages, mobile polish, catalog badge

### DIFF
--- a/src/app/(buyer)/cuenta/direcciones/page.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/page.tsx
@@ -2,10 +2,15 @@ import { Metadata } from 'next'
 import { requireAuth } from '@/lib/auth-guard'
 import { db } from '@/lib/db'
 import { DireccionesClient } from './DireccionesClient'
+import { getServerT } from '@/i18n/server'
+import { SITE_NAME } from '@/lib/constants'
 
-export const metadata: Metadata = {
-  title: 'Mis Direcciones | Mercado Productor',
-  description: 'Gestiona tus direcciones de envío',
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getServerT()
+  return {
+    title: `${t('account.addressesTitle')} | ${SITE_NAME}`,
+    description: t('account.addressesSubtitle'),
+  }
 }
 
 export default async function Direcciones() {
@@ -14,13 +19,14 @@ export default async function Direcciones() {
     where: { id: session.user.id },
     select: { firstName: true, lastName: true },
   })
+  const t = await getServerT()
 
   return (
     <main className="space-y-6 max-w-3xl mx-auto px-4 py-10 sm:px-6 lg:px-8">
       <div>
-        <h1 className="text-3xl font-bold text-[var(--foreground)]">Mis direcciones</h1>
+        <h1 className="text-3xl font-bold text-[var(--foreground)]">{t('account.addressesTitle')}</h1>
         <p className="mt-2 text-[var(--muted)]">
-          Gestiona tus direcciones de envío
+          {t('account.addressesSubtitle')}
         </p>
       </div>
 

--- a/src/app/(buyer)/cuenta/pedidos/page.tsx
+++ b/src/app/(buyer)/cuenta/pedidos/page.tsx
@@ -12,7 +12,10 @@ import type { Metadata } from 'next'
 import { getServerT } from '@/i18n/server'
 import { countPendingReviewsInOrder } from '@/domains/reviews/pending-policy'
 
-export const metadata: Metadata = { title: 'Mis pedidos' }
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getServerT()
+  return { title: t('account.ordersTitle') }
+}
 
 const STATUS_VARIANT: Record<string, 'green' | 'amber' | 'red' | 'blue' | 'default'> = {
   PLACED: 'blue',
@@ -43,18 +46,18 @@ export default async function MisPedidosPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-[var(--foreground)]">Mis pedidos</h1>
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">{t('account.ordersTitle')}</h1>
         <p className="mt-2 text-sm text-[var(--muted)]">
-          Repite compras anteriores en un clic o entra al detalle para revisar el pedido.
+          {t('account.ordersSubtitle')}
         </p>
       </div>
 
       {orders.length === 0 ? (
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-6 py-16 text-center shadow-sm">
           <p className="text-4xl mb-3">📦</p>
-          <p className="font-medium text-[var(--foreground-soft)]">Aún no tienes pedidos</p>
+          <p className="font-medium text-[var(--foreground-soft)]">{t('account.ordersEmpty')}</p>
           <Link href="/productos" className="mt-4 inline-flex rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/35 dark:text-emerald-300 dark:hover:bg-emerald-950/55">
-            Explorar productos
+            {t('account.ordersExplore')}
           </Link>
         </div>
       ) : (
@@ -82,7 +85,7 @@ export default async function MisPedidosPage() {
                     <p className="font-semibold text-[var(--foreground)]">{order.orderNumber}</p>
                     <p className="text-sm text-[var(--muted)]">{formatDate(order.placedAt)}</p>
                     <p className="text-xs text-[var(--muted)]">
-                      {totalItems} artículo{totalItems !== 1 ? 's' : ''} · {productCount} producto{productCount !== 1 ? 's' : ''}
+                      {totalItems} {totalItems === 1 ? t('account.ordersItem') : t('account.ordersItems')} · {productCount} {productCount === 1 ? t('account.ordersProduct') : t('account.ordersProducts')}
                     </p>
                   </div>
                   <div className="flex flex-col items-end gap-1">
@@ -110,7 +113,7 @@ export default async function MisPedidosPage() {
                     </div>
                   ))}
                   {order.lines.length > 3 && (
-                    <p className="text-xs text-[var(--muted)]">+{order.lines.length - 3} más</p>
+                    <p className="text-xs text-[var(--muted)]">+{order.lines.length - 3} {t('account.ordersMore')}</p>
                   )}
                 </div>
               </Link>
@@ -134,7 +137,7 @@ export default async function MisPedidosPage() {
                   href={`/cuenta/pedidos/${order.id}`}
                   className="text-sm font-medium text-emerald-700 underline-offset-4 hover:underline dark:text-emerald-400"
                 >
-                  Ver detalle
+                  {t('account.ordersViewDetail')}
                 </Link>
                 <RepeatOrderButton
                   orderNumber={order.orderNumber}

--- a/src/app/(buyer)/cuenta/perfil/page.tsx
+++ b/src/app/(buyer)/cuenta/perfil/page.tsx
@@ -1,20 +1,26 @@
 import { auth } from '@/lib/auth'
 import { redirect } from 'next/navigation'
 import { BuyerProfileForm } from '@/components/buyer/BuyerProfileForm'
+import { getServerT } from '@/i18n/server'
 import type { Metadata } from 'next'
 
-export const metadata: Metadata = { title: 'Mi perfil' }
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getServerT()
+  return { title: t('account.profileTitle') }
+}
 
 export default async function CuentaPerfilPage() {
   const session = await auth()
   if (!session) redirect('/login')
 
+  const t = await getServerT()
+
   return (
     <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8 space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-[var(--foreground)]">Mi perfil</h1>
+        <h1 className="text-3xl font-bold text-[var(--foreground)]">{t('account.profileTitle')}</h1>
         <p className="mt-2 text-[var(--muted)]">
-          Gestiona tu información personal y contraseña
+          {t('account.profileSubtitle')}
         </p>
       </div>
 

--- a/src/app/(public)/HomePageClient.tsx
+++ b/src/app/(public)/HomePageClient.tsx
@@ -264,18 +264,20 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
             <p className="text-xs font-semibold uppercase tracking-widest text-emerald-600 dark:text-emerald-400">{t('sectionLabelProcess')}</p>
             <h2 className="mt-1 text-2xl font-bold text-[var(--foreground)]">{t('sections.howItWorks')}</h2>
           </div>
-          <div className="grid gap-8 sm:grid-cols-4">
+          <div className="grid gap-5 sm:grid-cols-4 sm:gap-8">
             {STEPS.map((s, i) => (
               <div key={s.step} className="relative">
                 {i < 3 && (
                   <div className="absolute left-6 top-6 hidden h-px w-full bg-gradient-to-r from-emerald-300/60 to-transparent dark:from-emerald-700/60 sm:block" />
                 )}
-                <div className="relative flex flex-col items-start">
-                  <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-600 text-sm font-bold text-white shadow-md dark:bg-emerald-500 dark:text-gray-950">
+                <div className="relative flex flex-row items-start gap-4 rounded-2xl border border-[var(--border)] bg-[var(--background)] p-4 sm:flex-col sm:gap-0 sm:rounded-none sm:border-0 sm:bg-transparent sm:p-0">
+                  <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-emerald-600 text-sm font-bold text-white shadow-md dark:bg-emerald-500 dark:text-gray-950 sm:h-12 sm:w-12 sm:rounded-2xl">
                     {s.step}
                   </span>
-                  <h3 className="mt-4 font-semibold text-[var(--foreground)]">{t(s.titleKey)}</h3>
-                  <p className="mt-1 text-sm leading-relaxed text-[var(--muted)]">{t(s.descKey)}</p>
+                  <div className="min-w-0 flex-1 sm:mt-4">
+                    <h3 className="font-semibold text-[var(--foreground)]">{t(s.titleKey)}</h3>
+                    <p className="mt-1 text-sm leading-relaxed text-[var(--muted)]">{t(s.descKey)}</p>
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/app/(public)/aviso-legal/page.tsx
+++ b/src/app/(public)/aviso-legal/page.tsx
@@ -1,57 +1,61 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { SITE_NAME } from '@/lib/constants'
 import { LegalPage } from '@/components/legal/LegalPage'
+import { getLegalPageCopy } from '@/i18n/legal-page-copy'
+import { getServerLocale } from '@/i18n/server'
 import { buildPageMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = buildPageMetadata({
-  title: 'Aviso legal',
-  description: `Aviso legal y condiciones de uso de ${SITE_NAME}.`,
-  path: '/aviso-legal',
-})
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).legalNotice
 
-export default function AvisoLegalPage() {
+  return buildPageMetadata({
+    title: copy.metadataTitle,
+    description: copy.metadataDescription,
+    path: '/aviso-legal',
+  })
+}
+
+export default async function AvisoLegalPage() {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).legalNotice
+
   return (
     <LegalPage
-      title="Aviso legal"
-      updatedAt="11 de abril de 2026"
-      intro={`Este aviso legal regula el acceso y uso del sitio de ${SITE_NAME}, así como las responsabilidades generales de la plataforma y de las personas usuarias.`}
+      title={copy.title}
+      updatedAt={copy.updatedAt}
+      intro={copy.intro}
+      eyebrow={copy.eyebrow}
+      updatedAtLabel={copy.updatedAtLabel}
     >
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">1. Titularidad del sitio</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.ownership.title}</h2>
         <p className="mt-3">
-          {SITE_NAME} opera como un marketplace que conecta productores, compradores y equipos operativos.
-          La información de contacto para soporte y consultas está disponible en la página de{' '}
+          {copy.sections.ownership.bodyPrefix}{' '}
           <Link href="/contacto" className="text-emerald-700 underline-offset-2 hover:underline dark:text-emerald-400">
-            contacto
-          </Link>.
+            {copy.sections.ownership.contactLink}
+          </Link>
+          {copy.sections.ownership.bodySuffix}
         </p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">2. Condiciones de uso</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.usage.title}</h2>
         <ul className="mt-3 list-disc space-y-2 pl-5">
-          <li>No se permite usar la plataforma para actividades ilícitas o fraudulentas.</li>
-          <li>Las personas usuarias deben proporcionar información veraz y mantener sus credenciales seguras.</li>
-          <li>El acceso a áreas privadas puede requerir registro y autenticación.</li>
+          {copy.sections.usage.items.map(item => (
+            <li key={item}>{item}</li>
+          ))}
         </ul>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">3. Propiedad intelectual</h2>
-        <p className="mt-3">
-          Los contenidos de marca, diseño, textos y estructura del sitio están protegidos por la normativa
-          aplicable de propiedad intelectual e industrial. Los contenidos aportados por vendedores o terceros
-          siguen siendo de su titularidad, salvo que se indique lo contrario.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.ip.title}</h2>
+        <p className="mt-3">{copy.sections.ip.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">4. Responsabilidad</h2>
-        <p className="mt-3">
-          La plataforma actúa como intermediaria técnica entre compradores y vendedores. Cada parte es
-          responsable de cumplir sus obligaciones legales, comerciales y fiscales en el marco de sus operaciones.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.liability.title}</h2>
+        <p className="mt-3">{copy.sections.liability.body}</p>
       </section>
     </LegalPage>
   )

--- a/src/app/(public)/cookies/page.tsx
+++ b/src/app/(public)/cookies/page.tsx
@@ -1,52 +1,56 @@
 import type { Metadata } from 'next'
-import { SITE_NAME } from '@/lib/constants'
 import { LegalPage } from '@/components/legal/LegalPage'
+import { getLegalPageCopy } from '@/i18n/legal-page-copy'
+import { getServerLocale } from '@/i18n/server'
 import { buildPageMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = buildPageMetadata({
-  title: 'Política de cookies',
-  description: `Información sobre el uso de cookies en ${SITE_NAME}.`,
-  path: '/cookies',
-})
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).cookies
 
-export default function CookiesPage() {
+  return buildPageMetadata({
+    title: copy.metadataTitle,
+    description: copy.metadataDescription,
+    path: '/cookies',
+  })
+}
+
+export default async function CookiesPage() {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).cookies
+
   return (
     <LegalPage
-      title="Política de cookies"
-      updatedAt="11 de abril de 2026"
-      intro={`Esta política explica qué tipos de cookies puede usar ${SITE_NAME} y para qué se emplean.`}
+      title={copy.title}
+      updatedAt={copy.updatedAt}
+      intro={copy.intro}
+      eyebrow={copy.eyebrow}
+      updatedAtLabel={copy.updatedAtLabel}
     >
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">1. Qué son las cookies</h2>
-        <p className="mt-3">
-          Las cookies son pequeños archivos que el navegador almacena para recordar preferencias, mantener
-          la sesión y mejorar el funcionamiento del sitio.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.what.title}</h2>
+        <p className="mt-3">{copy.sections.what.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">2. Tipos de cookies que usamos</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.types.title}</h2>
         <ul className="mt-3 list-disc space-y-2 pl-5">
-          <li><strong>Técnicas:</strong> necesarias para iniciar sesión, mantener el carrito y proteger formularios.</li>
-          <li><strong>Preferencias:</strong> recuerdan idioma, tema visual y otras opciones de experiencia.</li>
-          <li><strong>Analíticas:</strong> se usan para medir el uso del sitio cuando están habilitadas en la configuración de la plataforma.</li>
+          {copy.sections.types.items.map(item => (
+            <li key={item.label}>
+              <strong>{item.label}:</strong> {item.text}
+            </li>
+          ))}
         </ul>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">3. Gestión del consentimiento</h2>
-        <p className="mt-3">
-          Cuando el sitio active cookies no esenciales, el consentimiento deberá gestionarse de forma clara
-          antes de su uso. También puedes bloquear o eliminar cookies desde la configuración de tu navegador.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.consent.title}</h2>
+        <p className="mt-3">{copy.sections.consent.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">4. Cómo desactivarlas</h2>
-        <p className="mt-3">
-          Puedes restringir, bloquear o eliminar cookies desde las preferencias de tu navegador. Ten en cuenta
-          que deshabilitar cookies técnicas puede afectar al inicio de sesión y al carrito.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.disable.title}</h2>
+        <p className="mt-3">{copy.sections.disable.body}</p>
       </section>
     </LegalPage>
   )

--- a/src/app/(public)/productos/[slug]/page.tsx
+++ b/src/app/(public)/productos/[slug]/page.tsx
@@ -197,7 +197,7 @@ export default async function ProductDetailPage({ params }: Props) {
           </div>
 
           <div className="mt-3">
-            <AutoTranslatedBadge translation={localizedProduct.translation} className="text-xs" />
+            <AutoTranslatedBadge translation={localizedProduct.translation} variant="full" />
           </div>
 
           {/* Description */}

--- a/src/app/(public)/terminos/page.tsx
+++ b/src/app/(public)/terminos/page.tsx
@@ -1,60 +1,59 @@
 import type { Metadata } from 'next'
-import { SITE_NAME } from '@/lib/constants'
 import { LegalPage } from '@/components/legal/LegalPage'
+import { getLegalPageCopy } from '@/i18n/legal-page-copy'
+import { getServerLocale } from '@/i18n/server'
 import { buildPageMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = buildPageMetadata({
-  title: 'Términos de uso',
-  description: `Términos y condiciones de uso de ${SITE_NAME}.`,
-  path: '/terminos',
-})
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).terms
 
-export default function TerminosPage() {
+  return buildPageMetadata({
+    title: copy.metadataTitle,
+    description: copy.metadataDescription,
+    path: '/terminos',
+  })
+}
+
+export default async function TerminosPage() {
+  const locale = await getServerLocale()
+  const copy = getLegalPageCopy(locale).terms
+
   return (
     <LegalPage
-      title="Términos de uso"
-      updatedAt="11 de abril de 2026"
-      intro={`Estos términos describen cómo se usa ${SITE_NAME}, qué obligaciones tiene cada parte y cómo se gestiona la compra en la plataforma.`}
+      title={copy.title}
+      updatedAt={copy.updatedAt}
+      intro={copy.intro}
+      eyebrow={copy.eyebrow}
+      updatedAtLabel={copy.updatedAtLabel}
     >
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">1. Registro y cuentas</h2>
-        <p className="mt-3">
-          Cuando una funcionalidad requiera cuenta, la persona usuaria debe aportar datos veraces, mantener
-          su contraseña segura y avisar de cualquier uso no autorizado de su cuenta.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.accounts.title}</h2>
+        <p className="mt-3">{copy.sections.accounts.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">2. Compras y disponibilidad</h2>
-        <p className="mt-3">
-          Los pedidos están sujetos a disponibilidad de stock, validación de pago y condiciones logísticas.
-          Los precios y promociones pueden actualizarse antes de completar la compra.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.purchases.title}</h2>
+        <p className="mt-3">{copy.sections.purchases.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">3. Envíos y devoluciones</h2>
-        <p className="mt-3">
-          Las condiciones de envío, plazos y posibles devoluciones se muestran en el proceso de compra y
-          pueden variar según la zona o el producto.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.shipping.title}</h2>
+        <p className="mt-3">{copy.sections.shipping.body}</p>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">4. Uso aceptable</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.acceptable.title}</h2>
         <ul className="mt-3 list-disc space-y-2 pl-5">
-          <li>No se permite el uso automatizado abusivo ni la manipulación de precios o pedidos.</li>
-          <li>Está prohibida la publicación de contenido engañoso, ilícito o que infrinja derechos de terceros.</li>
-          <li>La plataforma puede restringir accesos si detecta uso indebido o riesgo para la operación.</li>
+          {copy.sections.acceptable.items.map(item => (
+            <li key={item}>{item}</li>
+          ))}
         </ul>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-[var(--foreground)]">5. Cambios en los términos</h2>
-        <p className="mt-3">
-          {SITE_NAME} puede actualizar estos términos cuando cambien la operación, la normativa o la propia
-          plataforma. La versión vigente será la publicada en esta página.
-        </p>
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">{copy.sections.changes.title}</h2>
+        <p className="mt-3">{copy.sections.changes.body}</p>
       </section>
     </LegalPage>
   )

--- a/src/components/buyer/BuyerProfileForm.tsx
+++ b/src/components/buyer/BuyerProfileForm.tsx
@@ -1,28 +1,46 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button } from '@/components/ui/button'
+import { useT } from '@/i18n'
+import type { TranslationKeys } from '@/i18n'
 
-const profileSchema = z.object({
-  firstName: z.string().min(1, 'Nombre requerido').max(50),
-  lastName: z.string().min(1, 'Apellidos requeridos').max(50),
-  email: z.string().email('Email inválido'),
+const profileSchemaShape = z.object({
+  firstName: z.string().min(1).max(50),
+  lastName: z.string().min(1).max(50),
+  email: z.string().email(),
 })
 
-const passwordSchema = z.object({
-  currentPassword: z.string().min(1, 'Contraseña actual requerida'),
-  newPassword: z.string().min(8, 'Mínimo 8 caracteres'),
+const passwordSchemaShape = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string().min(8),
   confirmPassword: z.string(),
-}).refine(data => data.newPassword === data.confirmPassword, {
-  message: 'Las contraseñas no coinciden',
-  path: ['confirmPassword'],
 })
 
-type ProfileFormInput = z.infer<typeof profileSchema>
-type PasswordFormInput = z.infer<typeof passwordSchema>
+function buildSchemas(t: (key: TranslationKeys) => string) {
+  const profileSchema = z.object({
+    firstName: z.string().min(1, t('account.profileNameRequired')).max(50),
+    lastName: z.string().min(1, t('account.profileLastNameRequired')).max(50),
+    email: z.string().email(t('account.profileEmailInvalid')),
+  })
+
+  const passwordSchema = z.object({
+    currentPassword: z.string().min(1, t('account.profileCurrentPasswordRequired')),
+    newPassword: z.string().min(8, t('account.profileMin8')),
+    confirmPassword: z.string(),
+  }).refine(data => data.newPassword === data.confirmPassword, {
+    message: t('account.profilePasswordsDontMatch'),
+    path: ['confirmPassword'],
+  })
+
+  return { profileSchema, passwordSchema }
+}
+
+type ProfileFormInput = z.infer<typeof profileSchemaShape>
+type PasswordFormInput = z.infer<typeof passwordSchemaShape>
 
 interface Props {
   user: {
@@ -33,9 +51,12 @@ interface Props {
 }
 
 export function BuyerProfileForm({ user }: Props) {
+  const t = useT()
   const [profileSuccess, setProfileSuccess] = useState(false)
   const [passwordSuccess, setPasswordSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const { profileSchema, passwordSchema } = useMemo(() => buildSchemas(t), [t])
 
   const profileForm = useForm<ProfileFormInput>({
     resolver: zodResolver(profileSchema),
@@ -63,13 +84,13 @@ export function BuyerProfileForm({ user }: Props) {
 
       if (!res.ok) {
         const err = await res.json()
-        throw new Error(err.message || 'Error al actualizar perfil')
+        throw new Error(err.message || t('account.profileUpdateError'))
       }
 
       setProfileSuccess(true)
       setTimeout(() => setProfileSuccess(false), 3000)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error al actualizar perfil')
+      setError(err instanceof Error ? err.message : t('account.profileUpdateError'))
     }
   }
 
@@ -89,14 +110,14 @@ export function BuyerProfileForm({ user }: Props) {
 
       if (!res.ok) {
         const err = await res.json()
-        throw new Error(err.message || 'Error al cambiar contraseña')
+        throw new Error(err.message || t('account.profilePasswordError'))
       }
 
       setPasswordSuccess(true)
       passwordForm.reset()
       setTimeout(() => setPasswordSuccess(false), 3000)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error al cambiar contraseña')
+      setError(err instanceof Error ? err.message : t('account.profilePasswordError'))
     }
   }
 
@@ -110,12 +131,12 @@ export function BuyerProfileForm({ user }: Props) {
 
       {/* Profile Section */}
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
-        <h2 className="text-lg font-semibold text-[var(--foreground)] mb-4">Información personal</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)] mb-4">{t('account.profilePersonalInfo')}</h2>
 
         <form onSubmit={profileForm.handleSubmit(onProfileSubmit)} className="space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label className="block text-sm font-medium text-[var(--foreground)]">Nombre</label>
+              <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileNameLabel')}</label>
               <input
                 {...profileForm.register('firstName')}
                 className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
@@ -126,7 +147,7 @@ export function BuyerProfileForm({ user }: Props) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-[var(--foreground)]">Apellidos</label>
+              <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileLastNameLabel')}</label>
               <input
                 {...profileForm.register('lastName')}
                 className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
@@ -138,7 +159,7 @@ export function BuyerProfileForm({ user }: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--foreground)]">Email</label>
+            <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileEmailLabel')}</label>
             <input
               type="email"
               {...profileForm.register('email')}
@@ -151,11 +172,11 @@ export function BuyerProfileForm({ user }: Props) {
 
           <div className="flex gap-2 pt-4">
             <Button type="submit" disabled={profileForm.formState.isSubmitting}>
-              {profileForm.formState.isSubmitting ? 'Guardando...' : 'Guardar cambios'}
+              {profileForm.formState.isSubmitting ? t('account.profileSaving') : t('account.profileSaveChanges')}
             </Button>
             {profileSuccess && (
               <span className="inline-flex items-center text-sm text-emerald-600 dark:text-emerald-400">
-                ✓ Cambios guardados
+                {t('account.profileChangesSaved')}
               </span>
             )}
           </div>
@@ -164,11 +185,11 @@ export function BuyerProfileForm({ user }: Props) {
 
       {/* Password Section */}
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
-        <h2 className="text-lg font-semibold text-[var(--foreground)] mb-4">Cambiar contraseña</h2>
+        <h2 className="text-lg font-semibold text-[var(--foreground)] mb-4">{t('account.profileChangePassword')}</h2>
 
         <form onSubmit={passwordForm.handleSubmit(onPasswordSubmit)} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-[var(--foreground)]">Contraseña actual</label>
+            <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileCurrentPassword')}</label>
             <input
               type="password"
               {...passwordForm.register('currentPassword')}
@@ -180,7 +201,7 @@ export function BuyerProfileForm({ user }: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--foreground)]">Nueva contraseña</label>
+            <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileNewPassword')}</label>
             <input
               type="password"
               {...passwordForm.register('newPassword')}
@@ -192,7 +213,7 @@ export function BuyerProfileForm({ user }: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--foreground)]">Confirmar contraseña</label>
+            <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileConfirmPassword')}</label>
             <input
               type="password"
               {...passwordForm.register('confirmPassword')}
@@ -205,11 +226,11 @@ export function BuyerProfileForm({ user }: Props) {
 
           <div className="flex gap-2 pt-4">
             <Button type="submit" disabled={passwordForm.formState.isSubmitting}>
-              {passwordForm.formState.isSubmitting ? 'Cambiando...' : 'Cambiar contraseña'}
+              {passwordForm.formState.isSubmitting ? t('account.profileChanging') : t('account.profileChangePassword')}
             </Button>
             {passwordSuccess && (
               <span className="inline-flex items-center text-sm text-emerald-600 dark:text-emerald-400">
-                ✓ Contraseña actualizada
+                {t('account.profilePasswordUpdated')}
               </span>
             )}
           </div>

--- a/src/components/catalog/AutoTranslatedBadge.tsx
+++ b/src/components/catalog/AutoTranslatedBadge.tsx
@@ -5,13 +5,38 @@ import type { ProductTranslationMeta } from '@/i18n/catalog-copy'
 interface AutoTranslatedBadgeProps {
   translation?: ProductTranslationMeta | null
   className?: string
+  variant?: 'compact' | 'full'
 }
 
-export function AutoTranslatedBadge({ translation, className = '' }: AutoTranslatedBadgeProps) {
+export function AutoTranslatedBadge({
+  translation,
+  className = '',
+  variant = 'compact',
+}: AutoTranslatedBadgeProps) {
   if (!translation?.isAutoTranslated) return null
 
   const title = translation.badgeTitle || translation.badgeLabel
   const shortLabel = translation.sourceLocale?.toUpperCase() ?? ''
+
+  if (variant === 'full') {
+    return (
+      <Tooltip content={title} side="top">
+        <span
+          title={title}
+          aria-label={translation.badgeLabel}
+          className={[
+            'inline-flex max-w-full items-center gap-1.5 rounded-full border px-3 py-1',
+            'border-sky-200 bg-sky-50/90 text-xs font-semibold text-sky-700',
+            'dark:border-sky-900/50 dark:bg-sky-950/30 dark:text-sky-300',
+            className,
+          ].join(' ')}
+        >
+          <LanguageIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{translation.badgeLabel}</span>
+        </span>
+      </Tooltip>
+    )
+  }
 
   return (
     <Tooltip content={title} side="top">

--- a/src/components/catalog/AutoTranslatedBadge.tsx
+++ b/src/components/catalog/AutoTranslatedBadge.tsx
@@ -17,14 +17,14 @@ export function AutoTranslatedBadge({ translation, className = '' }: AutoTransla
       <span
         title={title}
         className={[
-          'inline-flex max-w-full items-center gap-1 rounded-full border px-2.5 py-1',
-          'border-sky-200 bg-sky-50/90 text-[10px] font-semibold text-sky-700',
+          'inline-flex max-w-full items-start gap-1 rounded-2xl border px-2.5 py-1',
+          'border-sky-200 bg-sky-50/90 text-[10px] font-semibold leading-tight text-sky-700',
           'dark:border-sky-900/50 dark:bg-sky-950/30 dark:text-sky-300',
           className,
         ].join(' ')}
       >
-        <LanguageIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span className="truncate">{translation.badgeLabel}</span>
+        <LanguageIcon className="mt-[1px] h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 break-words">{translation.badgeLabel}</span>
       </span>
     </Tooltip>
   )

--- a/src/components/catalog/AutoTranslatedBadge.tsx
+++ b/src/components/catalog/AutoTranslatedBadge.tsx
@@ -11,20 +11,22 @@ export function AutoTranslatedBadge({ translation, className = '' }: AutoTransla
   if (!translation?.isAutoTranslated) return null
 
   const title = translation.badgeTitle || translation.badgeLabel
+  const shortLabel = translation.sourceLocale?.toUpperCase() ?? ''
 
   return (
     <Tooltip content={title} side="top">
       <span
         title={title}
+        aria-label={translation.badgeLabel}
         className={[
-          'inline-flex max-w-full items-start gap-1 rounded-2xl border px-2.5 py-1',
-          'border-sky-200 bg-sky-50/90 text-[10px] font-semibold leading-tight text-sky-700',
+          'inline-flex items-center gap-1 rounded-full border px-2 py-0.5',
+          'border-sky-200 bg-sky-50/90 text-[10px] font-semibold text-sky-700',
           'dark:border-sky-900/50 dark:bg-sky-950/30 dark:text-sky-300',
           className,
         ].join(' ')}
       >
-        <LanguageIcon className="mt-[1px] h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span className="min-w-0 break-words">{translation.badgeLabel}</span>
+        <LanguageIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+        <span>{shortLabel}</span>
       </span>
     </Tooltip>
   )

--- a/src/i18n/legal-page-copy.ts
+++ b/src/i18n/legal-page-copy.ts
@@ -66,8 +66,101 @@ type PrivacyCopy = {
   }
 }
 
+type LegalNoticeCopy = {
+  metadataTitle: string
+  metadataDescription: string
+  eyebrow: string
+  updatedAtLabel: string
+  title: string
+  updatedAt: string
+  intro: string
+  sections: {
+    ownership: {
+      title: string
+      bodyPrefix: string
+      contactLink: string
+      bodySuffix: string
+    }
+    usage: {
+      title: string
+      items: string[]
+    }
+    ip: {
+      title: string
+      body: string
+    }
+    liability: {
+      title: string
+      body: string
+    }
+  }
+}
+
+type CookiesCopy = {
+  metadataTitle: string
+  metadataDescription: string
+  eyebrow: string
+  updatedAtLabel: string
+  title: string
+  updatedAt: string
+  intro: string
+  sections: {
+    what: {
+      title: string
+      body: string
+    }
+    types: {
+      title: string
+      items: LabeledItem[]
+    }
+    consent: {
+      title: string
+      body: string
+    }
+    disable: {
+      title: string
+      body: string
+    }
+  }
+}
+
+type TermsCopy = {
+  metadataTitle: string
+  metadataDescription: string
+  eyebrow: string
+  updatedAtLabel: string
+  title: string
+  updatedAt: string
+  intro: string
+  sections: {
+    accounts: {
+      title: string
+      body: string
+    }
+    purchases: {
+      title: string
+      body: string
+    }
+    shipping: {
+      title: string
+      body: string
+    }
+    acceptable: {
+      title: string
+      items: string[]
+    }
+    changes: {
+      title: string
+      body: string
+    }
+  }
+}
+
 type LegalPageCopy = {
   privacy: PrivacyCopy
+  legalNotice: LegalNoticeCopy
+  cookies: CookiesCopy
+  terms: TermsCopy
 }
 
 const legalPageCopy: Record<Locale, LegalPageCopy> = {
@@ -170,6 +263,105 @@ const legalPageCopy: Record<Locale, LegalPageCopy> = {
         legalNote: 'Esta política está diseñada para cumplir con RGPD (UE), LOPDGDD (España) y otras regulaciones aplicables de protección de datos.',
       },
     },
+    legalNotice: {
+      metadataTitle: 'Aviso legal',
+      metadataDescription: `Aviso legal y condiciones de uso de ${SITE_NAME}.`,
+      eyebrow: 'Información legal',
+      updatedAtLabel: 'Última revisión',
+      title: 'Aviso legal',
+      updatedAt: '11 de abril de 2026',
+      intro: `Este aviso legal regula el acceso y uso del sitio de ${SITE_NAME}, así como las responsabilidades generales de la plataforma y de las personas usuarias.`,
+      sections: {
+        ownership: {
+          title: '1. Titularidad del sitio',
+          bodyPrefix: `${SITE_NAME} opera como un marketplace que conecta productores, compradores y equipos operativos. La información de contacto para soporte y consultas está disponible en la página de`,
+          contactLink: 'contacto',
+          bodySuffix: '.',
+        },
+        usage: {
+          title: '2. Condiciones de uso',
+          items: [
+            'No se permite usar la plataforma para actividades ilícitas o fraudulentas.',
+            'Las personas usuarias deben proporcionar información veraz y mantener sus credenciales seguras.',
+            'El acceso a áreas privadas puede requerir registro y autenticación.',
+          ],
+        },
+        ip: {
+          title: '3. Propiedad intelectual',
+          body: 'Los contenidos de marca, diseño, textos y estructura del sitio están protegidos por la normativa aplicable de propiedad intelectual e industrial. Los contenidos aportados por vendedores o terceros siguen siendo de su titularidad, salvo que se indique lo contrario.',
+        },
+        liability: {
+          title: '4. Responsabilidad',
+          body: 'La plataforma actúa como intermediaria técnica entre compradores y vendedores. Cada parte es responsable de cumplir sus obligaciones legales, comerciales y fiscales en el marco de sus operaciones.',
+        },
+      },
+    },
+    cookies: {
+      metadataTitle: 'Política de cookies',
+      metadataDescription: `Información sobre el uso de cookies en ${SITE_NAME}.`,
+      eyebrow: 'Información legal',
+      updatedAtLabel: 'Última revisión',
+      title: 'Política de cookies',
+      updatedAt: '11 de abril de 2026',
+      intro: `Esta política explica qué tipos de cookies puede usar ${SITE_NAME} y para qué se emplean.`,
+      sections: {
+        what: {
+          title: '1. Qué son las cookies',
+          body: 'Las cookies son pequeños archivos que el navegador almacena para recordar preferencias, mantener la sesión y mejorar el funcionamiento del sitio.',
+        },
+        types: {
+          title: '2. Tipos de cookies que usamos',
+          items: [
+            { label: 'Técnicas', text: 'necesarias para iniciar sesión, mantener el carrito y proteger formularios.' },
+            { label: 'Preferencias', text: 'recuerdan idioma, tema visual y otras opciones de experiencia.' },
+            { label: 'Analíticas', text: 'se usan para medir el uso del sitio cuando están habilitadas en la configuración de la plataforma.' },
+          ],
+        },
+        consent: {
+          title: '3. Gestión del consentimiento',
+          body: 'Cuando el sitio active cookies no esenciales, el consentimiento deberá gestionarse de forma clara antes de su uso. También puedes bloquear o eliminar cookies desde la configuración de tu navegador.',
+        },
+        disable: {
+          title: '4. Cómo desactivarlas',
+          body: 'Puedes restringir, bloquear o eliminar cookies desde las preferencias de tu navegador. Ten en cuenta que deshabilitar cookies técnicas puede afectar al inicio de sesión y al carrito.',
+        },
+      },
+    },
+    terms: {
+      metadataTitle: 'Términos de uso',
+      metadataDescription: `Términos y condiciones de uso de ${SITE_NAME}.`,
+      eyebrow: 'Información legal',
+      updatedAtLabel: 'Última revisión',
+      title: 'Términos de uso',
+      updatedAt: '11 de abril de 2026',
+      intro: `Estos términos describen cómo se usa ${SITE_NAME}, qué obligaciones tiene cada parte y cómo se gestiona la compra en la plataforma.`,
+      sections: {
+        accounts: {
+          title: '1. Registro y cuentas',
+          body: 'Cuando una funcionalidad requiera cuenta, la persona usuaria debe aportar datos veraces, mantener su contraseña segura y avisar de cualquier uso no autorizado de su cuenta.',
+        },
+        purchases: {
+          title: '2. Compras y disponibilidad',
+          body: 'Los pedidos están sujetos a disponibilidad de stock, validación de pago y condiciones logísticas. Los precios y promociones pueden actualizarse antes de completar la compra.',
+        },
+        shipping: {
+          title: '3. Envíos y devoluciones',
+          body: 'Las condiciones de envío, plazos y posibles devoluciones se muestran en el proceso de compra y pueden variar según la zona o el producto.',
+        },
+        acceptable: {
+          title: '4. Uso aceptable',
+          items: [
+            'No se permite el uso automatizado abusivo ni la manipulación de precios o pedidos.',
+            'Está prohibida la publicación de contenido engañoso, ilícito o que infrinja derechos de terceros.',
+            'La plataforma puede restringir accesos si detecta uso indebido o riesgo para la operación.',
+          ],
+        },
+        changes: {
+          title: '5. Cambios en los términos',
+          body: `${SITE_NAME} puede actualizar estos términos cuando cambien la operación, la normativa o la propia plataforma. La versión vigente será la publicada en esta página.`,
+        },
+      },
+    },
   },
   en: {
     privacy: {
@@ -268,6 +460,105 @@ const legalPageCopy: Record<Locale, LegalPageCopy> = {
           accountNote: 'You can also review your data from the privacy section of your account.',
         },
         legalNote: 'This policy is intended to comply with the GDPR (EU), the Spanish LOPDGDD, and other applicable data protection regulations.',
+      },
+    },
+    legalNotice: {
+      metadataTitle: 'Legal Notice',
+      metadataDescription: `Legal notice and terms of use for ${SITE_NAME}.`,
+      eyebrow: 'Legal information',
+      updatedAtLabel: 'Last updated',
+      title: 'Legal Notice',
+      updatedAt: 'April 11, 2026',
+      intro: `This legal notice governs access to and use of the ${SITE_NAME} site, as well as the general responsibilities of the platform and its users.`,
+      sections: {
+        ownership: {
+          title: '1. Site ownership',
+          bodyPrefix: `${SITE_NAME} operates as a marketplace that connects producers, buyers, and operations teams. Contact information for support and inquiries is available on the`,
+          contactLink: 'contact page',
+          bodySuffix: '.',
+        },
+        usage: {
+          title: '2. Terms of use',
+          items: [
+            'The platform may not be used for unlawful or fraudulent activities.',
+            'Users must provide accurate information and keep their credentials secure.',
+            'Access to private areas may require registration and authentication.',
+          ],
+        },
+        ip: {
+          title: '3. Intellectual property',
+          body: 'Brand assets, design, copy, and site structure are protected by applicable intellectual and industrial property regulations. Content contributed by sellers or third parties remains the property of its respective owners unless stated otherwise.',
+        },
+        liability: {
+          title: '4. Liability',
+          body: 'The platform acts as a technical intermediary between buyers and sellers. Each party is responsible for meeting its own legal, commercial, and tax obligations in connection with its operations.',
+        },
+      },
+    },
+    cookies: {
+      metadataTitle: 'Cookie policy',
+      metadataDescription: `Information about how ${SITE_NAME} uses cookies.`,
+      eyebrow: 'Legal information',
+      updatedAtLabel: 'Last updated',
+      title: 'Cookie policy',
+      updatedAt: 'April 11, 2026',
+      intro: `This policy explains the types of cookies ${SITE_NAME} may use and what they are used for.`,
+      sections: {
+        what: {
+          title: '1. What cookies are',
+          body: 'Cookies are small files that the browser stores to remember preferences, keep your session active, and improve how the site works.',
+        },
+        types: {
+          title: '2. Types of cookies we use',
+          items: [
+            { label: 'Essential', text: 'required to sign in, keep the cart, and protect forms.' },
+            { label: 'Preferences', text: 'remember language, theme, and other experience options.' },
+            { label: 'Analytics', text: 'used to measure site usage when enabled in the platform configuration.' },
+          ],
+        },
+        consent: {
+          title: '3. Consent management',
+          body: 'When the site enables non-essential cookies, consent must be managed clearly before they are used. You can also block or delete cookies from your browser settings.',
+        },
+        disable: {
+          title: '4. How to disable them',
+          body: 'You can restrict, block, or delete cookies from your browser preferences. Note that disabling essential cookies may affect sign-in and the cart.',
+        },
+      },
+    },
+    terms: {
+      metadataTitle: 'Terms of use',
+      metadataDescription: `Terms and conditions of use for ${SITE_NAME}.`,
+      eyebrow: 'Legal information',
+      updatedAtLabel: 'Last updated',
+      title: 'Terms of use',
+      updatedAt: 'April 11, 2026',
+      intro: `These terms describe how ${SITE_NAME} is used, the obligations of each party, and how purchases are handled on the platform.`,
+      sections: {
+        accounts: {
+          title: '1. Registration and accounts',
+          body: 'When a feature requires an account, users must provide accurate information, keep their password secure, and report any unauthorized use of their account.',
+        },
+        purchases: {
+          title: '2. Purchases and availability',
+          body: 'Orders are subject to stock availability, payment validation, and logistics conditions. Prices and promotions may be updated before checkout is completed.',
+        },
+        shipping: {
+          title: '3. Shipping and returns',
+          body: 'Shipping conditions, lead times, and possible returns are shown during checkout and may vary by zone or product.',
+        },
+        acceptable: {
+          title: '4. Acceptable use',
+          items: [
+            'Abusive automated use and manipulation of prices or orders are not allowed.',
+            'Publishing misleading or unlawful content, or content that infringes third-party rights, is prohibited.',
+            'The platform may restrict access if it detects misuse or risk to operations.',
+          ],
+        },
+        changes: {
+          title: '5. Changes to these terms',
+          body: `${SITE_NAME} may update these terms when operations, regulations, or the platform itself change. The version published on this page is the one in force.`,
+        },
       },
     },
   },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -71,6 +71,9 @@ const en: Record<TranslationKeys, string> = {
   aboutUs: 'About Us',
   allRights: 'All rights reserved.',
   legal: 'Legal Notice',
+  privacy: 'Privacy',
+  cookies: 'Cookies',
+  terms: 'Terms',
 
   /* Language switcher */
   language: 'Language',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -339,6 +339,47 @@ const en: Record<TranslationKeys, string> = {
   'account.edit': 'Edit',
   'account.delete': 'Delete',
 
+  // Account – orders page
+  'account.ordersTitle': 'My orders',
+  'account.ordersSubtitle': 'Reorder a previous purchase in one click or open the details to review an order.',
+  'account.ordersEmpty': 'You don\'t have any orders yet',
+  'account.ordersExplore': 'Browse products',
+  'account.ordersViewDetail': 'View details',
+  'account.ordersItem': 'item',
+  'account.ordersItems': 'items',
+  'account.ordersProduct': 'product',
+  'account.ordersProducts': 'products',
+  'account.ordersMore': 'more',
+
+  // Account – profile page
+  'account.profileTitle': 'My profile',
+  'account.profileSubtitle': 'Manage your personal information and password',
+  'account.profilePersonalInfo': 'Personal information',
+  'account.profileNameLabel': 'First name',
+  'account.profileLastNameLabel': 'Last name',
+  'account.profileEmailLabel': 'Email',
+  'account.profileSaving': 'Saving...',
+  'account.profileSaveChanges': 'Save changes',
+  'account.profileChangesSaved': '✓ Changes saved',
+  'account.profileChangePassword': 'Change password',
+  'account.profileCurrentPassword': 'Current password',
+  'account.profileNewPassword': 'New password',
+  'account.profileConfirmPassword': 'Confirm password',
+  'account.profileChanging': 'Changing...',
+  'account.profilePasswordUpdated': '✓ Password updated',
+  'account.profileNameRequired': 'First name required',
+  'account.profileLastNameRequired': 'Last name required',
+  'account.profileEmailInvalid': 'Invalid email',
+  'account.profileCurrentPasswordRequired': 'Current password required',
+  'account.profileMin8': 'Minimum 8 characters',
+  'account.profilePasswordsDontMatch': 'Passwords do not match',
+  'account.profileUpdateError': 'Error updating profile',
+  'account.profilePasswordError': 'Error changing password',
+
+  // Account – addresses page header
+  'account.addressesTitle': 'My addresses',
+  'account.addressesSubtitle': 'Manage your shipping addresses',
+
   // Common
   'common.cancel': 'Cancel',
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -337,6 +337,47 @@ const es = {
   'account.edit': 'Editar',
   'account.delete': 'Eliminar',
 
+  // Account – orders page
+  'account.ordersTitle': 'Mis pedidos',
+  'account.ordersSubtitle': 'Repite compras anteriores en un clic o entra al detalle para revisar el pedido.',
+  'account.ordersEmpty': 'Aún no tienes pedidos',
+  'account.ordersExplore': 'Explorar productos',
+  'account.ordersViewDetail': 'Ver detalle',
+  'account.ordersItem': 'artículo',
+  'account.ordersItems': 'artículos',
+  'account.ordersProduct': 'producto',
+  'account.ordersProducts': 'productos',
+  'account.ordersMore': 'más',
+
+  // Account – profile page
+  'account.profileTitle': 'Mi perfil',
+  'account.profileSubtitle': 'Gestiona tu información personal y contraseña',
+  'account.profilePersonalInfo': 'Información personal',
+  'account.profileNameLabel': 'Nombre',
+  'account.profileLastNameLabel': 'Apellidos',
+  'account.profileEmailLabel': 'Email',
+  'account.profileSaving': 'Guardando...',
+  'account.profileSaveChanges': 'Guardar cambios',
+  'account.profileChangesSaved': '✓ Cambios guardados',
+  'account.profileChangePassword': 'Cambiar contraseña',
+  'account.profileCurrentPassword': 'Contraseña actual',
+  'account.profileNewPassword': 'Nueva contraseña',
+  'account.profileConfirmPassword': 'Confirmar contraseña',
+  'account.profileChanging': 'Cambiando...',
+  'account.profilePasswordUpdated': '✓ Contraseña actualizada',
+  'account.profileNameRequired': 'Nombre requerido',
+  'account.profileLastNameRequired': 'Apellidos requeridos',
+  'account.profileEmailInvalid': 'Email inválido',
+  'account.profileCurrentPasswordRequired': 'Contraseña actual requerida',
+  'account.profileMin8': 'Mínimo 8 caracteres',
+  'account.profilePasswordsDontMatch': 'Las contraseñas no coinciden',
+  'account.profileUpdateError': 'Error al actualizar perfil',
+  'account.profilePasswordError': 'Error al cambiar contraseña',
+
+  // Account – addresses page header
+  'account.addressesTitle': 'Mis direcciones',
+  'account.addressesSubtitle': 'Gestiona tus direcciones de envío',
+
   // Common
   'common.cancel': 'Cancelar',
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -69,6 +69,9 @@ const es = {
   aboutUs: 'Sobre nosotros',
   allRights: 'Todos los derechos reservados.',
   legal: 'Aviso legal',
+  privacy: 'Privacidad',
+  cookies: 'Cookies',
+  terms: 'Términos',
 
   /* Language switcher */
   language: 'Idioma',

--- a/test/i18n-parity.test.ts
+++ b/test/i18n-parity.test.ts
@@ -23,10 +23,12 @@ const enKeys = Object.keys(enMap).sort()
 const INTENTIONAL_COPY_KEYS = new Set<string>([
   // Words that are internationally identical or brand-style labels.
   'account.cityPlaceholder',      // city name placeholder (e.g. "Madrid")
+  'account.profileEmailLabel',    // "Email" is the same word in both locales
   'auth.recoveryEmail',           // "recovery@example.com" placeholder
   'cart.subtotal',                // "Subtotal" is the same word in both locales
   'cart.total',                   // "Total" is the same word in both locales
   'checkout.postalCodePlaceholder', // numeric example (e.g. "28001")
+  'cookies',                      // "Cookies" is the same word in both locales (footer link)
   'km0',                          // brand/label for "zero-kilometer" products
   'lang_en',                      // language name shown in its own language
   'lang_es',                      // language name shown in its own language

--- a/test/legal-pages.test.ts
+++ b/test/legal-pages.test.ts
@@ -20,8 +20,9 @@ test('footer links to the legal pages that now exist', () => {
 
   for (const path of legalPages) {
     const source = readSource(path)
-    assert.match(source, /export const metadata: Metadata/)
+    assert.match(source, /generateMetadata\(\): Promise<Metadata>/)
     assert.match(source, /LegalPage/)
+    assert.match(source, /getLegalPageCopy/)
   }
 })
 

--- a/test/orders-list-enhancements.test.ts
+++ b/test/orders-list-enhancements.test.ts
@@ -24,8 +24,9 @@ test('orders list page shows item count summary with total articles and products
 
   assert.match(source, /totalItems/)
   assert.match(source, /productCount/)
-  assert.match(source, /artículo/)
-  assert.match(source, /producto/)
+  // Labels come from i18n now, so assert on the translation keys rather than literals.
+  assert.match(source, /account\.ordersItem/)
+  assert.match(source, /account\.ordersProduct/)
 })
 
 test('orders list page displays payment status badge', () => {

--- a/test/public-pages-i18n.test.ts
+++ b/test/public-pages-i18n.test.ts
@@ -68,6 +68,98 @@ test('account GDPR keys are translated differently in Spanish and English', asyn
   assert.notEqual(locales.es['account.gdpr.desc'], locales.en['account.gdpr.desc'])
 })
 
+test('buyer account pages (orders, profile, addresses) i18n keys exist in both locales', async () => {
+  const { locales } = await import('@/i18n/locales')
+  const accountKeys = [
+    'account.ordersTitle',
+    'account.ordersSubtitle',
+    'account.ordersEmpty',
+    'account.ordersExplore',
+    'account.ordersViewDetail',
+    'account.ordersItem',
+    'account.ordersItems',
+    'account.ordersProduct',
+    'account.ordersProducts',
+    'account.ordersMore',
+    'account.profileTitle',
+    'account.profileSubtitle',
+    'account.profilePersonalInfo',
+    'account.profileNameLabel',
+    'account.profileLastNameLabel',
+    'account.profileEmailLabel',
+    'account.profileSaving',
+    'account.profileSaveChanges',
+    'account.profileChangesSaved',
+    'account.profileChangePassword',
+    'account.profileCurrentPassword',
+    'account.profileNewPassword',
+    'account.profileConfirmPassword',
+    'account.profileChanging',
+    'account.profilePasswordUpdated',
+    'account.profileNameRequired',
+    'account.profileLastNameRequired',
+    'account.profileEmailInvalid',
+    'account.profileCurrentPasswordRequired',
+    'account.profileMin8',
+    'account.profilePasswordsDontMatch',
+    'account.profileUpdateError',
+    'account.profilePasswordError',
+    'account.addressesTitle',
+    'account.addressesSubtitle',
+  ] as const
+
+  for (const key of accountKeys) {
+    assert.ok(key in locales.es, `Spanish locale missing key: ${key}`)
+    assert.ok(key in locales.en, `English locale missing key: ${key}`)
+    assert.ok((locales.es as Record<string, string>)[key].length > 0, `Spanish value empty for: ${key}`)
+    assert.ok((locales.en as Record<string, string>)[key].length > 0, `English value empty for: ${key}`)
+  }
+})
+
+test('buyer account translations differ between Spanish and English for human-readable copy', async () => {
+  const { locales } = await import('@/i18n/locales')
+  const compareKeys = [
+    'account.ordersTitle',
+    'account.ordersSubtitle',
+    'account.ordersEmpty',
+    'account.ordersExplore',
+    'account.profileTitle',
+    'account.profileSubtitle',
+    'account.profilePersonalInfo',
+    'account.profileChangePassword',
+    'account.addressesTitle',
+    'account.addressesSubtitle',
+  ] as const
+
+  for (const key of compareKeys) {
+    assert.notEqual(
+      (locales.es as Record<string, string>)[key],
+      (locales.en as Record<string, string>)[key],
+      `Expected ${key} to differ between locales`,
+    )
+  }
+})
+
+test('buyer account server pages and profile form consume i18n', () => {
+  const ordersPage = readFileSync(resolve(process.cwd(), 'src/app/(buyer)/cuenta/pedidos/page.tsx'), 'utf8')
+  const profilePage = readFileSync(resolve(process.cwd(), 'src/app/(buyer)/cuenta/perfil/page.tsx'), 'utf8')
+  const addressesPage = readFileSync(resolve(process.cwd(), 'src/app/(buyer)/cuenta/direcciones/page.tsx'), 'utf8')
+  const profileForm = readFileSync(resolve(process.cwd(), 'src/components/buyer/BuyerProfileForm.tsx'), 'utf8')
+
+  for (const src of [ordersPage, profilePage, addressesPage]) {
+    assert.match(src, /getServerT/, 'server page should call getServerT')
+    assert.match(src, /generateMetadata\(\): Promise<Metadata>/, 'server page should localize metadata via generateMetadata')
+  }
+
+  assert.doesNotMatch(ordersPage, />Mis pedidos</)
+  assert.doesNotMatch(profilePage, />Mi perfil</)
+  assert.doesNotMatch(addressesPage, />Mis direcciones</)
+
+  assert.match(profileForm, /useT/)
+  assert.match(profileForm, /account\.profilePersonalInfo/)
+  assert.doesNotMatch(profileForm, />Información personal</)
+})
+
 test('LanguageSwitcher displays the target language rather than the current one', () => {
   const src = readFileSync(
     resolve(process.cwd(), 'src/components/LanguageSwitcher.tsx'),

--- a/test/public-pages-i18n.test.ts
+++ b/test/public-pages-i18n.test.ts
@@ -27,6 +27,34 @@ test('legal privacy page exposes English copy', () => {
   assert.equal(en.sections.contact.contactLink, 'contact form')
 })
 
+test('legal notice, cookies and terms pages expose copy in both locales', () => {
+  const es = getLegalPageCopy('es')
+  const en = getLegalPageCopy('en')
+
+  assert.equal(es.legalNotice.title, 'Aviso legal')
+  assert.equal(en.legalNotice.title, 'Legal Notice')
+  assert.notEqual(es.legalNotice.intro, en.legalNotice.intro)
+  assert.equal(es.legalNotice.sections.usage.items.length, en.legalNotice.sections.usage.items.length)
+
+  assert.equal(es.cookies.title, 'Política de cookies')
+  assert.equal(en.cookies.title, 'Cookie policy')
+  assert.notEqual(es.cookies.intro, en.cookies.intro)
+  assert.equal(es.cookies.sections.types.items.length, en.cookies.sections.types.items.length)
+
+  assert.equal(es.terms.title, 'Términos de uso')
+  assert.equal(en.terms.title, 'Terms of use')
+  assert.notEqual(es.terms.intro, en.terms.intro)
+  assert.equal(es.terms.sections.acceptable.items.length, en.terms.sections.acceptable.items.length)
+})
+
+test('footer legal keys (privacy, cookies, terms) exist in both locales', async () => {
+  const { locales } = await import('@/i18n/locales')
+  for (const key of ['privacy', 'cookies', 'terms'] as const) {
+    assert.ok(key in locales.es, `Spanish missing ${key}`)
+    assert.ok(key in locales.en, `English missing ${key}`)
+  }
+})
+
 test('Spanish copy remains the default fallback for public pages', () => {
   const es = getPublicPageCopy('es')
 


### PR DESCRIPTION
## Summary

- **i18n: buyer account pages** — translate `/cuenta/pedidos`, `/cuenta/perfil`, `/cuenta/direcciones` and `BuyerProfileForm`, add ~35 `account.*` keys in ES/EN, localise metadata via `generateMetadata` + `getServerT`, move Zod schemas into a `useMemo` so validation messages localise.
- **i18n: legal pages** — translate `/aviso-legal`, `/cookies`, `/terminos` via `getLegalPageCopy` with new `LegalNoticeCopy` / `CookiesCopy` / `TermsCopy` types, and add the missing footer keys (`privacy`, `cookies`, `terms`).
- **Home mobile polish** — compact horizontal-card layout for "Cómo funciona" steps on mobile so the section no longer looks sparse; `sm+` keeps the original 4-column layout with the connector line.
- **Catalog auto-translated badge** — compact icon + source-locale (`ES` / `EN`) in list cards (full text in tooltip + `aria-label`), new `variant="full"` used on the product detail page so the complete "Auto-translated from Spanish" label is shown where it appears only once.

## Test plan

- [ ] `/productos` in EN: each product card shows tiny `🌐 ES` pill, hover shows full tooltip
- [ ] `/productos/<slug>` in EN: full `🌐 Auto-translated from Spanish` badge visible
- [ ] `/cuenta/pedidos`, `/cuenta/perfil`, `/cuenta/direcciones` translate when switching locale
- [ ] `/aviso-legal`, `/cookies`, `/terminos` translate when switching locale; footer legal links translate too
- [ ] Home on mobile: "Cómo funciona" steps render as compact cards (badge left, text right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)