### PR TITLE
fix(buyer): deep-link the pending-review badge to the right product (#204)

### DIFF
--- a/src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx
+++ b/src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx
@@ -104,7 +104,15 @@ export function OrderDetailClient({ order, nuevo, reviewEligibility }: Props) {
             const snapshot = parseOrderLineSnapshot(line.productSnapshot)
 
             return (
-              <div key={line.id} className="flex items-center gap-4 px-5 py-4">
+              <div
+                key={line.id}
+                // Stable anchor target for deep-links from the order list
+                // pending-review badge (#204): /cuenta/pedidos/{id}#review-{productId}
+                // The id stays on the row even when the product is already
+                // reviewed, so the URL fragment is meaningful regardless of state.
+                id={`review-${line.productId}`}
+                className="flex scroll-mt-24 items-center gap-4 px-5 py-4"
+              >
                 <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-lg bg-[var(--surface-raised)]">
                   {line.product.images?.[0]
                     ? <Image src={line.product.images[0]} alt={line.product.name} fill className="object-cover" sizes="56px" />

--- a/src/app/(buyer)/cuenta/pedidos/page.tsx
+++ b/src/app/(buyer)/cuenta/pedidos/page.tsx
@@ -10,7 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { RepeatOrderButton } from '@/components/buyer/RepeatOrderButton'
 import type { Metadata } from 'next'
 import { getServerT } from '@/i18n/server'
-import { countPendingReviewsInOrder } from '@/domains/reviews/pending-policy'
+import { countPendingReviewsInOrder, firstPendingReviewProductId } from '@/domains/reviews/pending-policy'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getServerT()
@@ -71,6 +71,13 @@ export default async function MisPedidosPage() {
               pendingReviews === 1
                 ? t('pendingReviews.badgeCountOne')
                 : t('pendingReviews.badgeCountOther').replace('{count}', String(pendingReviews))
+            // Deep-link to the first unreviewed product so the buyer lands on
+            // the form they need to fill, not at the top of the page. (#204)
+            const firstPendingProductId =
+              order.status === 'DELIVERED' ? firstPendingReviewProductId(order) : null
+            const pendingHref = firstPendingProductId
+              ? `/cuenta/pedidos/${order.id}#review-${firstPendingProductId}`
+              : `/cuenta/pedidos/${order.id}#reseñas`
             return (
             <article
               key={order.id}
@@ -120,7 +127,7 @@ export default async function MisPedidosPage() {
 
               {pendingReviews > 0 && (
                 <Link
-                  href={`/cuenta/pedidos/${order.id}#reseñas`}
+                  href={pendingHref}
                   className="mt-4 flex items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900 transition hover:border-amber-300 hover:bg-amber-100 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:border-amber-700 dark:hover:bg-amber-950/60"
                 >
                   <StarIcon className="h-5 w-5 shrink-0 text-amber-500 dark:text-amber-300" />

--- a/src/domains/reviews/pending-policy.ts
+++ b/src/domains/reviews/pending-policy.ts
@@ -15,3 +15,23 @@ export function countPendingReviewsInOrder(order: {
   }
   return pending
 }
+
+/**
+ * First product in the order that the buyer has not yet reviewed, in line
+ * order. Used by the order-list pending-review badge to deep-link directly
+ * to the right form field instead of dumping the buyer at the top of the
+ * page. Returns null when nothing is pending. (#204)
+ */
+export function firstPendingReviewProductId(order: {
+  lines: Array<{ productId: string }>
+  reviews: Array<{ productId: string }>
+}): string | null {
+  const reviewed = new Set(order.reviews.map(r => r.productId))
+  const seen = new Set<string>()
+  for (const line of order.lines) {
+    if (seen.has(line.productId)) continue
+    seen.add(line.productId)
+    if (!reviewed.has(line.productId)) return line.productId
+  }
+  return null
+}

--- a/test/reviews-pending.test.ts
+++ b/test/reviews-pending.test.ts
@@ -1,6 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { countPendingReviewsInOrder } from '@/domains/reviews/pending-policy'
+import { readFileSync } from 'node:fs'
+import {
+  countPendingReviewsInOrder,
+  firstPendingReviewProductId,
+} from '@/domains/reviews/pending-policy'
 
 test('countPendingReviewsInOrder returns the number of distinct unreviewed products', () => {
   const order = {
@@ -38,4 +42,70 @@ test('countPendingReviewsInOrder returns zero when every product is already revi
 
 test('countPendingReviewsInOrder returns zero on empty orders', () => {
   assert.equal(countPendingReviewsInOrder({ lines: [], reviews: [] }), 0)
+})
+
+// ─── #204: deep-link helper + page wiring ────────────────────────────────────
+
+test('firstPendingReviewProductId returns the first unreviewed product in line order', () => {
+  const order = {
+    lines: [{ productId: 'p1' }, { productId: 'p2' }, { productId: 'p3' }],
+    reviews: [{ productId: 'p1' }],
+  }
+  assert.equal(firstPendingReviewProductId(order), 'p2')
+})
+
+test('firstPendingReviewProductId skips duplicates and respects line order (#204)', () => {
+  // p1 appears twice (variants); the helper must not visit it twice.
+  // p2 is already reviewed. Expected: p3.
+  const order = {
+    lines: [
+      { productId: 'p1' },
+      { productId: 'p1' },
+      { productId: 'p2' },
+      { productId: 'p3' },
+      { productId: 'p4' },
+    ],
+    reviews: [{ productId: 'p1' }, { productId: 'p2' }],
+  }
+  assert.equal(firstPendingReviewProductId(order), 'p3')
+})
+
+test('firstPendingReviewProductId returns null when nothing is pending (#204)', () => {
+  assert.equal(
+    firstPendingReviewProductId({
+      lines: [{ productId: 'p1' }, { productId: 'p2' }],
+      reviews: [{ productId: 'p1' }, { productId: 'p2' }],
+    }),
+    null
+  )
+  assert.equal(firstPendingReviewProductId({ lines: [], reviews: [] }), null)
+})
+
+test('orders list page deep-links the pending-review badge to the first unreviewed product (#204)', () => {
+  const src = readFileSync(
+    new URL('../src/app/(buyer)/cuenta/pedidos/page.tsx', import.meta.url),
+    'utf8'
+  )
+  // The badge must use the first-pending helper and build a fragment URL,
+  // not the generic #reseñas section anchor.
+  assert.match(src, /firstPendingReviewProductId/)
+  assert.match(
+    src,
+    /#review-\$\{firstPendingProductId\}/,
+    'badge href must include #review-{productId} fragment'
+  )
+})
+
+test('OrderDetailClient renders id="review-{productId}" anchors on every line (#204)', () => {
+  const src = readFileSync(
+    new URL('../src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx', import.meta.url),
+    'utf8'
+  )
+  // Anchor target for the deep-link from the order list. Must be on the row,
+  // not inside a conditional, so the fragment works regardless of whether
+  // the product is currently reviewable.
+  assert.match(src, /id=\{`review-\$\{line\.productId\}`\}/)
+  // scroll-mt-* keeps the row below the sticky header after the browser
+  // scrolls to the fragment — without it, the row hides under the header.
+  assert.match(src, /scroll-mt-\d+/)
 })


### PR DESCRIPTION
Closes #204.

## Summary
The order-list pending-review badge already existed, but it pointed at a generic \`#reseñas\` section anchor — the buyer landed at the top of the order detail and had to scroll until they found the form for the right product. With multi-product orders that defeats the point of the badge.

## Changes
- New helper \`firstPendingReviewProductId(order)\`: pure function, line order, dedupes products that appear in several variants. Mirrors the existing \`countPendingReviewsInOrder\` shape so it tests the same way.
- Order list page: the badge href is now built from that helper — \`/cuenta/pedidos/{id}#review-{productId}\`. Falls back to \`#reseñas\` only when nothing is pending (defensive; the badge is hidden in that case).
- \`OrderDetailClient\`: every product row now has \`id=\"review-{productId}\"\` AND \`scroll-mt-24\` so the fragment scroll lands the row below the sticky header instead of hiding it underneath. The id stays on the row even when the product is already reviewed, so the fragment is meaningful regardless of state.

## Test plan
- [x] new \`firstPendingReviewProductId\` cases: first-unreviewed-in-line-order, dedup across variants, null on empty / fully-reviewed
- [x] order list page wires the helper into the badge href
- [x] OrderDetailClient renders \`id=\"review-{productId}\"\` + \`scroll-mt-*\` on every line
- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` (486 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)