### PR TITLE
fix(vendor-profile): dark-mode styles + producer logo field

### DIFF
--- a/src/app/(vendor)/perfil/StripeConnectUI.tsx
+++ b/src/app/(vendor)/perfil/StripeConnectUI.tsx
@@ -68,12 +68,12 @@ export function StripeConnectUI({ onboarded }: StripeConnectProps) {
 
   if (localOnboarded) {
     return (
-      <div className="rounded-lg border border-green-200 bg-green-50 p-6">
+      <div className="rounded-lg border border-green-200 bg-green-50 p-6 dark:border-emerald-900/40 dark:bg-emerald-950/30">
         <div className="flex items-start gap-3">
-          <CheckCircleIcon className="h-6 w-6 text-green-600 flex-shrink-0 mt-0.5" />
+          <CheckCircleIcon className="h-6 w-6 text-green-600 flex-shrink-0 mt-0.5 dark:text-emerald-400" />
           <div>
-            <h3 className="font-semibold text-green-900">Pagos configurados</h3>
-            <p className="mt-1 text-sm text-green-800">
+            <h3 className="font-semibold text-green-900 dark:text-emerald-200">Pagos configurados</h3>
+            <p className="mt-1 text-sm text-green-800 dark:text-emerald-300">
               Tu cuenta de Stripe está conectada. Recibirás liquidaciones semanales en tu cuenta
               bancaria.
             </p>
@@ -89,20 +89,20 @@ export function StripeConnectUI({ onboarded }: StripeConnectProps) {
         <div
           className={`rounded-lg p-4 ${
             message.type === 'success'
-              ? 'border border-green-200 bg-green-50 text-green-800'
-              : 'border border-red-200 bg-red-50 text-red-800'
+              ? 'border border-green-200 bg-green-50 text-green-800 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300'
+              : 'border border-red-200 bg-red-50 text-red-800 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300'
           }`}
         >
           {message.text}
         </div>
       )}
 
-      <div className="rounded-lg border border-gray-200 bg-white p-6">
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-6">
         <div className="flex items-start gap-3 mb-4">
-          <ExclamationCircleIcon className="h-6 w-6 text-amber-600 flex-shrink-0 mt-0.5" />
+          <ExclamationCircleIcon className="h-6 w-6 text-amber-600 flex-shrink-0 mt-0.5 dark:text-amber-400" />
           <div>
-            <h3 className="font-semibold text-gray-900">Configurar pagos</h3>
-            <p className="mt-1 text-sm text-gray-600">
+            <h3 className="font-semibold text-[var(--foreground)]">Configurar pagos</h3>
+            <p className="mt-1 text-sm text-[var(--muted)]">
               Conecta tu cuenta bancaria para recibir pagos. Usamos Stripe para gestionar los
               pagos de forma segura.
             </p>
@@ -112,12 +112,12 @@ export function StripeConnectUI({ onboarded }: StripeConnectProps) {
         <button
           onClick={handleConnect}
           disabled={loading}
-          className="w-full rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          className="w-full rounded-lg bg-blue-600 px-4 py-3 font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-blue-500 dark:hover:bg-blue-400"
         >
           {loading ? 'Conectando...' : 'Conectar con Stripe'}
         </button>
 
-        <p className="mt-3 text-xs text-gray-500">
+        <p className="mt-3 text-xs text-[var(--muted-light)]">
           Serás redirigido al formulario seguro de Stripe para completar tu información bancaria.
         </p>
       </div>

--- a/src/components/vendor/VendorProfileForm.tsx
+++ b/src/components/vendor/VendorProfileForm.tsx
@@ -7,12 +7,20 @@ import { z } from 'zod'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { updateVendorProfile } from '@/domains/vendors/actions'
+import { isAllowedImageUrl } from '@/lib/image-validation'
 import type { Vendor } from '@/generated/prisma/client'
 
 const profileSchema = z.object({
   displayName: z.string().min(3, 'Mínimo 3 caracteres').max(80),
   description: z.string().max(2000).optional(),
   location: z.string().max(100).optional(),
+  logo: z
+    .union([z.string(), z.literal(''), z.undefined()])
+    .transform(v => (v ?? '').trim())
+    .refine(
+      v => v === '' || isAllowedImageUrl(v),
+      'URL inválida. Usa cloudinary.com, uploadthing.com o unsplash.com (HTTPS)',
+    ),
   orderCutoffTime: z
     .union([z.string().regex(/^\d{2}:\d{2}$/, 'Formato HH:MM'), z.literal(''), z.undefined()])
     .transform(v => v || undefined),
@@ -35,6 +43,7 @@ export function VendorProfileForm({ vendor }: Props) {
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isSubmitting, isDirty },
   } = useForm<ProfileFormInput, unknown, ProfileFormValues>({
     resolver: zodResolver(profileSchema),
@@ -42,12 +51,16 @@ export function VendorProfileForm({ vendor }: Props) {
       displayName: vendor.displayName,
       description: vendor.description ?? '',
       location: vendor.location ?? '',
+      logo: vendor.logo ?? '',
       orderCutoffTime: vendor.orderCutoffTime ?? '',
       preparationDays: vendor.preparationDays ?? 2,
       iban: vendor.iban ?? '',
       bankAccountName: vendor.bankAccountName ?? '',
     },
   })
+
+  const logoUrl = (watch('logo') ?? '').trim()
+  const logoPreviewValid = logoUrl !== '' && isAllowedImageUrl(logoUrl)
 
   async function onSubmit(values: ProfileFormValues) {
     setServerError(null)
@@ -92,6 +105,27 @@ export function VendorProfileForm({ vendor }: Props) {
           error={errors.location?.message}
           {...register('location')}
         />
+
+        <div className="space-y-2">
+          <Input
+            label="Foto del productor (URL)"
+            placeholder="https://res.cloudinary.com/..."
+            hint="Sube tu foto a Cloudinary, UploadThing o Unsplash y pega la URL aquí."
+            error={errors.logo?.message}
+            {...register('logo')}
+          />
+          {logoPreviewValid && (
+            <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3">
+              <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-full border border-[var(--border)] bg-[var(--surface-muted,transparent)]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={logoUrl} alt="Vista previa" className="h-full w-full object-cover" />
+              </div>
+              <p className="text-xs text-[var(--muted)]">
+                Así se verá tu foto en el listado de productores.
+              </p>
+            </div>
+          )}
+        </div>
       </section>
 
       {/* Logistics */}

--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -10,6 +10,7 @@ import { getActionSession } from '@/lib/action-session'
 import { revalidateCatalogExperience, safeRevalidatePath } from '@/lib/revalidate'
 import { isVendor } from '@/lib/roles'
 import { assertVendorOnboarded } from '@/domains/vendors/onboarding'
+import { isAllowedImageUrl } from '@/lib/image-validation'
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
@@ -293,6 +294,13 @@ const profileSchema = z.object({
   displayName: z.string().min(3).max(80),
   description: z.string().max(2000).optional(),
   location: z.string().max(100).optional(),
+  logo: z
+    .union([z.string().url(), z.literal('')])
+    .optional()
+    .transform(v => (v ? v : null))
+    .refine(v => v === null || isAllowedImageUrl(v), {
+      message: 'Dominio no permitido. Usa cloudinary.com, uploadthing.com o unsplash.com',
+    }),
   orderCutoffTime: z.string().regex(/^\d{2}:\d{2}$/).optional(),
   preparationDays: z.coerce.number().int().min(0).max(30).optional(),
   iban: z.string().max(34).optional(),


### PR DESCRIPTION
## Summary
- Arregla el modo oscuro en `StripeConnectUI` (las tarjetas eran blancas duras con texto gris sin variantes `dark:`). Ahora usa `var(--surface)` / `var(--foreground)` como el resto del form.
- Añade el campo **Foto del productor** en "Mi perfil": input URL con validación de dominio (cloudinary / uploadthing / unsplash) y preview circular del resultado. Mismo patrón que el upload de imágenes de producto.
- `updateVendorProfile` valida el `logo` en servidor con `isAllowedImageUrl`, permite limpiar el campo (null) y evita dominios no permitidos.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] Abrir `/vendor/perfil` en modo oscuro y verificar que la tarjeta de Stripe ya no se ve blanca.
- [ ] Pegar una URL de Cloudinary/Unsplash en "Foto del productor", ver el preview, guardar y confirmar en la página pública del productor.
- [ ] Probar a pegar una URL de dominio no permitido → debe mostrar error.