### PR TITLE
fix(forms): surface validation errors per field (#131)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ next-env.d.ts
 
 # Local wiki source is published to the GitHub wiki repo separately
 docs/wiki/
+.claude/

--- a/src/app/api/buyers/password/route.ts
+++ b/src/app/api/buyers/password/route.ts
@@ -3,47 +3,46 @@ import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import bcrypt from 'bcryptjs'
+import { apiError, apiInternalError, apiNotFound, apiUnauthorized, apiValidationFromZod } from '@/lib/api-response'
 
 const passwordSchema = z.object({
-  currentPassword: z.string().min(1),
-  newPassword: z.string().min(8),
+  currentPassword: z.string().min(1, 'Introduce tu contraseña actual'),
+  newPassword: z.string().min(8, 'La nueva contraseña debe tener al menos 8 caracteres'),
 })
 
 export async function PUT(request: Request) {
   try {
     const session = await getActionSession()
     if (!session) {
-      return NextResponse.json({ message: 'No autorizado' }, { status: 401 })
+      return apiUnauthorized()
     }
 
     const body = await request.json()
-    const { currentPassword, newPassword } = passwordSchema.parse(body)
+    const parsed = passwordSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiValidationFromZod(parsed.error)
+    }
+    const { currentPassword, newPassword } = parsed.data
 
-    // Get user with password hash
     const user = await db.user.findUnique({
       where: { id: session.user.id },
       select: { id: true, passwordHash: true },
     })
 
     if (!user) {
-      return NextResponse.json(
-        { message: 'Usuario no encontrado' },
-        { status: 404 }
-      )
+      return apiNotFound('Usuario no encontrado')
     }
 
-    // Verify current password
     if (!user.passwordHash || !(await bcrypt.compare(currentPassword, user.passwordHash))) {
-      return NextResponse.json(
-        { message: 'Contraseña actual incorrecta' },
-        { status: 401 }
-      )
+      // Per-field so the client highlights the current-password input
+      // directly instead of a generic banner. (#131)
+      return apiError('La contraseña actual es incorrecta', 401, 'UNAUTHORIZED', {
+        fieldErrors: { currentPassword: 'La contraseña actual es incorrecta' },
+      })
     }
 
-    // Hash new password
     const newPasswordHash = await bcrypt.hash(newPassword, 12)
 
-    // Update password
     await db.user.update({
       where: { id: session.user.id },
       data: { passwordHash: newPasswordHash },
@@ -53,17 +52,7 @@ export async function PUT(request: Request) {
       message: 'Contraseña actualizada correctamente',
     })
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { message: 'Datos inválidos' },
-        { status: 400 }
-      )
-    }
     console.error('Password change error:', error)
-    return NextResponse.json(
-      { message: 'Error al cambiar contraseña' },
-      { status: 500 }
-    )
+    return apiInternalError('Error al cambiar contraseña')
   }
 }
-

--- a/src/app/api/buyers/profile/route.ts
+++ b/src/app/api/buyers/profile/route.ts
@@ -2,41 +2,42 @@ import { getActionSession } from '@/lib/action-session'
 import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { apiError, apiInternalError, apiUnauthorized, apiValidationFromZod } from '@/lib/api-response'
 
 const profileSchema = z.object({
-  firstName: z.string().min(1).max(50),
-  lastName: z.string().min(1).max(50),
-  email: z.string().email(),
+  firstName: z.string().min(1, 'El nombre es obligatorio').max(50, 'Máximo 50 caracteres'),
+  lastName: z.string().min(1, 'El apellido es obligatorio').max(50, 'Máximo 50 caracteres'),
+  email: z.string().email('Email inválido'),
 })
 
 export async function PUT(request: Request) {
   try {
     const session = await getActionSession()
     if (!session) {
-      return NextResponse.json({ message: 'No autorizado' }, { status: 401 })
+      return apiUnauthorized()
     }
 
     const body = await request.json()
-    const { firstName, lastName, email } = profileSchema.parse(body)
+    const parsed = profileSchema.safeParse(body)
+    if (!parsed.success) {
+      return apiValidationFromZod(parsed.error)
+    }
+    const { firstName, lastName, email } = parsed.data
 
-    // Check if email is already taken by another user
+    // Email-conflict surfaces as a per-field error so the client can highlight
+    // the email input directly instead of a generic banner. (#131)
     if (email !== session.user.email) {
       const existing = await db.user.findUnique({ where: { email } })
       if (existing) {
-        return NextResponse.json(
-          { message: 'Email ya está en uso' },
-          { status: 400 }
-        )
+        return apiError('Este email ya está en uso por otra cuenta', 409, 'CONFLICT', {
+          fieldErrors: { email: 'Este email ya está en uso por otra cuenta' },
+        })
       }
     }
 
     const user = await db.user.update({
       where: { id: session.user.id },
-      data: {
-        firstName,
-        lastName,
-        email,
-      },
+      data: { firstName, lastName, email },
     })
 
     return NextResponse.json({
@@ -46,16 +47,7 @@ export async function PUT(request: Request) {
       email: user.email,
     })
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { message: 'Datos inválidos' },
-        { status: 400 }
-      )
-    }
     console.error('Profile update error:', error)
-    return NextResponse.json(
-      { message: 'Error al actualizar perfil' },
-      { status: 500 }
-    )
+    return apiInternalError('Error al actualizar perfil')
   }
 }

--- a/src/components/buyer/BuyerProfileForm.tsx
+++ b/src/components/buyer/BuyerProfileForm.tsx
@@ -71,6 +71,36 @@ export function BuyerProfileForm({ user }: Props) {
     resolver: zodResolver(passwordSchema),
   })
 
+  /**
+   * Surface server-side validation errors per field instead of dumping a
+   * generic banner. Routes return `{ error, code, fieldErrors? }` on 4xx;
+   * we forward fieldErrors into RHF's `setError` so the offending input is
+   * highlighted with the same UX as a client-side validation miss. (#131)
+   */
+  type ApiErrorBody = {
+    error?: string
+    message?: string
+    fieldErrors?: Record<string, string>
+  }
+
+  function applyServerFieldErrors(
+    body: ApiErrorBody,
+    setFieldError: (name: string, error: { type: string; message: string }) => void,
+    knownFields: readonly string[],
+    fallbackMessage: string
+  ) {
+    const fieldErrors = body.fieldErrors ?? {}
+    let appliedAny = false
+    for (const [field, message] of Object.entries(fieldErrors)) {
+      if (knownFields.includes(field)) {
+        setFieldError(field, { type: 'server', message })
+        appliedAny = true
+      }
+    }
+    if (appliedAny) return null
+    return body.error ?? body.message ?? fallbackMessage
+  }
+
   const onProfileSubmit = async (data: ProfileFormInput) => {
     try {
       setError(null)
@@ -83,8 +113,15 @@ export function BuyerProfileForm({ user }: Props) {
       })
 
       if (!res.ok) {
-        const err = await res.json()
-        throw new Error(err.message || t('account.profileUpdateError'))
+        const body: ApiErrorBody = await res.json().catch(() => ({}))
+        const remaining = applyServerFieldErrors(
+          body,
+          (name, err) => profileForm.setError(name as keyof ProfileFormInput, err),
+          ['firstName', 'lastName', 'email'],
+          t('account.profileUpdateError')
+        )
+        if (remaining) setError(remaining)
+        return
       }
 
       setProfileSuccess(true)
@@ -109,8 +146,15 @@ export function BuyerProfileForm({ user }: Props) {
       })
 
       if (!res.ok) {
-        const err = await res.json()
-        throw new Error(err.message || t('account.profilePasswordError'))
+        const body: ApiErrorBody = await res.json().catch(() => ({}))
+        const remaining = applyServerFieldErrors(
+          body,
+          (name, err) => passwordForm.setError(name as keyof PasswordFormInput, err),
+          ['currentPassword', 'newPassword', 'confirmPassword'],
+          t('account.profilePasswordError')
+        )
+        if (remaining) setError(remaining)
+        return
       }
 
       setPasswordSuccess(true)

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import type { ZodError } from 'zod'
 
 /**
  * Canonical error-response helpers for /api routes.
@@ -29,18 +30,63 @@ export interface ApiErrorBody {
   error: string
   code: ApiErrorCode
   details?: unknown
+  /**
+   * Map of field path → human-readable message for form-style validation
+   * errors. The client surfaces these inline next to the offending input
+   * instead of a generic "Datos inválidos" banner. (#131)
+   */
+  fieldErrors?: Record<string, string>
+}
+
+export interface ApiErrorOptions {
+  details?: unknown
+  fieldErrors?: Record<string, string>
+  headers?: Record<string, string>
 }
 
 export function apiError(
   message: string,
   status: number,
   code: ApiErrorCode = 'INTERNAL_ERROR',
-  details?: unknown,
+  detailsOrOptions?: unknown | ApiErrorOptions,
   extraHeaders?: Record<string, string>
 ): NextResponse<ApiErrorBody> {
+  // Back-compat: accept either the legacy (details, headers) tuple or the
+  // newer options bag with fieldErrors.
+  const opts: ApiErrorOptions =
+    detailsOrOptions != null
+      && typeof detailsOrOptions === 'object'
+      && !Array.isArray(detailsOrOptions)
+      && ('fieldErrors' in detailsOrOptions || 'details' in detailsOrOptions || 'headers' in detailsOrOptions)
+      ? (detailsOrOptions as ApiErrorOptions)
+      : { details: detailsOrOptions, headers: extraHeaders }
+
   const body: ApiErrorBody = { error: message, code }
-  if (details !== undefined) body.details = details
-  return NextResponse.json(body, { status, headers: extraHeaders })
+  if (opts.details !== undefined) body.details = opts.details
+  if (opts.fieldErrors !== undefined) body.fieldErrors = opts.fieldErrors
+  return NextResponse.json(body, { status, headers: opts.headers })
+}
+
+/**
+ * Flatten a Zod error into a `{ field: 'message' }` map keyed by dotted path.
+ * Returns the first message encountered for each path, which is what users
+ * actually want to read next to the input.
+ */
+export function zodFieldErrors(error: ZodError): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const issue of error.issues) {
+    const path = issue.path.join('.')
+    if (path && map[path] === undefined) {
+      map[path] = issue.message
+    }
+  }
+  return map
+}
+
+export function apiValidationFromZod(error: ZodError, fallbackMessage = 'Revisa los datos del formulario') {
+  const fieldErrors = zodFieldErrors(error)
+  const firstMessage = Object.values(fieldErrors)[0] ?? fallbackMessage
+  return apiError(firstMessage, 422, 'VALIDATION_ERROR', { fieldErrors })
 }
 
 export const apiBadRequest = (message: string, details?: unknown) =>

--- a/test/api-response.test.ts
+++ b/test/api-response.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { z } from 'zod'
 import {
   apiBadRequest,
   apiConflict,
@@ -10,6 +11,8 @@ import {
   apiRateLimited,
   apiUnauthorized,
   apiValidationError,
+  apiValidationFromZod,
+  zodFieldErrors,
 } from '@/lib/api-response'
 
 async function readBody(response: Response): Promise<Record<string, unknown>> {
@@ -61,4 +64,88 @@ test('apiRateLimited sets Retry-After header and optional limit', async () => {
 test('apiRateLimited floors negative retry-after to zero', () => {
   const res = apiRateLimited('slow down', -4)
   assert.equal(res.headers.get('Retry-After'), '0')
+})
+
+// ─── #131: per-field validation error surfacing ──────────────────────────────
+
+test('zodFieldErrors flattens issues into a path → message map (#131)', () => {
+  const schema = z.object({
+    firstName: z.string().min(1, 'El nombre es obligatorio'),
+    email: z.string().email('Email inválido'),
+    nested: z.object({ age: z.number().min(18, 'Tienes que ser mayor de edad') }),
+  })
+
+  const result = schema.safeParse({ firstName: '', email: 'no-arroba', nested: { age: 12 } })
+  assert.equal(result.success, false)
+
+  const fieldErrors = zodFieldErrors(result.error!)
+  assert.equal(fieldErrors.firstName, 'El nombre es obligatorio')
+  assert.equal(fieldErrors.email, 'Email inválido')
+  assert.equal(fieldErrors['nested.age'], 'Tienes que ser mayor de edad')
+})
+
+test('zodFieldErrors keeps the first message per path (#131)', () => {
+  const schema = z.object({
+    password: z.string().min(8, 'Mínimo 8 caracteres').max(20, 'Máximo 20 caracteres'),
+  })
+  const result = schema.safeParse({ password: 'a'.repeat(50) })
+  assert.equal(result.success, false)
+  const fieldErrors = zodFieldErrors(result.error!)
+  // Only the first issue (max in this case) is recorded — never two messages
+  // for the same field, otherwise the form UI would show both at once.
+  assert.equal(Object.keys(fieldErrors).length, 1)
+  assert.equal(fieldErrors.password, 'Máximo 20 caracteres')
+})
+
+test('apiValidationFromZod returns 422 with fieldErrors and a human top-level message (#131)', async () => {
+  const schema = z.object({
+    firstName: z.string().min(1, 'Nombre obligatorio'),
+    email: z.string().email('Email inválido'),
+  })
+  const result = schema.safeParse({ firstName: '', email: 'meh' })
+  assert.equal(result.success, false)
+
+  const res = apiValidationFromZod(result.error!)
+  assert.equal(res.status, 422)
+  const body = await readBody(res)
+  assert.equal(body.code, 'VALIDATION_ERROR')
+  assert.deepEqual(body.fieldErrors, {
+    firstName: 'Nombre obligatorio',
+    email: 'Email inválido',
+  })
+  // The top-level error mirrors the first field message so a basic client
+  // that doesn't know about fieldErrors still shows something useful.
+  assert.equal(body.error, 'Nombre obligatorio')
+})
+
+test('apiError accepts an options bag with fieldErrors for non-Zod conflicts (#131)', async () => {
+  const res = apiError('Email ya en uso', 409, 'CONFLICT', {
+    fieldErrors: { email: 'Email ya en uso' },
+  })
+  assert.equal(res.status, 409)
+  const body = await readBody(res)
+  assert.deepEqual(body.fieldErrors, { email: 'Email ya en uso' })
+  assert.equal(body.code, 'CONFLICT')
+})
+
+test('apiError keeps legacy (details, headers) signature intact', async () => {
+  const res = apiError('boom', 500, 'INTERNAL_ERROR', { trace: 'abc' })
+  const body = await readBody(res)
+  assert.deepEqual(body.details, { trace: 'abc' })
+  assert.equal('fieldErrors' in body, false)
+})
+
+test('BuyerProfileForm forwards server fieldErrors into RHF setError (#131)', () => {
+  // Source-level guard: the form must read `fieldErrors` from the response
+  // body and call setError per known field instead of dumping a generic
+  // banner. This keeps the contract honest if someone later refactors the
+  // submit handler.
+  const form = require('node:fs').readFileSync(
+    new URL('../src/components/buyer/BuyerProfileForm.tsx', import.meta.url),
+    'utf8'
+  ) as string
+
+  assert.match(form, /fieldErrors/, 'must read fieldErrors from the API response')
+  assert.match(form, /profileForm\.setError/, 'must call setError on the profile form')
+  assert.match(form, /passwordForm\.setError/, 'must call setError on the password form')
 })


### PR DESCRIPTION
Closes #131.

## Summary
Buyer profile/password forms previously bubbled every server error into a single \"Datos inválidos\" banner with no indication of which field was wrong. The buyer had to guess which input to fix.

## API contract
- New \`fieldErrors?: Record<string,string>\` on \`ApiErrorBody\`
- New helper \`apiValidationFromZod(error)\` flattens a \`ZodError\` into a per-field map (first message per path) and returns 422 with the top-level \`error\` mirroring the first message — basic clients still see something useful
- \`apiError\` now accepts an options bag \`{ details, fieldErrors, headers }\` while keeping the legacy \`(details, headers)\` signature working

## Routes
- **/api/buyers/profile**: zod validation goes through \`apiValidationFromZod\`; email-already-taken returns 409 with \`fieldErrors.email\`
- **/api/buyers/password**: same for zod; \"current password incorrect\" returns 401 with \`fieldErrors.currentPassword\` so the client highlights that input directly

## Form
\`BuyerProfileForm\` reads \`body.fieldErrors\` and forwards each entry to react-hook-form's \`setError\`. Only when no field-level error matches do we fall back to the top banner. Same for the password form.

## Test plan
- [x] \`zodFieldErrors\` flattens nested paths and keeps the first message per field
- [x] \`apiValidationFromZod\` returns 422 + \`code: VALIDATION_ERROR\` + \`fieldErrors\` + a useful top-level message
- [x] \`apiError\` options bag carries \`fieldErrors\` through; legacy \`(details, headers)\` tuple still works
- [x] BuyerProfileForm source guard: must call \`setError\` per field on both forms
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (487 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)