### PR TITLE
fix(checkout): precheck stock before creating Stripe PaymentIntent (#133)

### DIFF
--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -179,6 +179,41 @@ export async function createOrder(
     }
   })
 
+  // Stock precheck (#133): bail out BEFORE creating a Stripe PaymentIntent
+  // when the latest committed stock is already insufficient. The transaction
+  // below still uses FOR UPDATE to catch the race window between this read
+  // and the write, but without this fast path the user would land on the
+  // Stripe payment page only to have the order fail at submit, leaving us
+  // with an orphaned PaymentIntent we'd have to cancel.
+  const stockShortages: string[] = []
+  for (const item of validatedItems) {
+    const product = products.find(p => p.id === item.productId)
+    if (!product || !product.trackStock) continue
+
+    if (item.variantId) {
+      const variant = product.variants.find(v => v.id === item.variantId)
+      if (!variant || variant.stock == null) continue
+      if (variant.stock < item.quantity) {
+        const variantName = variant.name ? ` (${variant.name})` : ''
+        stockShortages.push(
+          `"${product.name}"${variantName} — solo quedan ${variant.stock} ` +
+          `${variant.stock === 1 ? 'unidad' : 'unidades'}, pediste ${item.quantity}`
+        )
+      }
+    } else {
+      if (product.stock < item.quantity) {
+        stockShortages.push(
+          `"${product.name}" — solo quedan ${product.stock} ` +
+          `${product.stock === 1 ? 'unidad' : 'unidades'}, pediste ${item.quantity}`
+        )
+      }
+    }
+  }
+
+  if (stockShortages.length > 0) {
+    throw new Error(`Stock insuficiente: ${stockShortages.join('; ')}`)
+  }
+
   // Calculate totals
   const pricing = calculateOrderPricing(
     lines.map(line => ({

--- a/test/orders-checkout.test.ts
+++ b/test/orders-checkout.test.ts
@@ -152,6 +152,33 @@ test('toCheckoutFormAddress maps a saved address into checkout form values', () 
   })
 })
 
+test('createOrder runs a stock precheck BEFORE creating a Stripe PaymentIntent (#133)', () => {
+  const actions = readSource('../src/domains/orders/actions.ts')
+
+  // The precheck loop must exist with the recognizable shortage message...
+  assert.match(actions, /Stock insuficiente: \$\{stockShortages\.join/, 'must surface a clear stock-shortage error')
+
+  // ...and it must run before createPaymentIntent so we never charge a buyer
+  // we can't fulfil. Capture both code positions and assert ordering.
+  const precheckIndex = actions.indexOf('stockShortages')
+  const paymentIntentIndex = actions.indexOf('createPaymentIntent(')
+
+  assert.ok(precheckIndex > 0, 'precheck must exist in createOrder')
+  assert.ok(paymentIntentIndex > 0, 'createPaymentIntent call must exist')
+  assert.ok(
+    precheckIndex < paymentIntentIndex,
+    'stock precheck must run before createPaymentIntent (no orphan PaymentIntents)'
+  )
+})
+
+test('createOrder still validates stock atomically inside the transaction (#133)', () => {
+  // The precheck is best-effort. The transactional FOR UPDATE check must
+  // remain in place to defeat the race window between the read and the write.
+  const actions = readSource('../src/domains/orders/actions.ts')
+  assert.match(actions, /FOR UPDATE/, 'transactional row lock must still be present')
+  assert.match(actions, /Stock insuficiente para/, 'transactional check must still throw on shortage')
+})
+
 test('checkout success redirects to the confirmation page instead of leaving the buyer without feedback', () => {
   const checkoutClient = readSource('../src/components/buyer/CheckoutPageClient.tsx')
   const stripeForm = readSource('../src/components/checkout/StripeCheckoutForm.tsx')


### PR DESCRIPTION
Closes #133.

## Summary
\`createOrder\` previously created the Stripe PaymentIntent **first** and validated stock **after**, inside the transaction. If stock had run out between cart and checkout, the buyer landed on the Stripe payment page only to have the order fail at submit — leaving us with an orphaned PaymentIntent and no clear feedback.

This adds a fast precheck against the latest committed stock right after loading the products and right before \`createPaymentIntent\`. The transactional \`FOR UPDATE\` row lock is kept exactly as-is: the precheck is best-effort, the lock still defeats the close race.

The error message now also lists which products are short and how many remain, so the buyer can fix the cart in one step instead of guessing which item failed.

## Test plan
- [x] new \`orders-checkout.test.ts\` assertions:
  - stock precheck exists and runs **before** \`createPaymentIntent\`
  - transactional \`FOR UPDATE\` and the in-transaction shortage error are still present
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (474 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)