### PR TITLE
perf(db): add critical query indexes (#134)

### DIFF
--- a/prisma/migrations/20260412170000_query_indexes_134/migration.sql
+++ b/prisma/migrations/20260412170000_query_indexes_134/migration.sql
@@ -1,0 +1,12 @@
+-- Critical query indexes (#134)
+--
+-- Backs three frequent query shapes that previously triggered a full
+-- scan + sort:
+--   - buyer order list:           Order(customerId) ORDER BY placedAt DESC
+--   - admin incidents page:       Incident ORDER BY createdAt DESC
+--   - vendor fulfillments portal: VendorFulfillment(vendorId) ORDER BY createdAt
+--
+
+CREATE INDEX "Order_customerId_placedAt_idx" ON "Order"("customerId", "placedAt");
+CREATE INDEX "Incident_createdAt_idx" ON "Incident"("createdAt");
+CREATE INDEX "VendorFulfillment_vendorId_createdAt_idx" ON "VendorFulfillment"("vendorId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -372,6 +372,7 @@ model Order {
   reviews      Review[]
 
   @@index([customerId, status])
+  @@index([customerId, placedAt])
   @@index([status, placedAt])
   @@index([orderNumber])
 }
@@ -436,6 +437,7 @@ model VendorFulfillment {
 
   @@index([orderId])
   @@index([vendorId, status])
+  @@index([vendorId, createdAt])
 }
 
 model OrderEvent {
@@ -530,6 +532,7 @@ model Incident {
   @@index([status, slaDeadline])
   @@index([customerId])
   @@index([customerId, status])
+  @@index([createdAt])
 }
 
 model IncidentMessage {


### PR DESCRIPTION
Closes #134.

## Summary
Three frequent query shapes were doing a full scan + in-memory sort:

- **buyer order list**: \`Order(customerId) ORDER BY placedAt DESC\` — neither \`(customerId, status)\` nor \`(status, placedAt)\` covers it
- **admin incidents page**: \`Incident ORDER BY createdAt DESC LIMIT 20\` — no \`createdAt\` index at all
- **vendor fulfillments portal**: \`VendorFulfillment(vendorId) ORDER BY createdAt\` — \`(vendorId, status)\` doesn't help the sort

Adds composite indexes that match each shape exactly so the planner can read from the index and skip the sort.

## What's already covered (kept as-is)
The repo already had the indexes the issue called out for OrderLine(vendorId), Review(vendorId, createdAt), Review(productId, createdAt), and the partial Incident(status, slaDeadline). PR is intentionally narrow — just the missing pieces.

## Test plan
- [x] \`npx prisma generate\` clean
- [x] \`npm run typecheck\` clean
- [x] migration is additive (CREATE INDEX only) — safe to apply on a populated DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)