### PR TITLE
fix(cart): loading state + accidental-removal guard (#132)

### DIFF
--- a/src/components/buyer/CartPageClient.tsx
+++ b/src/components/buyer/CartPageClient.tsx
@@ -97,7 +97,10 @@ export function CartPageClient({ shippingSettings }: Props) {
       <h1 className="mb-8 text-2xl font-bold text-[var(--foreground)]">{t('cart.title')} ({itemCount()})</h1>
 
       <div className="grid gap-8 lg:grid-cols-3">
-        <div className="order-last space-y-3 lg:order-first lg:col-span-2">
+        <div
+          className="order-last space-y-3 lg:order-first lg:col-span-2"
+          aria-busy={checkingStock || undefined}
+        >
           {hasBlockingIssues && (
             <div
               role="alert"
@@ -189,7 +192,13 @@ export function CartPageClient({ shippingSettings }: Props) {
                         type="button"
                         onClick={() => updateQty(item.productId, item.quantity - 1, item.variantId)}
                         aria-label={`Reducir cantidad de ${item.name}`}
-                        className="rounded-l-lg p-1.5 hover:bg-[var(--surface-raised)]"
+                        // Disable when quantity===1 so the user can't accidentally
+                        // remove the item by clicking minus repeatedly. The trash
+                        // icon is the explicit removal affordance. Also disable
+                        // during the stock check so the optimistic update doesn't
+                        // race against the in-flight verification (#132).
+                        disabled={item.quantity <= 1 || checkingStock}
+                        className="rounded-l-lg p-1.5 transition hover:bg-[var(--surface-raised)] disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         <MinusIcon className="h-3.5 w-3.5 text-[var(--foreground-soft)]" />
                       </button>
@@ -199,20 +208,21 @@ export function CartPageClient({ shippingSettings }: Props) {
                         max={available ?? undefined}
                         inputMode="numeric"
                         value={item.quantity}
+                        disabled={checkingStock}
                         onChange={event => {
                           const nextQuantity = Number.parseInt(event.target.value, 10)
-                          if (Number.isNaN(nextQuantity)) return
+                          if (Number.isNaN(nextQuantity) || nextQuantity < 1) return
                           updateQty(item.productId, nextQuantity, item.variantId)
                         }}
-                        className="w-12 bg-transparent text-center text-sm font-medium text-[var(--foreground)] focus:outline-none"
+                        className="w-12 bg-transparent text-center text-sm font-medium text-[var(--foreground)] focus:outline-none disabled:opacity-60"
                         aria-label={`Cantidad de ${item.name}`}
                       />
                       <button
                         type="button"
                         onClick={() => updateQty(item.productId, item.quantity + 1, item.variantId)}
                         aria-label={`Aumentar cantidad de ${item.name}`}
-                        disabled={available !== null && item.quantity >= available}
-                        className="rounded-r-lg p-1.5 hover:bg-[var(--surface-raised)] disabled:cursor-not-allowed disabled:opacity-40"
+                        disabled={checkingStock || (available !== null && item.quantity >= available)}
+                        className="rounded-r-lg p-1.5 transition hover:bg-[var(--surface-raised)] disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         <PlusIcon className="h-3.5 w-3.5 text-[var(--foreground-soft)]" />
                       </button>
@@ -221,7 +231,8 @@ export function CartPageClient({ shippingSettings }: Props) {
                       type="button"
                       onClick={() => removeItem(item.productId, item.variantId)}
                       aria-label={`Eliminar ${item.name} del carrito`}
-                      className="text-[var(--muted)] hover:text-red-600 dark:hover:text-red-400"
+                      disabled={checkingStock}
+                      className="text-[var(--muted)] transition hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:text-red-400"
                     >
                       <TrashIcon className="h-4 w-4" />
                     </button>
@@ -237,7 +248,8 @@ export function CartPageClient({ shippingSettings }: Props) {
             type="button"
             onClick={clearCart}
             aria-label={t('cart.clearCart')}
-            className="mt-2 text-sm text-[var(--muted)] hover:text-red-600 dark:hover:text-red-400"
+            disabled={checkingStock}
+            className="mt-2 text-sm text-[var(--muted)] transition hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-40 dark:hover:text-red-400"
           >
             {t('cart.clearCart')}
           </button>

--- a/test/cart-loading-states.test.ts
+++ b/test/cart-loading-states.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Cart loading-state contract tests (#132)
+ *
+ * The cart store itself is fully client-side (Zustand), so the
+ * "optimistic update" the issue asks for is implicit — every cart
+ * mutation updates the UI synchronously. The async surface that actually
+ * needed feedback is the stock-availability check that runs every time
+ * the cart changes: a slow network there used to leave the user clicking
+ * +/- and the trash icon while a stale check was still in flight, which
+ * caused races and visible jank.
+ *
+ * These tests guard the contract:
+ *   - cart controls are disabled during the in-flight stock check
+ *   - the cart list announces aria-busy while the check is running
+ *   - the minus button is disabled at quantity 1 (so the user can't
+ *     accidentally remove an item by clicking minus)
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const SRC = readFileSync(
+  new URL('../src/components/buyer/CartPageClient.tsx', import.meta.url),
+  'utf8'
+)
+
+test('cart list section announces aria-busy while stock is being checked (#132)', () => {
+  assert.match(
+    SRC,
+    /aria-busy=\{checkingStock \|\| undefined\}/,
+    'cart list must surface aria-busy during the in-flight stock check'
+  )
+})
+
+test('quantity − button is disabled at quantity 1 to prevent accidental removal (#132)', () => {
+  // A user clicking − repeatedly used to silently remove the item once it
+  // hit zero, with no confirmation. The trash icon is the explicit
+  // affordance — minus must stop at 1.
+  assert.match(
+    SRC,
+    /disabled=\{item\.quantity <= 1 \|\| checkingStock\}/,
+    'minus button must guard against item.quantity <= 1'
+  )
+})
+
+test('quantity controls and trash button are disabled during stock check (#132)', () => {
+  // Each control checked separately so a refactor that drops one is caught.
+  const minusGuard = SRC.match(/disabled=\{item\.quantity <= 1 \|\| checkingStock\}/)
+  const inputGuard = SRC.match(/disabled=\{checkingStock\}\s+onChange=\{event/)
+  const plusGuard = SRC.match(/disabled=\{checkingStock \|\| \(available !== null && item\.quantity >= available\)\}/)
+  // Trash button uses disabled={checkingStock} on a different line; match
+  // against its aria-label context to avoid catching the clear-cart guard.
+  const trashGuard = SRC.match(
+    /aria-label=\{`Eliminar [^`]+`\}\s+disabled=\{checkingStock\}/
+  )
+
+  assert.ok(minusGuard, 'minus button must be disabled while checkingStock')
+  assert.ok(inputGuard, 'quantity input must be disabled while checkingStock')
+  assert.ok(plusGuard, 'plus button must be disabled while checkingStock')
+  assert.ok(trashGuard, 'trash button must be disabled while checkingStock')
+})
+
+test('clear-cart button is disabled while stock is being checked (#132)', () => {
+  // Most destructive single-click action in the page — clearing the entire
+  // cart while a stock check is mid-flight would leak the result into an
+  // empty state. Disable it for the same reason as the per-item controls.
+  assert.match(
+    SRC,
+    /onClick=\{clearCart\}[\s\S]*?disabled=\{checkingStock\}/,
+    'clear-cart must be disabled while checkingStock'
+  )
+})
+
+test('cart store updates remain synchronous (the optimistic guarantee, #132)', () => {
+  // Defensive: if anyone ever switches the store to async server actions,
+  // the contract above stops being enough — the user would need full
+  // optimistic-update + revert-on-error wiring. This test fires when that
+  // refactor lands so we remember to expand the contract first.
+  const storeSrc = readFileSync(
+    new URL('../src/lib/cart-store.ts', import.meta.url),
+    'utf8'
+  )
+  // Match: addItem / removeItem / updateQty are *not* declared async.
+  assert.ok(!/addItem:\s*async/.test(storeSrc), 'addItem must remain synchronous')
+  assert.ok(!/removeItem:\s*async/.test(storeSrc), 'removeItem must remain synchronous')
+  assert.ok(!/updateQty:\s*async/.test(storeSrc), 'updateQty must remain synchronous')
+})


### PR DESCRIPTION
Closes #132.

## Summary
The cart store is fully client-side (Zustand), so the *optimistic update* part of the issue is implicit — every mutation already updates the UI synchronously. The async surface that actually needed feedback is the **stock-availability check** that runs every time the cart changes: on a slow network the buyer was mashing +/− and the trash icon while a stale check was still in flight, racing against the next response.

## Changes
- Cart list section announces \`aria-busy={checkingStock}\` so assistive tech reads the in-flight verification
- +/−/qty input/trash button on each row, and the clear-cart button, are all disabled while \`checkingStock\` — stops the buyer from kicking off a new mutation+check before the previous one resolves
- **− button is now disabled at \`quantity === 1\`**. Previously a buyer who clicked − repeatedly would silently remove the item once it hit zero (\`updateQty(0)\` → \`removeItem\`). The trash icon is the explicit removal affordance — minus must stop at the floor
- Quantity input rejects values \`< 1\` inline so an empty/zero input doesn't fire a destructive update

## Test plan
- [x] new \`test/cart-loading-states.test.ts\` covering: aria-busy on the list, minus disabled at 1, all controls disabled while checkingStock, clear-cart disabled while checkingStock, guard test that fires if anyone switches the store to async server actions later
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (486 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)