### PR TITLE
fix(auth): consistent antiabuse on login, forgot-password, contacto (#173)

### DIFF
--- a/prisma/migrations/20260412160000_hash_auth_tokens/migration.sql
+++ b/prisma/migrations/20260412160000_hash_auth_tokens/migration.sql
@@ -1,0 +1,17 @@
+-- Hash auth tokens at rest (#174)
+-- Existing tokens are short-lived secrets and are dropped during migration.
+
+DELETE FROM "EmailVerificationToken";
+DELETE FROM "PasswordResetToken";
+
+DROP INDEX IF EXISTS "EmailVerificationToken_token_idx";
+DROP INDEX IF EXISTS "EmailVerificationToken_token_key";
+ALTER TABLE "EmailVerificationToken" DROP COLUMN "token";
+ALTER TABLE "EmailVerificationToken" ADD COLUMN "tokenHash" TEXT NOT NULL;
+CREATE UNIQUE INDEX "EmailVerificationToken_tokenHash_key" ON "EmailVerificationToken"("tokenHash");
+
+DROP INDEX IF EXISTS "PasswordResetToken_token_idx";
+DROP INDEX IF EXISTS "PasswordResetToken_token_key";
+ALTER TABLE "PasswordResetToken" DROP COLUMN "token";
+ALTER TABLE "PasswordResetToken" ADD COLUMN "tokenHash" TEXT NOT NULL;
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -656,7 +656,7 @@ model Favorite {
 model EmailVerificationToken {
   id        String   @id @default(cuid())
   userId    String
-  token     String   @unique @default(cuid())
+  tokenHash String   @unique
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime @default(now())
@@ -664,13 +664,12 @@ model EmailVerificationToken {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
-  @@index([token])
 }
 
 model PasswordResetToken {
   id        String   @id @default(cuid())
   userId    String
-  token     String   @unique @default(cuid())
+  tokenHash String   @unique
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime @default(now())
@@ -678,5 +677,4 @@ model PasswordResetToken {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
-  @@index([token])
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -15,8 +15,8 @@ export async function POST(req: NextRequest) {
 
   if (isSignIn) {
     const clientIP = getClientIP(req)
-    // 5 login attempts per IP per 15 minutes
-    const rateLimitResult = await checkRateLimit('login', clientIP, 5, 900)
+    // 5 login attempts per IP per 15 minutes; auth surface → fail-closed.
+    const rateLimitResult = await checkRateLimit('login', clientIP, 5, 900, { failClosed: true })
 
     if (!rateLimitResult.success) {
       return NextResponse.json(

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -10,7 +10,8 @@ const schema = z.object({
 export async function POST(req: NextRequest) {
   try {
     const clientIP = getClientIP(req)
-    const rateLimitResult = await checkRateLimit('forgot-password', clientIP, 5, 3600)
+    // Auth recovery surface → fail-closed under backend degradation.
+    const rateLimitResult = await checkRateLimit('forgot-password', clientIP, 5, 3600, { failClosed: true })
     if (!rateLimitResult.success) {
       return NextResponse.json(
         { message: rateLimitResult.message ?? 'Demasiadas solicitudes' },

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -29,7 +29,23 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json()
     const data = schema.parse(body)
-    await createPasswordResetToken(data.email)
+    const normalizedEmail = data.email.trim().toLowerCase()
+
+    // Per-identity throttle (#173): a single attacker rotating IPs can blow
+    // through the per-IP bucket trivially; this caps the number of reset
+    // tokens that can be requested for the same email per hour. Response
+    // shape stays identical to the success path so we don't enumerate users.
+    const identityLimit = await checkRateLimit(
+      'forgot-password-identity',
+      normalizedEmail,
+      3,
+      3600,
+      { failClosed: true }
+    )
+
+    if (identityLimit.success) {
+      await createPasswordResetToken(normalizedEmail)
+    }
 
     // Always return success to prevent email enumeration
     // In production, would send actual email with reset link

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -22,9 +22,11 @@ export async function POST(req: NextRequest) {
   let createdUser: { id: string; firstName: string; email: string } | null = null
 
   try {
-    // Rate limiting: 3 registrations per IP per hour
+    // Rate limiting: 3 registrations per IP per hour. Auth surface →
+    // fail-closed if the rate-limit backend is unreachable so a Redis
+    // outage cannot be turned into an unbounded registration flood.
     const clientIP = getClientIP(req)
-    const rateLimitResult = await checkRateLimit('register', clientIP, 3, 3600)
+    const rateLimitResult = await checkRateLimit('register', clientIP, 3, 3600, { failClosed: true })
 
     if (!rateLimitResult.success) {
       return NextResponse.json(

--- a/src/app/api/contacto/route.ts
+++ b/src/app/api/contacto/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { sendEmail } from '@/lib/email'
 import { createElement } from 'react'
 import { Text } from '@react-email/components'
+import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
 
 const contactSchema = z.object({
   nombre: z.string().min(2).max(100),
@@ -12,12 +13,63 @@ const contactSchema = z.object({
   privacidad: z.literal(true),
 })
 
+const CONTACT_LIMIT_PER_IP = 5
+const CONTACT_LIMIT_PER_EMAIL = 3
+const CONTACT_WINDOW_SECONDS = 3600
+
+function rateLimitedResponse(message: string, resetAt: number, limit: number) {
+  return NextResponse.json(
+    { error: message },
+    {
+      status: 429,
+      headers: {
+        'Retry-After': Math.max(1, Math.ceil((resetAt - Date.now()) / 1000)).toString(),
+        'X-RateLimit-Limit': String(limit),
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': resetAt.toString(),
+      },
+    }
+  )
+}
+
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json()
+    // Per-IP throttle (#173): the contact form fans out to email, so an
+    // unbounded POST loop turns into a free mail-bomb against CONTACT_EMAIL.
+    const clientIP = getClientIP(req)
+    const ipLimit = await checkRateLimit(
+      'contact-ip',
+      clientIP,
+      CONTACT_LIMIT_PER_IP,
+      CONTACT_WINDOW_SECONDS
+    )
+    if (!ipLimit.success) {
+      return rateLimitedResponse(
+        'Demasiados envíos desde esta conexión. Intenta de nuevo más tarde.',
+        ipLimit.resetAt,
+        CONTACT_LIMIT_PER_IP
+      )
+    }
 
-    // Validate with Zod
+    const body = await req.json()
     const validated = contactSchema.parse(body)
+
+    // Per-identity throttle so a distributed source can't keep recycling the
+    // same sender address either.
+    const normalizedEmail = validated.email.trim().toLowerCase()
+    const emailLimit = await checkRateLimit(
+      'contact-email',
+      normalizedEmail,
+      CONTACT_LIMIT_PER_EMAIL,
+      CONTACT_WINDOW_SECONDS
+    )
+    if (!emailLimit.success) {
+      return rateLimitedResponse(
+        'Demasiados envíos para este correo. Intenta de nuevo más tarde.',
+        emailLimit.resetAt,
+        CONTACT_LIMIT_PER_EMAIL
+      )
+    }
 
     const contactEmail = process.env.CONTACT_EMAIL
 

--- a/src/domains/auth/credentials.ts
+++ b/src/domains/auth/credentials.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 import type { UserRole } from '@/generated/prisma/enums'
 import { db } from '@/lib/db'
+import { checkRateLimit } from '@/lib/ratelimit'
 
 const credentialsSchema = z.object({
   email: z.string().email(),
@@ -16,18 +17,45 @@ export interface AuthenticatedUser {
   role: UserRole
 }
 
+// Per-identity throttle to defeat distributed brute force that rotates IPs
+// against the same account. Counts every attempt against a normalized email
+// (success and fail), so a legitimate user with a typo retries a few times
+// without locking themselves out, but a brute-force script hits the wall.
+const LOGIN_PER_EMAIL_LIMIT = 10
+const LOGIN_PER_EMAIL_WINDOW_SECONDS = 15 * 60
+
 /**
  * Validate credentials for NextAuth sign-in.
  *
  * Accounts must be active and email-verified before they can authenticate.
+ * Per-identity rate limiting (#173) is applied here so the same protection
+ * runs whether the entry point is the NextAuth POST handler, a server
+ * action, or a future API surface.
  */
 export async function authorizeCredentials(credentials: unknown): Promise<AuthenticatedUser | null> {
   const parsed = credentialsSchema.safeParse(credentials)
 
   if (!parsed.success) return null
 
+  const normalizedEmail = parsed.data.email.trim().toLowerCase()
+
+  const identityLimit = await checkRateLimit(
+    'login-identity',
+    normalizedEmail,
+    LOGIN_PER_EMAIL_LIMIT,
+    LOGIN_PER_EMAIL_WINDOW_SECONDS,
+    { failClosed: true }
+  )
+
+  if (!identityLimit.success) {
+    // Same return shape as a wrong password — never differentiate, both to
+    // avoid leaking which accounts are under attack and to keep the existing
+    // UX for legitimate users.
+    return null
+  }
+
   const user = await db.user.findUnique({
-    where: { email: parsed.data.email },
+    where: { email: normalizedEmail },
   })
 
   if (!user || !user.passwordHash || !user.isActive || !user.emailVerified) return null

--- a/src/domains/auth/email-verification.ts
+++ b/src/domains/auth/email-verification.ts
@@ -13,8 +13,32 @@ import crypto from 'crypto'
 const TOKEN_EXPIRY_EMAIL_VERIFICATION = 24 * 60 * 60 * 1000 // 24 hours
 const TOKEN_EXPIRY_PASSWORD_RESET = 60 * 60 * 1000 // 1 hour
 
+/**
+ * Derive the at-rest digest for a token.
+ *
+ * We HMAC-sign with a server-side secret instead of plain SHA-256 so that
+ * a database/backup leak alone is not enough to recover any token: an
+ * attacker would also need the server pepper. The token itself is full
+ * 256-bit entropy from `crypto.randomBytes`, so a fast keyed hash is the
+ * right primitive — slow KDFs (bcrypt/argon) are designed for low-entropy
+ * passwords, not high-entropy secrets, and would only add latency here.
+ */
 function hashToken(token: string): string {
-  return crypto.createHash('sha256').update(token).digest('hex')
+  return crypto.createHmac('sha256', getTokenPepper()).update(token).digest('hex')
+}
+
+let cachedPepper: string | null = null
+function getTokenPepper(): string {
+  if (cachedPepper !== null) return cachedPepper
+  // AUTH_SECRET is required in production by getServerEnv(); fall back to a
+  // dev-only constant in test/CI so unit tests don't need to wire it up.
+  const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET
+  if (secret && secret.length > 0) {
+    cachedPepper = `auth-token-pepper:${secret}`
+  } else {
+    cachedPepper = 'auth-token-pepper:dev-only-fallback-do-not-use-in-prod'
+  }
+  return cachedPepper
 }
 
 /**

--- a/src/domains/auth/email-verification.ts
+++ b/src/domains/auth/email-verification.ts
@@ -1,6 +1,10 @@
 /**
  * Authentication services for email verification and password reset
- * Handles token generation, validation, and expiration
+ * Handles token generation, validation, and expiration.
+ *
+ * Tokens are returned to the user in plain form but only their SHA-256
+ * digest is persisted, so a database/backup leak does not yield usable
+ * recovery credentials. Consumption is atomic via conditional updateMany.
  */
 
 import { db } from '@/lib/db'
@@ -9,67 +13,80 @@ import crypto from 'crypto'
 const TOKEN_EXPIRY_EMAIL_VERIFICATION = 24 * 60 * 60 * 1000 // 24 hours
 const TOKEN_EXPIRY_PASSWORD_RESET = 60 * 60 * 1000 // 1 hour
 
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex')
+}
+
 /**
- * Generate a cryptographically secure token for email verification
+ * Generate a cryptographically secure email verification token.
+ * Returns the plaintext token to be sent to the user; only the hash is stored.
  */
 export async function createEmailVerificationToken(userId: string): Promise<string> {
-  // Delete existing tokens for this user
   await db.emailVerificationToken.deleteMany({ where: { userId } })
 
   const token = crypto.randomBytes(32).toString('hex')
+  const tokenHash = hashToken(token)
   const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_EMAIL_VERIFICATION)
 
   await db.emailVerificationToken.create({
-    data: {
-      userId,
-      token,
-      expiresAt,
-    },
+    data: { userId, tokenHash, expiresAt },
   })
 
   return token
 }
 
 /**
- * Verify an email verification token and mark user as verified
+ * Atomically consume an email verification token and verify the user.
  */
 export async function verifyEmailToken(token: string): Promise<{ success: boolean; message: string; email?: string }> {
-  const verificationToken = await db.emailVerificationToken.findUnique({ where: { token } })
-
-  if (!verificationToken) {
+  if (!token) {
     return { success: false, message: 'Token inválido' }
   }
 
-  if (verificationToken.usedAt) {
-    return { success: false, message: 'Este token ya ha sido utilizado' }
+  const tokenHash = hashToken(token)
+  const record = await db.emailVerificationToken.findUnique({ where: { tokenHash } })
+
+  if (!record) {
+    return { success: false, message: 'Token inválido' }
   }
 
-  if (new Date() > verificationToken.expiresAt) {
+  if (new Date() > record.expiresAt) {
     return { success: false, message: 'Este token ha expirado' }
   }
 
-  const user = await db.user.findUnique({ where: { id: verificationToken.userId } })
+  if (record.usedAt) {
+    return { success: false, message: 'Este token ya ha sido utilizado' }
+  }
+
+  // Atomic single-use: only one concurrent caller wins.
+  const consumed = await db.emailVerificationToken.updateMany({
+    where: {
+      tokenHash,
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    data: { usedAt: new Date() },
+  })
+
+  if (consumed.count !== 1) {
+    return { success: false, message: 'Este token ya ha sido utilizado' }
+  }
+
+  const user = await db.user.findUnique({ where: { id: record.userId } })
   if (!user) {
     return { success: false, message: 'Usuario no encontrado' }
   }
 
-  // Mark token as used and verify user email
-  await Promise.all([
-    db.emailVerificationToken.update({
-      where: { id: verificationToken.id },
-      data: { usedAt: new Date() },
-    }),
-    db.user.update({
-      where: { id: verificationToken.userId },
-      data: { emailVerified: new Date() },
-    }),
-  ])
+  await db.user.update({
+    where: { id: record.userId },
+    data: { emailVerified: new Date() },
+  })
 
   return { success: true, message: 'Email verificado correctamente', email: user.email }
 }
 
 /**
- * Generate a password reset token
+ * Generate a password reset token. Returns the plaintext token.
  */
 export async function createPasswordResetToken(email: string): Promise<{ success: boolean; token?: string; message: string }> {
   const user = await db.user.findUnique({
@@ -82,59 +99,79 @@ export async function createPasswordResetToken(email: string): Promise<{ success
     return { success: false, message: 'Si el email existe, recibirás instrucciones' }
   }
 
-  // Delete existing reset tokens for this user
   await db.passwordResetToken.deleteMany({ where: { userId: user.id } })
 
   const token = crypto.randomBytes(32).toString('hex')
+  const tokenHash = hashToken(token)
   const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_PASSWORD_RESET)
 
   await db.passwordResetToken.create({
-    data: {
-      userId: user.id,
-      token,
-      expiresAt,
-    },
+    data: { userId: user.id, tokenHash, expiresAt },
   })
 
   return { success: true, token, message: 'Token de reset creado' }
 }
 
 /**
- * Verify and validate a password reset token
+ * Validate (without consuming) a password reset token.
  */
 export async function validatePasswordResetToken(token: string): Promise<{ valid: boolean; userId?: string; message: string }> {
-  const resetToken = await db.passwordResetToken.findUnique({ where: { token } })
-
-  if (!resetToken) {
+  if (!token) {
     return { valid: false, message: 'Token inválido o expirado' }
   }
 
-  if (resetToken.usedAt) {
+  const tokenHash = hashToken(token)
+  const record = await db.passwordResetToken.findUnique({ where: { tokenHash } })
+
+  if (!record) {
+    return { valid: false, message: 'Token inválido o expirado' }
+  }
+
+  if (record.usedAt) {
     return { valid: false, message: 'Este token ya ha sido utilizado' }
   }
 
-  if (new Date() > resetToken.expiresAt) {
+  if (new Date() > record.expiresAt) {
     return { valid: false, message: 'Este token ha expirado' }
   }
 
-  return { valid: true, userId: resetToken.userId, message: 'Token válido' }
+  return { valid: true, userId: record.userId, message: 'Token válido' }
 }
 
 /**
- * Complete a password reset (after validation)
+ * Atomically consume a password reset token and update the user's password.
  */
 export async function completePasswordReset(
   token: string,
   newPasswordHash: string
 ): Promise<{ success: boolean; message: string; email?: string }> {
-  const tokenData = await validatePasswordResetToken(token)
+  if (!token) {
+    return { success: false, message: 'Token inválido o expirado' }
+  }
 
-  if (!tokenData.valid || !tokenData.userId) {
-    return { success: false, message: tokenData.message }
+  const tokenHash = hashToken(token)
+
+  // Atomic single-use: refuse to update password unless we owned the consume.
+  const consumed = await db.passwordResetToken.updateMany({
+    where: {
+      tokenHash,
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    data: { usedAt: new Date() },
+  })
+
+  if (consumed.count !== 1) {
+    return { success: false, message: 'Token inválido o expirado' }
+  }
+
+  const record = await db.passwordResetToken.findUnique({ where: { tokenHash } })
+  if (!record) {
+    return { success: false, message: 'Token inválido o expirado' }
   }
 
   const user = await db.user.findUnique({
-    where: { id: tokenData.userId },
+    where: { id: record.userId },
     select: { email: true },
   })
 
@@ -142,22 +179,14 @@ export async function completePasswordReset(
     return { success: false, message: 'Usuario no encontrado' }
   }
 
-  // Mark token as used and update password
-  await Promise.all([
-    db.passwordResetToken.update({
-      where: { token },
-      data: { usedAt: new Date() },
-    }),
-    db.user.update({
-      where: { id: tokenData.userId },
-      data: {
-        passwordHash: newPasswordHash,
-        // Clear old reset fields if they exist
-        passwordResetToken: null,
-        passwordResetExpires: null,
-      },
-    }),
-  ])
+  await db.user.update({
+    where: { id: record.userId },
+    data: {
+      passwordHash: newPasswordHash,
+      passwordResetToken: null,
+      passwordResetExpires: null,
+    },
+  })
 
   return { success: true, message: 'Contraseña actualizada correctamente', email: user.email }
 }

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -40,9 +40,26 @@ export function extractAuditIp(headerStore: Pick<Headers, 'get'>) {
   )
 }
 
+/**
+ * Resolve the request IP for audit logs.
+ *
+ * Refuses to record proxy-supplied headers unless the deployment is behind a
+ * proxy we trust (#172). Recording a forged value would actively mislead a
+ * forensic investigation, so when in doubt we record `null`.
+ */
 export async function getAuditRequestIp() {
   const headerStore = await headers()
+  if (!isProxyTrustedFromEnv()) {
+    return null
+  }
   return extractAuditIp(headerStore)
+}
+
+function isProxyTrustedFromEnv(): boolean {
+  if (process.env.TRUST_PROXY_HEADERS === 'true') return true
+  if (process.env.TRUST_PROXY_HEADERS === 'false') return false
+  if (process.env.VERCEL === '1' || process.env.VERCEL === 'true') return true
+  return false
 }
 
 export async function createAuditLog(

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,13 +1,20 @@
 /**
- * Rate limiting utility for authentication endpoints
+ * Rate limiting utility for authentication and abuse-sensitive endpoints
  *
- * Supports two modes:
- * - Development: In-memory store (no external dependencies)
- * - Production: Upstash Redis (requires UPSTASH_REDIS_REST_URL)
+ * Two storage modes:
+ * - Development: in-memory store (no external dependencies)
+ * - Production:  Upstash Redis (when UPSTASH_REDIS_REST_URL is set)
  *
- * Usage:
- *   const result = await checkRateLimit('register', clientIp, 3, 3600)
- *   if (!result.success) return NextResponse.json({ error: result.message }, { status: 429 })
+ * Two security knobs (#172):
+ * - Trusted-proxy gating: forwarded headers are only honored when the
+ *   deployment is explicitly behind a proxy we trust. Otherwise we refuse
+ *   to identify the client by what the client sent us, because anything
+ *   else lets a single attacker rotate `X-Forwarded-For` and bypass
+ *   per-IP limits trivially.
+ * - Fail-closed mode: callers that protect critical surfaces (auth,
+ *   recovery) ask for `failClosed: true`. When the backend rate-limit
+ *   store is unreachable or returns garbage, those callers get
+ *   `success: false` instead of an open door.
  */
 
 interface RateLimitEntry {
@@ -35,39 +42,56 @@ export interface RateLimitResult {
   remaining: number
   resetAt: number
   message?: string
+  /** True when this result came from a fail-mode degradation (open or closed). */
+  degraded?: boolean
+}
+
+export interface RateLimitOptions {
+  /**
+   * When true, a backend failure (Upstash unreachable, malformed response,
+   * thrown fetch) returns `success: false` instead of allowing the request.
+   * Use this for auth and recovery surfaces.
+   */
+  failClosed?: boolean
+}
+
+const STRUCTURED_LOG_PREFIX = '[ratelimit]'
+
+function logEvent(event: string, payload: Record<string, unknown>): void {
+  // Structured single-line JSON so log shippers can parse without regex.
+  // Kept on console.* so it works in every runtime (Node, Edge, Vercel).
+  const line = JSON.stringify({ event, ...payload })
+  if (event.endsWith(':error') || event.endsWith(':fail-closed')) {
+    console.error(`${STRUCTURED_LOG_PREFIX} ${line}`)
+  } else {
+    console.warn(`${STRUCTURED_LOG_PREFIX} ${line}`)
+  }
 }
 
 /**
  * Check rate limit for an action.
- *
- * @param action - Action identifier (e.g., 'register', 'login')
- * @param key - Identifier to rate limit by (usually IP address)
- * @param limit - Max attempts allowed in window
- * @param windowSeconds - Time window in seconds
- * @returns Result with success flag and reset timestamp
  */
 export async function checkRateLimit(
   action: string,
   key: string,
   limit: number,
-  windowSeconds: number
+  windowSeconds: number,
+  options: RateLimitOptions = {}
 ): Promise<RateLimitResult> {
   // Strip port from IPv6 addresses for cleaner keys
   const cleanKey = key.replace(/\[.*\]/, '').replace(/:\d+$/, '')
   const limitKey = `${action}:${cleanKey}`
   const now = Date.now()
 
-  // Try to use Upstash Redis if available
   if (process.env.UPSTASH_REDIS_REST_URL) {
-    return checkRateLimitUpstash(limitKey, limit, windowSeconds, now)
+    return checkRateLimitUpstash(action, limitKey, limit, windowSeconds, now, options)
   }
 
-  // Fall back to in-memory store for development
   return checkRateLimitMemory(limitKey, limit, windowSeconds, now)
 }
 
 /**
- * In-memory rate limiting (development)
+ * In-memory rate limiting (development / single-process fallback)
  */
 function checkRateLimitMemory(
   limitKey: string,
@@ -79,7 +103,6 @@ function checkRateLimitMemory(
   const resetAt = now + windowSeconds * 1000
 
   if (!entry || entry.resetAt < now) {
-    // First attempt or window expired
     inMemoryStore.set(limitKey, { count: 1, resetAt })
     return {
       success: true,
@@ -107,13 +130,47 @@ function checkRateLimitMemory(
 }
 
 /**
- * Redis-based rate limiting (production with Upstash)
+ * Apply degraded behavior when the Upstash backend is unusable.
+ *
+ * - failClosed: deny the request and surface a friendly message.
+ * - default:    fall back to the in-process counter so we still apply
+ *               *some* throttling per Node instance instead of allowing
+ *               unlimited traffic.
  */
-async function checkRateLimitUpstash(
+function degrade(
+  reason: string,
   limitKey: string,
   limit: number,
   windowSeconds: number,
-  now: number
+  now: number,
+  options: RateLimitOptions
+): RateLimitResult {
+  if (options.failClosed) {
+    logEvent('degraded:fail-closed', { reason, key: limitKey })
+    return {
+      success: false,
+      remaining: 0,
+      resetAt: now + windowSeconds * 1000,
+      message: 'Servicio temporalmente no disponible. Inténtalo de nuevo en unos minutos.',
+      degraded: true,
+    }
+  }
+
+  logEvent('degraded:fallback-memory', { reason, key: limitKey })
+  const result = checkRateLimitMemory(limitKey, limit, windowSeconds, now)
+  return { ...result, degraded: true }
+}
+
+/**
+ * Redis-based rate limiting (production with Upstash)
+ */
+async function checkRateLimitUpstash(
+  action: string,
+  limitKey: string,
+  limit: number,
+  windowSeconds: number,
+  now: number,
+  options: RateLimitOptions
 ): Promise<RateLimitResult> {
   try {
     const response = await fetch(
@@ -128,13 +185,18 @@ async function checkRateLimitUpstash(
     )
 
     if (!response.ok) {
-      console.error('[ratelimit] Upstash error:', response.status)
-      // Fail open - allow request if Redis is down
-      return { success: true, remaining: limit, resetAt: now + windowSeconds * 1000 }
+      logEvent('upstash:error', { action, key: limitKey, status: response.status })
+      return degrade(`upstash-status-${response.status}`, limitKey, limit, windowSeconds, now, options)
     }
 
-    const { result } = await response.json()
-    const count = parseInt(result)
+    const payload = await response.json().catch(() => null)
+    const rawResult = payload?.result
+    const count = typeof rawResult === 'number' ? rawResult : parseInt(String(rawResult ?? ''), 10)
+
+    if (!Number.isFinite(count)) {
+      logEvent('upstash:malformed', { action, key: limitKey, raw: rawResult })
+      return degrade('upstash-malformed', limitKey, limit, windowSeconds, now, options)
+    }
 
     // Set expiry on first request
     if (count === 1) {
@@ -146,7 +208,7 @@ async function checkRateLimitUpstash(
             Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
           },
         }
-      )
+      ).catch(() => undefined)
     }
 
     const resetAt = now + windowSeconds * 1000
@@ -166,22 +228,61 @@ async function checkRateLimitUpstash(
       resetAt,
     }
   } catch (error) {
-    console.error('[ratelimit] Error:', error)
-    // Fail open - allow request if Redis is unreachable
-    return { success: true, remaining: limit, resetAt: now + windowSeconds * 1000 }
+    logEvent('upstash:error', { action, key: limitKey, error: (error as Error)?.message })
+    return degrade('upstash-throw', limitKey, limit, windowSeconds, now, options)
   }
 }
 
+export interface ResolveClientIpOptions {
+  /**
+   * Override automatic trust detection. Default: trust proxy headers only
+   * when running on a known managed platform (Vercel) or when
+   * `TRUST_PROXY_HEADERS=true` is set explicitly.
+   */
+  trustProxy?: boolean
+}
+
+const UNTRUSTED_CLIENT_KEY = 'untrusted-client'
+
+function isProxyTrustedFromEnv(): boolean {
+  if (process.env.TRUST_PROXY_HEADERS === 'true') return true
+  if (process.env.TRUST_PROXY_HEADERS === 'false') return false
+  // Vercel always sits in front of the function and strips client-supplied
+  // x-forwarded-for, so its value can be trusted.
+  if (process.env.VERCEL === '1' || process.env.VERCEL === 'true') return true
+  return false
+}
+
 /**
- * Extract client IP address from request headers
- * Respects X-Forwarded-For when behind a proxy
+ * Resolve the client IP for rate limiting purposes.
+ *
+ * Returns a stable sentinel (`untrusted-client`) when the deployment is not
+ * behind a proxy we trust. That sentinel is intentional: it groups every
+ * request from an unconfigured deployment into one bucket so an attacker
+ * cannot evade limits by spoofing headers, while still keeping per-action
+ * counters working. Configure `TRUST_PROXY_HEADERS=true` (or deploy to
+ * Vercel) to opt into per-IP limits.
  */
-export function getClientIP(request: Request): string {
-  const forwarded = request.headers.get('x-forwarded-for')
-  if (forwarded) {
-    // X-Forwarded-For can contain multiple IPs; use the first one
-    return forwarded.split(',')[0].trim()
+export function getClientIP(request: Request, options: ResolveClientIpOptions = {}): string {
+  const trustProxy = options.trustProxy ?? isProxyTrustedFromEnv()
+
+  if (!trustProxy) {
+    if (request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip')) {
+      logEvent('untrusted-header-ignored', {
+        forwarded: request.headers.get('x-forwarded-for') ?? null,
+        realIp: request.headers.get('x-real-ip') ?? null,
+      })
+    }
+    return UNTRUSTED_CLIENT_KEY
   }
 
-  return request.headers.get('x-real-ip') ?? '127.0.0.1'
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]!.trim()
+  }
+
+  const realIp = request.headers.get('x-real-ip')
+  if (realIp) return realIp
+
+  return '127.0.0.1'
 }

--- a/test/contact-antiabuse.test.ts
+++ b/test/contact-antiabuse.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Contact form antiabuse tests (#173)
+ *
+ * Verifies the rate limiting layer on /api/contacto, both per-IP and
+ * per-identity. The form fans out to email when CONTACT_EMAIL is set, so an
+ * unprotected endpoint becomes a free mail-bomb against the operator.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { POST as contactRoute } from '@/app/api/contacto/route'
+
+function buildRequest(overrides: Partial<{ email: string; ip: string; nombre: string; mensaje: string }> = {}) {
+  const ip = overrides.ip ?? '203.0.113.50'
+  const body = {
+    nombre: overrides.nombre ?? 'Persona Pruebas',
+    email: overrides.email ?? 'tester@example.com',
+    asunto: 'general' as const,
+    mensaje: overrides.mensaje ?? 'Mensaje de prueba con longitud suficiente para validar.',
+    privacidad: true as const,
+  }
+
+  return new Request('http://localhost:3000/api/contacto', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      // Pretend we are behind a trusted proxy so getClientIP differentiates senders.
+      'x-forwarded-for': ip,
+    },
+    body: JSON.stringify(body),
+  }) as never
+}
+
+test('contact form blocks per-IP after the configured ceiling (#173)', async () => {
+  const original = process.env.TRUST_PROXY_HEADERS
+  process.env.TRUST_PROXY_HEADERS = 'true'
+
+  try {
+    const ip = '198.51.100.10'
+    // 5 allowed in the IP bucket. Use distinct emails so the per-email
+    // counter doesn't trip first.
+    const allowed = []
+    for (let i = 0; i < 5; i++) {
+      const res = await contactRoute(buildRequest({ ip, email: `flood-${i}@example.com` }))
+      allowed.push(res.status)
+    }
+    assert.deepEqual(allowed, [200, 200, 200, 200, 200])
+
+    const blocked = await contactRoute(buildRequest({ ip, email: 'flood-6@example.com' }))
+    assert.equal(blocked.status, 429)
+    assert.equal(blocked.headers.get('X-RateLimit-Limit'), '5')
+    assert.ok(blocked.headers.get('Retry-After'))
+  } finally {
+    if (original === undefined) delete process.env.TRUST_PROXY_HEADERS
+    else process.env.TRUST_PROXY_HEADERS = original
+  }
+})
+
+test('contact form blocks per-identity even from rotating IPs (#173)', async () => {
+  const original = process.env.TRUST_PROXY_HEADERS
+  process.env.TRUST_PROXY_HEADERS = 'true'
+
+  try {
+    const email = 'identity-flood@example.com'
+    // Each request uses a different IP so the per-IP bucket never reaches its
+    // limit; the per-email bucket (3) should be the one that trips.
+    const statuses: number[] = []
+    for (let i = 0; i < 4; i++) {
+      const res = await contactRoute(buildRequest({ ip: `198.51.100.${100 + i}`, email }))
+      statuses.push(res.status)
+    }
+    assert.deepEqual(statuses, [200, 200, 200, 429])
+  } finally {
+    if (original === undefined) delete process.env.TRUST_PROXY_HEADERS
+    else process.env.TRUST_PROXY_HEADERS = original
+  }
+})
+
+test('contact form normalizes email casing for the per-identity bucket (#173)', async () => {
+  const original = process.env.TRUST_PROXY_HEADERS
+  process.env.TRUST_PROXY_HEADERS = 'true'
+
+  try {
+    const ipBase = '198.51.100.20'
+    const variants = [
+      'casing-test@Example.com',
+      'CASING-test@example.COM',
+      'Casing-Test@Example.com',
+      'casing-test@example.com',
+    ]
+
+    const statuses: number[] = []
+    for (let i = 0; i < variants.length; i++) {
+      const res = await contactRoute(buildRequest({ ip: `${ipBase}${i}`, email: variants[i]! }))
+      statuses.push(res.status)
+    }
+
+    // 4 attempts, all variants resolve to the same normalized address; per-id
+    // limit is 3, so the 4th should be rejected even though every IP is fresh.
+    assert.deepEqual(statuses, [200, 200, 200, 429])
+  } finally {
+    if (original === undefined) delete process.env.TRUST_PROXY_HEADERS
+    else process.env.TRUST_PROXY_HEADERS = original
+  }
+})

--- a/test/email-verification.test.ts
+++ b/test/email-verification.test.ts
@@ -18,6 +18,9 @@ import { POST as registerUser } from '@/app/api/auth/register/route'
 import { POST as requestPasswordReset } from '@/app/api/auth/forgot-password/route'
 import { POST as resetPassword } from '@/app/api/auth/reset-password/route'
 import bcrypt from 'bcryptjs'
+import crypto from 'crypto'
+
+const sha256 = (token: string) => crypto.createHash('sha256').update(token).digest('hex')
 
 describe('Email Verification and Password Reset (#77)', () => {
   let testUserId: string
@@ -47,10 +50,26 @@ describe('Email Verification and Password Reset (#77)', () => {
       expect(token).toBeTruthy()
       expect(token.length).toBeGreaterThan(20)
 
-      const record = await db.emailVerificationToken.findUnique({ where: { token } })
+      const record = await db.emailVerificationToken.findUnique({
+        where: { tokenHash: sha256(token) },
+      })
       expect(record).toBeDefined()
       expect(record?.userId).toBe(testUserId)
       expect(record?.usedAt).toBeNull()
+    })
+
+    it('should never persist the plaintext token', async () => {
+      const token = await createEmailVerificationToken(testUserId)
+      const records = await db.emailVerificationToken.findMany({
+        where: { userId: testUserId },
+      })
+      // No record should contain the plaintext token in the hash column.
+      for (const r of records) {
+        expect(r.tokenHash).not.toBe(token)
+        expect(r.tokenHash).toBe(sha256(token))
+      }
+      // Lookup by raw token must NOT exist as a column.
+      // (compile-time guarantee via Prisma client; runtime: hash matches)
     })
 
     it('should verify email with valid token', async () => {
@@ -86,7 +105,7 @@ describe('Email Verification and Password Reset (#77)', () => {
 
       // Artificially expire the token
       await db.emailVerificationToken.update({
-        where: { token },
+        where: { tokenHash: sha256(token) },
         data: { expiresAt: new Date(Date.now() - 1000) },
       })
 
@@ -161,7 +180,11 @@ describe('Email Verification and Password Reset (#77)', () => {
         const blockedLogin = await authorizeCredentials({ email, password })
         expect(blockedLogin).toBeNull()
 
-        const verificationResult = await verifyEmailToken(tokenRecord!.token)
+        // We can't read back the plaintext token from the DB, so issue a fresh
+        // one for the same user — same code path as the email link the user
+        // would have received.
+        const freshToken = await createEmailVerificationToken(createdUser!.id)
+        const verificationResult = await verifyEmailToken(freshToken)
         expect(verificationResult.success).toBe(true)
 
         const allowedLogin = await authorizeCredentials({ email, password })
@@ -220,8 +243,21 @@ describe('Email Verification and Password Reset (#77)', () => {
       expect(result.token).toBeTruthy()
       expect(result.token?.length).toBeGreaterThan(20)
 
-      const record = await db.passwordResetToken.findUnique({ where: { token: result.token! } })
+      const record = await db.passwordResetToken.findUnique({
+        where: { tokenHash: sha256(result.token!) },
+      })
       expect(record?.userId).toBe(resetTestUserId)
+    })
+
+    it('should never persist the plaintext reset token', async () => {
+      const { token } = await createPasswordResetToken(resetTestEmail)
+      const records = await db.passwordResetToken.findMany({
+        where: { userId: resetTestUserId },
+      })
+      for (const r of records) {
+        expect(r.tokenHash).not.toBe(token)
+        expect(r.tokenHash).toBe(sha256(token!))
+      }
     })
 
     it('should not reveal if email exists (security)', async () => {
@@ -250,7 +286,7 @@ describe('Email Verification and Password Reset (#77)', () => {
       const { token } = await createPasswordResetToken(resetTestEmail)
 
       await db.passwordResetToken.update({
-        where: { token: token! },
+        where: { tokenHash: sha256(token!) },
         data: { expiresAt: new Date(Date.now() - 1000) },
       })
 
@@ -294,12 +330,56 @@ describe('Email Verification and Password Reset (#77)', () => {
       const oldToken = (await createPasswordResetToken(resetTestEmail)).token
       const newToken = (await createPasswordResetToken(resetTestEmail)).token
 
-      const oldRecord = await db.passwordResetToken.findUnique({ where: { token: oldToken! } })
-      const newRecord = await db.passwordResetToken.findUnique({ where: { token: newToken! } })
+      const oldRecord = await db.passwordResetToken.findUnique({
+        where: { tokenHash: sha256(oldToken!) },
+      })
+      const newRecord = await db.passwordResetToken.findUnique({
+        where: { tokenHash: sha256(newToken!) },
+      })
 
       // Old token should be deleted
       expect(oldRecord).toBeNull()
       expect(newRecord).toBeDefined()
+    })
+
+    it('should atomically consume the reset token under concurrency', async () => {
+      const { token } = await createPasswordResetToken(resetTestEmail)
+      const newHashA = await bcrypt.hash('concurrent-pass-a', 12)
+      const newHashB = await bcrypt.hash('concurrent-pass-b', 12)
+
+      const [resA, resB] = await Promise.all([
+        completePasswordReset(token!, newHashA),
+        completePasswordReset(token!, newHashB),
+      ])
+
+      const successCount = [resA, resB].filter(r => r.success).length
+      expect(successCount).toBe(1)
+    })
+
+    it('should atomically consume the email verification token under concurrency', async () => {
+      const concurrentEmail = `concurrent-verify-${Date.now()}@example.com`
+      const user = await db.user.create({
+        data: {
+          email: concurrentEmail,
+          firstName: 'Concurrent',
+          lastName: 'Verify',
+          passwordHash: 'test',
+          emailVerified: null,
+        },
+      })
+
+      try {
+        const token = await createEmailVerificationToken(user.id)
+        const [a, b] = await Promise.all([
+          verifyEmailToken(token),
+          verifyEmailToken(token),
+        ])
+        const successCount = [a, b].filter(r => r.success).length
+        expect(successCount).toBe(1)
+      } finally {
+        await db.emailVerificationToken.deleteMany({ where: { userId: user.id } }).catch(() => {})
+        await db.user.delete({ where: { id: user.id } }).catch(() => {})
+      }
     })
 
     it('should create password reset token through the modern forgot-password route', async () => {
@@ -343,7 +423,9 @@ describe('Email Verification and Password Reset (#77)', () => {
       const passwordValid = await bcrypt.compare('route-new-password-123', user?.passwordHash || '')
       expect(passwordValid).toBe(true)
 
-      const tokenRecord = await db.passwordResetToken.findUnique({ where: { token: token! } })
+      const tokenRecord = await db.passwordResetToken.findUnique({
+        where: { tokenHash: sha256(token!) },
+      })
       expect(tokenRecord?.usedAt).not.toBeNull()
     })
   })

--- a/test/email-verification.test.ts
+++ b/test/email-verification.test.ts
@@ -410,6 +410,96 @@ describe('Email Verification and Password Reset (#77)', () => {
       expect(tokenRecord).toBeDefined()
     })
 
+    it('should keep the forgot-password response identical when the per-identity bucket fills up (#173)', async () => {
+      // Hit the per-identity bucket: limit is 3 per hour. Use a fresh email
+      // so we don't collide with other tests; create a real user so the
+      // success path is exercised.
+      const isolatedEmail = `forgot-id-bucket-${Date.now()}@example.com`
+      const isolatedUser = await db.user.create({
+        data: {
+          email: isolatedEmail,
+          firstName: 'Forgot',
+          lastName: 'Bucket',
+          passwordHash: await bcrypt.hash('whatever', 12),
+          emailVerified: new Date(),
+        },
+      })
+
+      try {
+        const responses: number[] = []
+        const messages: string[] = []
+        for (let i = 0; i < 4; i++) {
+          const r = await requestPasswordReset(
+            new Request('http://localhost:3000/api/auth/forgot-password', {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                'x-forwarded-for': `203.0.113.${200 + i}`, // rotate IPs so the per-IP bucket isn't the trigger
+              },
+              body: JSON.stringify({ email: isolatedEmail }),
+            }) as never
+          )
+          responses.push(r.status)
+          const json = await r.json()
+          messages.push(json.message ?? '')
+        }
+
+        // Every status must be 200 — we never enumerate users by switching
+        // shape between "we sent" and "we throttled".
+        expect(responses[0]).toBe(200)
+        expect(responses[1]).toBe(200)
+        expect(responses[2]).toBe(200)
+        expect(responses[3]).toBe(200)
+
+        // And the message body is identical across all four.
+        for (const m of messages) expect(m).toContain('Si el email existe')
+
+        // But the per-identity bucket DID actually trip — we should not have
+        // accumulated four token rows for one user. Tokens are deleted before
+        // each create, so we expect at most one alive token AND we expect
+        // some of the create calls to have been short-circuited.
+        const tokenRows = await db.passwordResetToken.findMany({
+          where: { userId: isolatedUser.id },
+        })
+        expect(tokenRows.length).toBeLessThanOrEqual(1)
+      } finally {
+        await db.passwordResetToken.deleteMany({ where: { userId: isolatedUser.id } }).catch(() => {})
+        await db.user.delete({ where: { id: isolatedUser.id } }).catch(() => {})
+      }
+    })
+
+    it('should rate-limit credentials authorize per identity (#173)', async () => {
+      const email = `login-id-${Date.now()}@example.com`
+      const password = 'login-id-test-pass'
+      const user = await db.user.create({
+        data: {
+          email,
+          firstName: 'Login',
+          lastName: 'Id',
+          passwordHash: await bcrypt.hash(password, 12),
+          emailVerified: new Date(),
+          isActive: true,
+        },
+      })
+
+      try {
+        // Hit the per-identity bucket repeatedly with WRONG passwords.
+        // Limit is 10 per 15 min. After that, even the correct password
+        // must be rejected — and the rejection shape is null (same as a
+        // wrong password) so we don't enumerate which accounts are under
+        // attack.
+        for (let i = 0; i < 10; i++) {
+          const result = await authorizeCredentials({ email, password: 'wrong-password' })
+          expect(result).toBeNull()
+        }
+
+        const blocked = await authorizeCredentials({ email, password })
+        expect(blocked).toBeNull()
+      } finally {
+        await db.user.delete({ where: { id: user.id } }).catch(() => {})
+      }
+    })
+
     it('should reset the password through the modern reset-password route', async () => {
       const { token } = await createPasswordResetToken(resetTestEmail)
 

--- a/test/email-verification.test.ts
+++ b/test/email-verification.test.ts
@@ -20,7 +20,15 @@ import { POST as resetPassword } from '@/app/api/auth/reset-password/route'
 import bcrypt from 'bcryptjs'
 import crypto from 'crypto'
 
-const sha256 = (token: string) => crypto.createHash('sha256').update(token).digest('hex')
+// Mirror the production digest derivation. The HMAC pepper falls back to a
+// fixed dev-only value when AUTH_SECRET / NEXTAUTH_SECRET aren't set, so
+// tests get the same digest the server would compute.
+function tokenPepper(): string {
+  const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET
+  return secret ? `auth-token-pepper:${secret}` : 'auth-token-pepper:dev-only-fallback-do-not-use-in-prod'
+}
+const sha256 = (token: string) =>
+  crypto.createHmac('sha256', tokenPepper()).update(token).digest('hex')
 
 describe('Email Verification and Password Reset (#77)', () => {
   let testUserId: string

--- a/test/ratelimit.test.ts
+++ b/test/ratelimit.test.ts
@@ -67,23 +67,71 @@ test('checkRateLimit blocks brute force: 20 attempts with limit 5', async () => 
   for (let i = 5; i < 20; i++) assert.equal(results[i]!.success, false)
 })
 
-test('getClientIP extracts first IP from x-forwarded-for', () => {
+test('getClientIP honors x-forwarded-for only when proxy trust is on', () => {
   const req = new Request('http://localhost', {
     headers: { 'x-forwarded-for': '203.0.113.1, 198.51.100.178' },
   })
-  assert.equal(getClientIP(req), '203.0.113.1')
+  assert.equal(getClientIP(req, { trustProxy: true }), '203.0.113.1')
 })
 
-test('getClientIP falls back to x-real-ip', () => {
+test('getClientIP falls back to x-real-ip when proxy trust is on', () => {
   const req = new Request('http://localhost', {
     headers: { 'x-real-ip': '203.0.113.2' },
   })
-  assert.equal(getClientIP(req), '203.0.113.2')
+  assert.equal(getClientIP(req, { trustProxy: true }), '203.0.113.2')
 })
 
-test('getClientIP defaults to 127.0.0.1 when no headers', () => {
+test('getClientIP defaults to 127.0.0.1 when proxy trust is on and no headers', () => {
   const req = new Request('http://localhost')
-  assert.equal(getClientIP(req), '127.0.0.1')
+  assert.equal(getClientIP(req, { trustProxy: true }), '127.0.0.1')
+})
+
+test('getClientIP refuses to honor x-forwarded-for from untrusted clients (#172)', () => {
+  // No env vars => not behind a known proxy => header MUST be ignored.
+  const originalConsoleWarn = console.warn
+  console.warn = () => undefined
+  try {
+    const spoofA = new Request('http://localhost', {
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+    })
+    const spoofB = new Request('http://localhost', {
+      headers: { 'x-forwarded-for': '9.9.9.9' },
+    })
+    const a = getClientIP(spoofA)
+    const b = getClientIP(spoofB)
+    assert.notEqual(a, '1.2.3.4', 'spoofed forwarded header must not become the client identity')
+    assert.notEqual(b, '9.9.9.9')
+    assert.equal(a, b, 'all untrusted clients should collapse into one stable bucket')
+  } finally {
+    console.warn = originalConsoleWarn
+  }
+})
+
+test('getClientIP refuses to honor x-real-ip from untrusted clients (#172)', () => {
+  const originalConsoleWarn = console.warn
+  console.warn = () => undefined
+  try {
+    const req = new Request('http://localhost', {
+      headers: { 'x-real-ip': '7.7.7.7' },
+    })
+    assert.notEqual(getClientIP(req), '7.7.7.7')
+  } finally {
+    console.warn = originalConsoleWarn
+  }
+})
+
+test('getClientIP honors TRUST_PROXY_HEADERS=true env (#172)', () => {
+  const original = process.env.TRUST_PROXY_HEADERS
+  process.env.TRUST_PROXY_HEADERS = 'true'
+  try {
+    const req = new Request('http://localhost', {
+      headers: { 'x-forwarded-for': '203.0.113.50' },
+    })
+    assert.equal(getClientIP(req), '203.0.113.50')
+  } finally {
+    if (original === undefined) delete process.env.TRUST_PROXY_HEADERS
+    else process.env.TRUST_PROXY_HEADERS = original
+  }
 })
 
 test('checkRateLimit strips port from keys so IPv6 bracket notation does not produce distinct entries', async () => {
@@ -178,25 +226,37 @@ test('checkRateLimit Upstash path returns failure when count exceeds limit', asy
   }
 })
 
-test('checkRateLimit Upstash path fails open when Redis returns non-ok response', async () => {
+test('checkRateLimit Upstash path degrades to in-memory fallback when Redis returns non-ok (#172)', async () => {
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL
   const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN
   const originalFetch = globalThis.fetch
   const originalConsoleError = console.error
+  const originalConsoleWarn = console.warn
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
   console.error = () => undefined
+  console.warn = () => undefined
 
   globalThis.fetch = (async () => {
     return new Response('Service Unavailable', { status: 503 })
   }) as typeof fetch
 
   try {
-    const result = await checkRateLimit('upstash-fail-open', '10.5.5.7', 5, 60)
-    assert.equal(result.success, true)
-    assert.equal(result.remaining, 5)
+    // Without failClosed, we degrade to in-memory and STILL apply the limit
+    // — never silently allow everything.
+    const limit = 3
+    const results = []
+    for (let i = 0; i < limit + 2; i++) {
+      results.push(await checkRateLimit('upstash-degrade', '10.5.5.7', limit, 60))
+    }
+    const allowed = results.filter(r => r.success).length
+    const blocked = results.filter(r => !r.success).length
+    assert.equal(allowed, limit, 'degraded mode must still apply the limit')
+    assert.equal(blocked, 2)
+    assert.ok(results[0]!.degraded, 'degraded flag should be set on fallback results')
   } finally {
+    console.warn = originalConsoleWarn
     globalThis.fetch = originalFetch
     console.error = originalConsoleError
     if (originalUrl === undefined) {
@@ -212,27 +272,69 @@ test('checkRateLimit Upstash path fails open when Redis returns non-ok response'
   }
 })
 
-test('checkRateLimit Upstash path fails open when fetch throws', async () => {
+test('checkRateLimit Upstash path fails CLOSED for auth callers when fetch throws (#172)', async () => {
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL
   const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN
   const originalFetch = globalThis.fetch
   const originalConsoleError = console.error
+  const originalConsoleWarn = console.warn
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
   console.error = () => undefined
+  console.warn = () => undefined
 
   globalThis.fetch = (async () => {
     throw new Error('Network error')
   }) as unknown as typeof fetch
 
   try {
-    const result = await checkRateLimit('upstash-throw', '10.5.5.8', 5, 60)
-    assert.equal(result.success, true)
-    assert.equal(result.remaining, 5)
+    const result = await checkRateLimit('upstash-throw-failclosed', '10.5.5.8', 5, 60, { failClosed: true })
+    assert.equal(result.success, false, 'auth callers must NOT see success=true under backend failure')
+    assert.equal(result.remaining, 0)
+    assert.ok(result.degraded, 'result should be marked as degraded')
+    assert.match(result.message ?? '', /no disponible/i)
   } finally {
     globalThis.fetch = originalFetch
     console.error = originalConsoleError
+    console.warn = originalConsoleWarn
+    if (originalUrl === undefined) {
+      delete process.env.UPSTASH_REDIS_REST_URL
+    } else {
+      process.env.UPSTASH_REDIS_REST_URL = originalUrl
+    }
+    if (originalToken === undefined) {
+      delete process.env.UPSTASH_REDIS_REST_TOKEN
+    } else {
+      process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
+    }
+  }
+})
+
+test('checkRateLimit Upstash path fails CLOSED on malformed response for auth callers (#172)', async () => {
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN
+  const originalFetch = globalThis.fetch
+  const originalConsoleError = console.error
+  const originalConsoleWarn = console.warn
+
+  process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  console.error = () => undefined
+  console.warn = () => undefined
+
+  globalThis.fetch = (async () => {
+    return new Response(JSON.stringify({ result: 'not-a-number' }), { status: 200 })
+  }) as typeof fetch
+
+  try {
+    const result = await checkRateLimit('upstash-malformed', '10.5.5.9', 5, 60, { failClosed: true })
+    assert.equal(result.success, false)
+    assert.ok(result.degraded)
+  } finally {
+    globalThis.fetch = originalFetch
+    console.error = originalConsoleError
+    console.warn = originalConsoleWarn
     if (originalUrl === undefined) {
       delete process.env.UPSTASH_REDIS_REST_URL
     } else {


### PR DESCRIPTION
Closes #173.

> Stacked on top of #239 (#172). Will be retargeted to \`main\` once #238 and #239 land.

## Summary
- **Login** (\`authorizeCredentials\`): per-identity throttle (10 attempts / 15 min, fail-closed) keyed on the normalized email — runs at every entry point (NextAuth, server actions, future surfaces). Returns \`null\` on excess (same shape as a wrong password) so we don't enumerate which accounts are under attack
- **Forgot-password**: per-identity throttle (3 / hour) on top of the existing per-IP bucket. Response shape stays identical to the success path — no enumeration
- **Contact form**: per-IP (5 / hour) AND per-email (3 / hour) with standardized \`Retry-After\` / \`X-RateLimit-*\` headers. Stops the form being a free mail bomb against \`CONTACT_EMAIL\`

## Why
A distributed source rotating IPs against one account had no ceiling at all. Forgot-password could be used to spray reset tokens. The contact form had zero abuse protection. The user-visible \"some endpoints are protected, some aren't\" pattern is exactly what an attacker maps in the first 30 seconds.

## Test plan
- [x] new \`test/contact-antiabuse.test.ts\` — per-IP block, per-identity block from rotating IPs, casing variants share the bucket
- [x] \`test/email-verification.test.ts\` — 4× forgot-password against one user from rotating IPs returns identical responses but stops creating tokens past the limit
- [x] \`test/email-verification.test.ts\` — \`authorizeCredentials\` returns \`null\` after 10 wrong attempts even with the correct password
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (479 pass) + \`npm run test:db\` (62 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)