### PR TITLE
wip(vendor): inline quick-fix actions for problem products

### DIFF
--- a/src/components/vendor/ProductQuickFix.tsx
+++ b/src/components/vendor/ProductQuickFix.tsx
@@ -1,0 +1,207 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import {
+  ArrowPathIcon,
+  CalendarDaysIcon,
+  CubeIcon,
+  PaperAirplaneIcon,
+  PencilSquareIcon,
+} from '@heroicons/react/24/outline'
+import { updateProduct, submitForReview } from '@/domains/vendors/actions'
+import { Button } from '@/components/ui/button'
+import { useT } from '@/i18n'
+
+export type ProductProblem =
+  | 'rejected'
+  | 'expired'
+  | 'out-of-stock'
+  | 'low-stock'
+  | 'draft'
+  | null
+
+interface Props {
+  product: {
+    id: string
+    status: string
+    stock: number
+    trackStock: boolean
+    expiresAt?: Date | string | null
+  }
+  problem: ProductProblem
+}
+
+export function ProductQuickFix({ product, problem }: Props) {
+  const t = useT()
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [stockValue, setStockValue] = useState<string>(
+    String(product.stock > 0 ? product.stock : 10),
+  )
+  const [dateValue, setDateValue] = useState<string>(() => {
+    const d = new Date()
+    d.setDate(d.getDate() + 14)
+    return d.toISOString().slice(0, 10)
+  })
+
+  if (!problem) return null
+
+  function run(action: () => Promise<unknown>) {
+    setError(null)
+    startTransition(async () => {
+      try {
+        await action()
+        setOpen(false)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Error')
+      }
+    })
+  }
+
+  if (problem === 'rejected') {
+    return (
+      <Link
+        href={`/vendor/productos/${product.id}`}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400"
+      >
+        <PencilSquareIcon className="h-3.5 w-3.5" />
+        {t('vendor.fix.editAndResubmit')}
+      </Link>
+    )
+  }
+
+  if (problem === 'draft') {
+    return (
+      <button
+        type="button"
+        disabled={pending}
+        onClick={() => run(() => submitForReview(product.id))}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-50 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400"
+      >
+        {pending ? (
+          <ArrowPathIcon className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <PaperAirplaneIcon className="h-3.5 w-3.5" />
+        )}
+        {t('vendor.fix.submitForReview')}
+      </button>
+    )
+  }
+
+  if (problem === 'expired') {
+    return (
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen(v => !v)}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-amber-700 dark:bg-amber-500 dark:text-gray-950 dark:hover:bg-amber-400"
+        >
+          <CalendarDaysIcon className="h-3.5 w-3.5" />
+          {t('vendor.fix.renew')}
+        </button>
+        {open && (
+          <Popover onClose={() => setOpen(false)}>
+            <p className="mb-2 text-xs font-medium text-[var(--foreground-soft)]">
+              {t('vendor.fix.newExpiration')}
+            </p>
+            <input
+              type="date"
+              value={dateValue}
+              min={new Date().toISOString().slice(0, 10)}
+              onChange={e => setDateValue(e.target.value)}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-2.5 py-1.5 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+            />
+            {error && <p className="mt-1.5 text-xs text-red-500">{error}</p>}
+            <div className="mt-3 flex justify-end gap-2">
+              <Button variant="secondary" size="sm" onClick={() => setOpen(false)}>
+                {t('vendor.fix.cancel')}
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                isLoading={pending}
+                onClick={() => run(() => updateProduct(product.id, { expiresAt: dateValue }))}
+              >
+                {t('vendor.fix.save')}
+              </Button>
+            </div>
+          </Popover>
+        )}
+      </div>
+    )
+  }
+
+  // out-of-stock or low-stock
+  const isOut = problem === 'out-of-stock'
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition ${
+          isOut
+            ? 'bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400'
+            : 'bg-amber-600 hover:bg-amber-700 dark:bg-amber-500 dark:text-gray-950 dark:hover:bg-amber-400'
+        }`}
+      >
+        <CubeIcon className="h-3.5 w-3.5" />
+        {t('vendor.fix.restock')}
+      </button>
+      {open && (
+        <Popover onClose={() => setOpen(false)}>
+          <p className="mb-2 text-xs font-medium text-[var(--foreground-soft)]">
+            {t('vendor.fix.newStock')}
+          </p>
+          <input
+            type="number"
+            min={0}
+            value={stockValue}
+            autoFocus
+            onChange={e => setStockValue(e.target.value)}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-2.5 py-1.5 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+          />
+          {error && <p className="mt-1.5 text-xs text-red-500">{error}</p>}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button variant="secondary" size="sm" onClick={() => setOpen(false)}>
+              {t('vendor.fix.cancel')}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              isLoading={pending}
+              onClick={() => {
+                const n = Number(stockValue)
+                if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+                  setError(t('vendor.fix.invalidStock'))
+                  return
+                }
+                run(() => updateProduct(product.id, { stock: n }))
+              }}
+            >
+              {t('vendor.fix.save')}
+            </Button>
+          </div>
+        </Popover>
+      )}
+    </div>
+  )
+}
+
+function Popover({
+  children,
+  onClose,
+}: {
+  children: React.ReactNode
+  onClose: () => void
+}) {
+  return (
+    <>
+      <div className="fixed inset-0 z-10" onClick={onClose} />
+      <div className="absolute right-0 top-full z-20 mt-1 w-60 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3 shadow-2xl ring-1 ring-black/5 backdrop-blur dark:ring-white/10">
+        {children}
+      </div>
+    </>
+  )
+}

--- a/src/components/vendor/VendorProductListClient.tsx
+++ b/src/components/vendor/VendorProductListClient.tsx
@@ -4,11 +4,22 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { formatPrice } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
-import { PlusIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import {
+  PlusIcon,
+  ExclamationTriangleIcon,
+  CalendarDaysIcon,
+  CubeIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline'
 import { ProductActions } from '@/components/vendor/ProductActions'
+import { ProductQuickFix, type ProductProblem } from '@/components/vendor/ProductQuickFix'
 import { useT } from '@/i18n'
 import type { BadgeVariant } from '@/domains/catalog/types'
-import { formatExpirationLabel, getExpirationTone, isProductExpired } from '@/domains/catalog/availability'
+import {
+  formatExpirationLabel,
+  getExpirationTone,
+  isProductExpired,
+} from '@/domains/catalog/availability'
 import type { getMyProducts } from '@/domains/vendors/actions'
 
 type ProductWithCategory = Awaited<ReturnType<typeof getMyProducts>>[number]
@@ -25,20 +36,55 @@ interface Props {
   products: ProductWithCategory[]
 }
 
+// Lower number = more urgent. Used for sorting + badge color.
+const PROBLEM_PRIORITY: Record<NonNullable<ProductProblem>, number> = {
+  rejected: 0,
+  expired: 1,
+  'out-of-stock': 2,
+  'low-stock': 3,
+  draft: 4,
+}
+
+function getProblem(product: ProductWithCategory, now: Date): ProductProblem {
+  if (product.status === 'REJECTED') return 'rejected'
+  if (isProductExpired(product.expiresAt, now)) return 'expired'
+  if (product.status === 'ACTIVE' && product.trackStock) {
+    if (product.stock === 0) return 'out-of-stock'
+    if (product.stock <= 5) return 'low-stock'
+  }
+  if (product.status === 'DRAFT') return 'draft'
+  return null
+}
+
 export function VendorProductListClient({ products }: Props) {
   const t = useT()
   const now = new Date()
 
-  const lowStock = products.filter(p => p.trackStock && p.stock > 0 && p.stock <= 5)
-  const outOfStock = products.filter(p => p.trackStock && p.stock === 0 && p.status === 'ACTIVE')
-  const expired = products.filter(product => isProductExpired(product.expiresAt, now))
+  const annotated = products.map(p => ({ product: p, problem: getProblem(p, now) }))
+
+  // Sort: problems first by severity, healthy last
+  annotated.sort((a, b) => {
+    const ap = a.problem ? PROBLEM_PRIORITY[a.problem] : 99
+    const bp = b.problem ? PROBLEM_PRIORITY[b.problem] : 99
+    return ap - bp
+  })
+
+  const counts = {
+    rejected: annotated.filter(a => a.problem === 'rejected').length,
+    expired: annotated.filter(a => a.problem === 'expired').length,
+    outOfStock: annotated.filter(a => a.problem === 'out-of-stock').length,
+    lowStock: annotated.filter(a => a.problem === 'low-stock').length,
+  }
+  const totalIssues = counts.rejected + counts.expired + counts.outOfStock + counts.lowStock
 
   return (
     <div className="space-y-5 max-w-4xl">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-[var(--foreground)]">{t('vendor.myCatalog')}</h1>
-          <p className="text-sm text-[var(--muted)]">{products.length} {productsUnit(products.length)}</p>
+          <p className="text-sm text-[var(--muted)]">
+            {products.length} {productsUnit(products.length)}
+          </p>
         </div>
         <Link
           href="/vendor/productos/nuevo"
@@ -48,95 +94,146 @@ export function VendorProductListClient({ products }: Props) {
         </Link>
       </div>
 
-      {/* Stock alerts */}
-      {(lowStock.length > 0 || outOfStock.length > 0 || expired.length > 0) && (
-        <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-800 dark:bg-amber-950/30">
-          <ExclamationTriangleIcon className="h-5 w-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
-          <div className="text-sm">
-            {expired.length > 0 && (
-              <p className="font-medium text-amber-900 dark:text-amber-300">
-                {expired.length} producto{expired.length > 1 ? 's' : ''} retirado{expired.length > 1 ? 's' : ''} por caducidad: {expired.map(product => product.name).join(', ')}
-              </p>
+      {/* Issues summary banner */}
+      {totalIssues > 0 && (
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-800/60 dark:bg-amber-950/30">
+          <div className="flex items-center gap-2">
+            <ExclamationTriangleIcon className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            <p className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+              {totalIssues === 1
+                ? t('vendor.fix.oneNeedsAttention')
+                : t('vendor.fix.manyNeedAttention').replace('{n}', String(totalIssues))}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {counts.rejected > 0 && (
+              <SummaryChip tone="red" icon={<XCircleIcon className="h-3.5 w-3.5" />}>
+                {counts.rejected} {t('vendor.fix.chipRejected')}
+              </SummaryChip>
             )}
-            {outOfStock.length > 0 && (
-              <p className="font-medium text-amber-900 dark:text-amber-300">
-                {outOfStock.length} producto{outOfStock.length > 1 ? 's' : ''} sin stock: {outOfStock.map(p => p.name).join(', ')}
-              </p>
+            {counts.expired > 0 && (
+              <SummaryChip tone="amber" icon={<CalendarDaysIcon className="h-3.5 w-3.5" />}>
+                {counts.expired} {t('vendor.fix.chipExpired')}
+              </SummaryChip>
             )}
-            {lowStock.length > 0 && (
-              <p className="text-amber-800 dark:text-amber-400 mt-0.5">
-                Stock bajo: {lowStock.map(p => `${p.name} (${p.stock})`).join(', ')}
-              </p>
+            {counts.outOfStock > 0 && (
+              <SummaryChip tone="red" icon={<CubeIcon className="h-3.5 w-3.5" />}>
+                {counts.outOfStock} {t('vendor.fix.chipOutOfStock')}
+              </SummaryChip>
+            )}
+            {counts.lowStock > 0 && (
+              <SummaryChip tone="amber" icon={<CubeIcon className="h-3.5 w-3.5" />}>
+                {counts.lowStock} {t('vendor.fix.chipLowStock')}
+              </SummaryChip>
             )}
           </div>
+          <p className="basis-full text-xs text-amber-800/80 dark:text-amber-300/80">
+            {t('vendor.fix.hint')}
+          </p>
         </div>
       )}
 
       {products.length === 0 ? (
         <div className="rounded-xl border-2 border-dashed border-[var(--border)] py-16 text-center">
           <p className="text-[var(--muted)] mb-3">{t('vendor.noProducts')}</p>
-          <Link href="/vendor/productos/nuevo"
-            className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+          <Link
+            href="/vendor/productos/nuevo"
+            className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+          >
             <PlusIcon className="h-4 w-4" /> {t('vendor.addFirstProduct')}
           </Link>
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
           <div className="divide-y divide-[var(--border)]">
-            {products.map(product => {
-              const statusConfig = STATUS_CONFIG[product.status] ?? { label: product.status, variant: 'default' }
+            {annotated.map(({ product, problem }) => {
+              const statusConfig = STATUS_CONFIG[product.status] ?? {
+                label: product.status,
+                variant: 'default' as BadgeVariant,
+              }
               const expirationTone = getExpirationTone(product.expiresAt, now)
               const expirationLabel = formatExpirationLabel(product.expiresAt, now)
+              const hasProblem = problem !== null
               return (
-                <div key={product.id} className="flex items-center gap-4 p-4 transition-colors hover:bg-[var(--surface-raised)]">
-                  <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-[var(--surface-raised)]">
-                    {product.images?.[0]
-                      ? <Image src={product.images[0]} alt={product.name} fill className="object-cover" sizes="64px" />
-                      : <div className="flex h-full items-center justify-center text-2xl">🌿</div>}
-                  </div>
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="font-medium text-[var(--foreground)] truncate">{product.name}</p>
-                      <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
-                      {expirationTone === 'expired' && <Badge variant="red">{t('vendor.expired')}</Badge>}
-                      {expirationTone === 'today' && <Badge variant="amber">{t('vendor.expiresToday')}</Badge>}
-                      {expirationTone === 'soon' && <Badge variant="amber">{t('vendor.expiresSoon')}</Badge>}
+                <div
+                  key={product.id}
+                  className={`flex flex-col gap-3 p-4 transition-colors hover:bg-[var(--surface-raised)] sm:flex-row sm:items-center sm:gap-4 ${
+                    hasProblem ? 'bg-amber-50/40 dark:bg-amber-950/10' : ''
+                  }`}
+                >
+                  <div className="flex items-start gap-4 sm:flex-1 sm:items-center">
+                    <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-[var(--surface-raised)]">
+                      {product.images?.[0] ? (
+                        <Image
+                          src={product.images[0]}
+                          alt={product.name}
+                          fill
+                          className="object-cover"
+                          sizes="64px"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-2xl">🌿</div>
+                      )}
                     </div>
-                    <p className="text-sm text-[var(--muted)] mt-0.5">
-                      {formatPrice(Number(product.basePrice))} / {product.unit}
-                      {product.category && ` · ${product.category.name}`}
-                    </p>
-                    {expirationLabel && (
-                      <p className={`mt-1 text-xs ${
-                        expirationTone === 'expired'
-                          ? 'text-red-600 dark:text-red-400'
-                          : expirationTone === 'today' || expirationTone === 'soon'
-                            ? 'text-amber-700 dark:text-amber-400'
-                            : 'text-[var(--muted)]'
-                      }`}>
-                        {expirationLabel}
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium text-[var(--foreground)] truncate">{product.name}</p>
+                        <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
+                        {expirationTone === 'expired' && <Badge variant="red">{t('vendor.expired')}</Badge>}
+                        {expirationTone === 'today' && <Badge variant="amber">{t('vendor.expiresToday')}</Badge>}
+                        {expirationTone === 'soon' && <Badge variant="amber">{t('vendor.expiresSoon')}</Badge>}
+                      </div>
+                      <p className="text-sm text-[var(--muted)] mt-0.5">
+                        {formatPrice(Number(product.basePrice))} / {product.unit}
+                        {product.category && ` · ${product.category.name}`}
                       </p>
-                    )}
-                    {product.status === 'REJECTED' && product.rejectionNote && (
-                      <p className="text-xs text-red-600 dark:text-red-400 mt-1">
-                        Motivo: {product.rejectionNote}
-                      </p>
-                    )}
+                      {expirationLabel && (
+                        <p
+                          className={`mt-1 text-xs ${
+                            expirationTone === 'expired'
+                              ? 'text-red-600 dark:text-red-400'
+                              : expirationTone === 'today' || expirationTone === 'soon'
+                                ? 'text-amber-700 dark:text-amber-400'
+                                : 'text-[var(--muted)]'
+                          }`}
+                        >
+                          {expirationLabel}
+                        </p>
+                      )}
+                      {product.status === 'REJECTED' && product.rejectionNote && (
+                        <div className="mt-2 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 dark:border-red-900/50 dark:bg-red-950/30">
+                          <XCircleIcon className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+                          <p className="text-xs text-red-700 dark:text-red-300">
+                            <span className="font-semibold">{t('vendor.fix.rejectionReason')}:</span>{' '}
+                            {product.rejectionNote}
+                          </p>
+                        </div>
+                      )}
+                    </div>
                   </div>
 
-                  <div className="shrink-0 text-right">
+                  <div className="flex items-center justify-between gap-3 sm:justify-end">
                     {product.trackStock && (
-                      <p className={`text-sm font-medium ${
-                        product.stock === 0 ? 'text-red-600 dark:text-red-400' :
-                        product.stock <= 5 ? 'text-amber-600 dark:text-amber-400' : 'text-[var(--muted)]'
-                      }`}>
-                        {product.stock === 0 ? t('vendor.noStock') : `${product.stock} ${t('vendor.inStock')}`}
+                      <p
+                        className={`text-sm font-medium sm:text-right ${
+                          product.stock === 0
+                            ? 'text-red-600 dark:text-red-400'
+                            : product.stock <= 5
+                              ? 'text-amber-600 dark:text-amber-400'
+                              : 'text-[var(--muted)]'
+                        }`}
+                      >
+                        {product.stock === 0
+                          ? t('vendor.noStock')
+                          : `${product.stock} ${t('vendor.inStock')}`}
                       </p>
                     )}
-                  </div>
 
-                  <ProductActions product={product} />
+                    <ProductQuickFix product={product} problem={problem} />
+
+                    <ProductActions product={product} />
+                  </div>
                 </div>
               )
             })}
@@ -144,6 +241,29 @@ export function VendorProductListClient({ products }: Props) {
         </div>
       )}
     </div>
+  )
+}
+
+function SummaryChip({
+  children,
+  icon,
+  tone,
+}: {
+  children: React.ReactNode
+  icon: React.ReactNode
+  tone: 'red' | 'amber'
+}) {
+  const cls =
+    tone === 'red'
+      ? 'bg-red-100 text-red-800 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900/60'
+      : 'bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/60'
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${cls}`}
+    >
+      {icon}
+      {children}
+    </span>
   )
 }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -256,6 +256,25 @@ const en: Record<TranslationKeys, string> = {
   'vendor.noStock': 'Out of stock',
   'vendor.inStock': 'in stock',
 
+  // Vendor – quick fixes (inline actions on catalog rows)
+  'vendor.fix.oneNeedsAttention': '1 product needs your attention',
+  'vendor.fix.manyNeedAttention': '{n} products need your attention',
+  'vendor.fix.hint': 'Fix each issue in one click using the button on its row.',
+  'vendor.fix.chipRejected': 'rejected',
+  'vendor.fix.chipExpired': 'expired',
+  'vendor.fix.chipOutOfStock': 'out of stock',
+  'vendor.fix.chipLowStock': 'low stock',
+  'vendor.fix.editAndResubmit': 'Edit & resubmit',
+  'vendor.fix.submitForReview': 'Submit for review',
+  'vendor.fix.renew': 'Renew date',
+  'vendor.fix.restock': 'Restock',
+  'vendor.fix.newExpiration': 'New expiration date',
+  'vendor.fix.newStock': 'New stock available',
+  'vendor.fix.rejectionReason': 'Rejection reason',
+  'vendor.fix.save': 'Save',
+  'vendor.fix.cancel': 'Cancel',
+  'vendor.fix.invalidStock': 'Enter a valid integer',
+
   // Vendor – product form
   'vendor.nameLabel': 'Name',
   'vendor.description': 'Description',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -254,6 +254,25 @@ const es = {
   'vendor.noStock': 'Sin stock',
   'vendor.inStock': 'en stock',
 
+  // Vendor – quick fixes (inline actions on catalog rows)
+  'vendor.fix.oneNeedsAttention': '1 producto necesita tu atención',
+  'vendor.fix.manyNeedAttention': '{n} productos necesitan tu atención',
+  'vendor.fix.hint': 'Resuelve cada problema con un clic en el botón de su fila.',
+  'vendor.fix.chipRejected': 'rechazado',
+  'vendor.fix.chipExpired': 'caducado',
+  'vendor.fix.chipOutOfStock': 'sin stock',
+  'vendor.fix.chipLowStock': 'stock bajo',
+  'vendor.fix.editAndResubmit': 'Editar y reenviar',
+  'vendor.fix.submitForReview': 'Enviar a revisión',
+  'vendor.fix.renew': 'Renovar fecha',
+  'vendor.fix.restock': 'Reponer stock',
+  'vendor.fix.newExpiration': 'Nueva fecha de caducidad',
+  'vendor.fix.newStock': 'Nuevo stock disponible',
+  'vendor.fix.rejectionReason': 'Motivo del rechazo',
+  'vendor.fix.save': 'Guardar',
+  'vendor.fix.cancel': 'Cancelar',
+  'vendor.fix.invalidStock': 'Introduce un número entero válido',
+
   // Vendor – product form
   'vendor.nameLabel': 'Nombre',
   'vendor.description': 'Descripción',


### PR DESCRIPTION
> **Draft — rescued work-in-progress from a concurrent agent session.**
> This is NOT ready to merge. Opened so the work is visible and can be picked up later.

## Summary
- New `ProductQuickFix` client component that renders an inline fix button per problematic product row (rejected / expired / out-of-stock / low-stock / draft).
- `VendorProductListClient` sorts products by problem priority, shows a problem-count chip row, and mounts `ProductQuickFix` inline per affected row.
- Adds matching `vendor.fix.*` keys in ES/EN locales (19 keys covering chips, actions, form labels, validation).

## Status
- Mid-implementation when rescued — last touched files are coherent but the feature may not be fully wired.
- Needs a pass for: UX polish, empty state behavior, full i18n parity verification, and tests.

## Test plan
- [ ] Verify build + typecheck still pass.
- [ ] `npm run test -- i18n-parity`
- [ ] Manual: vendor dashboard with products in each problem state.
- [ ] Decide scope and open a proper (non-draft) PR once complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)