### PR TITLE
fix(ui): aria-busy + disabled-while-pending on async action buttons (#188)

### DIFF
--- a/src/components/admin/ProductModerationActions.tsx
+++ b/src/components/admin/ProductModerationActions.tsx
@@ -52,7 +52,7 @@ export function ProductModerationActions({ productId, productName, status }: Pro
         <Button size="sm" isLoading={loading} onClick={handleApprove}>
           Aprobar
         </Button>
-        <Button size="sm" variant="danger" onClick={() => setRejectModal(true)}>
+        <Button size="sm" variant="danger" disabled={loading} onClick={() => setRejectModal(true)}>
           Rechazar
         </Button>
       </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -46,10 +46,16 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={cn(buttonVariants({ variant, size }), className)}
         disabled={disabled || isLoading}
+        aria-busy={isLoading || undefined}
         {...props}
       >
         {isLoading && (
-          <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+          <svg
+            className="h-4 w-4 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
           </svg>

--- a/src/components/vendor/ProductActions.tsx
+++ b/src/components/vendor/ProductActions.tsx
@@ -67,9 +67,10 @@ export function ProductActions({ product }: Props) {
                 <button
                   onClick={handleSubmitReview}
                   disabled={loading}
-                  className="block w-full px-4 py-2 text-left text-sm text-emerald-700 transition hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/35"
+                  aria-busy={loading || undefined}
+                  className="block w-full px-4 py-2 text-left text-sm text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-emerald-400 dark:hover:bg-emerald-950/35"
                 >
-                  Enviar a revisión
+                  {loading ? 'Enviando…' : 'Enviar a revisión'}
                 </button>
               )}
               {product.status === 'ACTIVE' && !isExpired && (

--- a/test/loading-states.test.ts
+++ b/test/loading-states.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Loading-state contract tests (#188)
+ *
+ * These tests guard the patterns required by issue #188:
+ *  - Buttons that trigger async work must be disabled during the operation
+ *  - They must expose aria-busy=true so screen readers announce the wait
+ *  - Double-clicks during pending state must not double-submit
+ *
+ * Implemented as static-source assertions (the same shape the rest of the
+ * repo's contract tests use) so they don't need a DOM and run in the fast
+ * non-DB test suite.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function read(path: string): string {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8')
+}
+
+test('shared Button component sets aria-busy when isLoading (#188)', () => {
+  const src = read('src/components/ui/button.tsx')
+  // The aria-busy attribute is the accessibility half of the contract: a
+  // disabled button is not enough for assistive tech to announce that
+  // something is in flight.
+  assert.match(
+    src,
+    /aria-busy=\{isLoading\s*\|\|\s*undefined\}/,
+    'Button must set aria-busy={isLoading || undefined}'
+  )
+  // Defense-in-depth: the spinner SVG itself should be aria-hidden so
+  // screen readers don't read it as "image" once the button is announced.
+  assert.match(src, /aria-hidden="true"/, 'Button spinner must be aria-hidden')
+  // disabled || isLoading must remain — that's how we prevent
+  // double-submission on rapid clicks.
+  assert.match(
+    src,
+    /disabled=\{disabled\s*\|\|\s*isLoading\}/,
+    'Button must remain disabled while loading'
+  )
+})
+
+test('LoginForm wires its submit button to a loading state (#188)', () => {
+  const src = read('src/components/auth/LoginForm.tsx')
+  assert.match(src, /isLoading=\{loading\}/, 'login submit must surface its loading state')
+  // The setLoading(true) → await → setLoading(false) pattern must be intact.
+  assert.match(src, /setLoading\(true\)/)
+  assert.match(src, /setLoading\(false\)/)
+})
+
+test('CheckoutPageClient submit button reflects isSubmitting and processing step (#188)', () => {
+  const src = read('src/components/buyer/CheckoutPageClient.tsx')
+  assert.match(
+    src,
+    /isLoading=\{isSubmitting \|\| step === 'processing'\}/,
+    'place-order button must be loading during submit AND while the order is processing'
+  )
+})
+
+test('ProductActions Enviar a revisión button is disabled and aria-busy while in flight (#188)', () => {
+  const src = read('src/components/vendor/ProductActions.tsx')
+  // The raw <button> must set both attributes — using Button would also work,
+  // but the file uses a styled <button> for the menu item.
+  assert.match(src, /disabled=\{loading\}/, 'must disable while loading')
+  assert.match(src, /aria-busy=\{loading \|\| undefined\}/, 'must announce busy state')
+  // Label must change so a sighted user without a spinner still gets feedback.
+  assert.match(src, /loading \? 'Enviando…'/)
+})
+
+test('ProductModerationActions reject button is disabled while approve is pending (#188)', () => {
+  const src = read('src/components/admin/ProductModerationActions.tsx')
+  // Both moderation buttons share one `loading` state. The approve button
+  // already used isLoading={loading}; the reject opener (which mounts the
+  // modal) must also be disabled so the admin can't fire two server actions
+  // in flight against the same product.
+  assert.match(
+    src,
+    /variant="danger" disabled=\{loading\} onClick=\{\(\) => setRejectModal\(true\)\}/,
+    'reject opener must be disabled while approve is in flight'
+  )
+})
+
+test('AddToCartButton routes through the shared Button so it inherits aria-busy (#188)', () => {
+  const src = read('src/components/catalog/AddToCartButton.tsx')
+  // The cart-add itself is synchronous (Zustand store), so there's no async
+  // work to gate. This test just guards the contract: it MUST go through the
+  // shared Button so future async refactors automatically pick up
+  // aria-busy and the disabled-while-pending behavior.
+  assert.match(src, /import \{ Button[^}]*\} from '@\/components\/ui\/button'/)
+  assert.match(src, /<Button[\s\S]*?>/, 'must render a Button, not a raw <button>')
+})


### PR DESCRIPTION
Closes #188.

## Summary
Several action buttons either left themselves clickable during the in-flight async call or didn't expose the busy state to assistive tech. This adds the missing pieces.

- **Shared Button**: sets \`aria-busy={isLoading || undefined}\`; spinner SVG is now \`aria-hidden\` so screen readers don't announce it as \"image\"; the existing \`disabled || isLoading\` guard remains, blocking double-submit.
- **ProductActions \"Enviar a revisión\"**: the raw \`<button>\` menu item now has \`aria-busy\` and a label change (\`Enviando…\`) so a sighted user without a spinner still gets feedback.
- **ProductModerationActions**: the reject opener is now also disabled while approve is in flight — both buttons share one \`loading\` state, so an admin can no longer fire two server actions against the same product.
- **LoginForm**, **CheckoutPageClient**, **AddToCartButton**: already routed through the shared Button, so they inherit the aria-busy upgrade automatically.

## Test plan
- [x] new \`test/loading-states.test.ts\` contract suite covering all 6 components from the issue
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (487 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)