### PR TITLE
fix(mobile-drawer): clearer locale switcher, tidier auth/settings block

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -5,45 +5,58 @@ import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import type { Locale } from '@/i18n/locales'
 
-const FLAGS: Record<Locale, string> = {
-  es: '🇪🇸',
-  en: '🇬🇧',
-}
+const LOCALES: ReadonlyArray<{ code: Locale; label: string; full: string }> = [
+  { code: 'es', label: 'ES', full: 'Español' },
+  { code: 'en', label: 'EN', full: 'English' },
+]
 
-const LABELS: Record<Locale, string> = {
-  es: 'ES',
-  en: 'EN',
-}
-
+/**
+ * Segmented two-option toggle so the current locale and the alternative
+ * are both visible — the previous single-button "next locale" design
+ * was ambiguous (clicking `EN` read as "switch to English" to some users
+ * and "you are in English" to others, and the flag emoji fell back to
+ * plain `ES` letters on some Android builds producing a spooky `ES ES`).
+ */
 export function LanguageSwitcher({ className }: { className?: string }) {
   const router = useRouter()
   const { locale, setLocale } = useI18n()
 
-  const next: Locale = locale === 'es' ? 'en' : 'es'
-  const switchLabel =
-    locale === 'es'
-      ? `Cambiar idioma a ${next === 'en' ? 'English' : 'Español'}`
-      : `Switch language to ${next === 'en' ? 'English' : 'Español'}`
+  function handleSelect(next: Locale) {
+    if (next === locale) return
+    setLocale(next)
+    router.refresh()
+  }
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        setLocale(next)
-        router.refresh()
-      }}
-      title={switchLabel}
-      aria-label={switchLabel}
+    <div
+      role="group"
+      aria-label={locale === 'es' ? 'Seleccionar idioma' : 'Select language'}
       className={cn(
-        'flex h-9 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-[var(--muted)]',
-        'hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
-        'border border-transparent hover:border-[var(--border)] focus-visible:border-[var(--border)]',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]',
+        'inline-flex items-center gap-0.5 rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] p-0.5',
         className
       )}
     >
-      <span aria-hidden="true">{FLAGS[next]}</span>
-      <span>{LABELS[next]}</span>
-    </button>
+      {LOCALES.map(({ code, label, full }) => {
+        const active = code === locale
+        return (
+          <button
+            key={code}
+            type="button"
+            onClick={() => handleSelect(code)}
+            aria-pressed={active}
+            title={full}
+            className={cn(
+              'rounded-md px-2.5 py-1 text-xs font-semibold transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30',
+              active
+                ? 'bg-emerald-600 text-white dark:bg-emerald-500 dark:text-gray-950'
+                : 'text-[var(--muted)] hover:text-[var(--foreground)]'
+            )}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
   )
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -324,29 +324,29 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
                 </div>
               </>
             ) : (
-              <div className="space-y-2 pt-1">
-                <Link
-                  href="/login?callbackUrl=%2Fvendor%2Fdashboard"
-                  className="block rounded-xl border border-[var(--border)] px-4 py-2.5 text-center text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
-                >
-                  {t('producerPortal')}
+              <div className="flex gap-2 pt-1">
+                <Link href="/login" onClick={() => setMobileOpen(false)} className="flex-1 rounded-xl border border-[var(--border)] px-4 py-2.5 text-center text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  {t('signIn')}
                 </Link>
-                <div className="flex gap-2">
-                  <Link href="/login" className="flex-1 rounded-xl border border-[var(--border)] px-4 py-2.5 text-center text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
-                    {t('signIn')}
-                  </Link>
-                  <Link href="/register" className="flex-1 rounded-xl bg-emerald-600 px-4 py-2.5 text-center text-sm font-semibold text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
-                    {t('register')}
-                  </Link>
-                </div>
+                <Link href="/register" onClick={() => setMobileOpen(false)} className="flex-1 rounded-xl bg-emerald-600 px-4 py-2.5 text-center text-sm font-semibold text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  {t('register')}
+                </Link>
               </div>
             )}
 
-            {/* Language toggle in mobile menu */}
+            {/* Footer settings row: language + producer portal link */}
             <div className="mx-0 my-2 border-t border-[var(--border)] sm:hidden" />
-            <div className="flex items-center justify-between px-1 pt-1 sm:hidden">
-              <span className="text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">{t('language')}</span>
+            <div className="flex items-center justify-between gap-3 px-1 pt-1 sm:hidden">
               <LanguageToggle />
+              {!user && (
+                <Link
+                  href="/login?callbackUrl=%2Fvendor%2Fdashboard"
+                  onClick={() => setMobileOpen(false)}
+                  className="text-xs font-medium text-[var(--muted)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 rounded"
+                >
+                  {t('producerPortal')}
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -50,7 +50,7 @@ const en: Record<TranslationKeys, string> = {
   searchMobile: 'Search...',
   myAccount: 'My Account',
   myOrders: 'My Orders',
-  signIn: 'Sign In',
+  signIn: 'Sign in',
   market_local: 'Local market',
   admin_panel: 'Admin panel',
   vendor_panel: 'Producer panel',

--- a/test/public-pages-i18n.test.ts
+++ b/test/public-pages-i18n.test.ts
@@ -188,15 +188,16 @@ test('buyer account server pages and profile form consume i18n', () => {
   assert.doesNotMatch(profileForm, />Información personal</)
 })
 
-test('LanguageSwitcher displays the target language rather than the current one', () => {
+test('LanguageSwitcher is a segmented two-option toggle with the current locale highlighted', () => {
   const src = readFileSync(
     resolve(process.cwd(), 'src/components/LanguageSwitcher.tsx'),
     'utf8'
   )
-  // The button labels must show [next] (target locale) so users see what they will switch TO
-  assert.match(src, /FLAGS\[next\]/, 'Button flag should show the target language flag')
-  assert.match(src, /LABELS\[next\]/, 'Button label should show the target language label')
-  // Must NOT display the current locale as the button text
-  assert.doesNotMatch(src, />\s*\{FLAGS\[locale\]\}/, 'Button must not show current locale flag as its label')
-  assert.doesNotMatch(src, />\s*\{LABELS\[locale\]\}/, 'Button must not show current locale label as its text')
+  // Must render both locale buttons (segmented control) so the state is unambiguous
+  assert.match(src, /code:\s*'es'/, 'Must enumerate the es locale')
+  assert.match(src, /code:\s*'en'/, 'Must enumerate the en locale')
+  // Active state must be driven by comparing each option to the current locale
+  assert.match(src, /code === locale/, 'Must compare each button against the current locale')
+  // aria-pressed communicates the active segment to screen readers
+  assert.match(src, /aria-pressed/, 'Active segment must expose aria-pressed')
 })


### PR DESCRIPTION
Three small UX fixes on the mobile drawer.

## Summary

1. **Segmented `ES | EN` language switcher** — the previous "show the target locale" button was ambiguous (both "current state" and "action" readings) and rendered visually as `ES ES` on devices that fall back from the Union Jack emoji to plain letters. The new design always shows both options with the active one highlighted (`aria-pressed=true`), so the state is unambiguous regardless of emoji rendering.

2. **`Sign In` → `Sign in`** in `en.ts` so capitalization matches the sentence-case "Sign up" sibling.

3. **Producer Portal demoted** from a full-width primary button in the anonymous auth block to a small text link in the bottom settings row next to the language switcher. On a buyer-first menu it was eating prime space above the fold for what is effectively a secondary entry point, and the Sign in / Sign up row is now the only call-to-action in the auth block.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 466/466 pass (updated the source-level LanguageSwitcher test to match the segmented design)
- [ ] Manual: open the mobile drawer on a real device, toggle ES/EN, confirm the active segment highlights and the text no longer reads "ES ES"

🤖 Generated with [Claude Code](https://claude.com/claude-code)