### PR TITLE
fix(auth): wire src/proxy.ts as Next.js root middleware (#124)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+export { proxy as middleware } from '@/proxy'
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|api/auth|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+}


### PR DESCRIPTION
## Summary

Adds the missing `middleware.ts` at the project root that wires up `src/proxy.ts` as the Next.js middleware. This activates the route protection that was already implemented but inert.

### Background

`src/proxy.ts` already implements:

- Auth gate for `/admin`, `/vendor`, `/cuenta`, `/carrito`, `/checkout` (unauthenticated → `/login?callbackUrl=...`).
- Role-based gate: non-admin → `/`, non-vendor → `/`.
- A matcher excluding `_next`, static assets, and `api/auth`.

But there was no `middleware.ts` at the root re-exporting it, so the matcher never ran and the protection was dead code. This PR is the one-line wiring.

### Why inline `config` instead of re-exporting

Next.js 16 / Turbopack rejects re-exported `config` from a middleware file (the route-segment-config parser only accepts statically-analyzable inline definitions). The matcher is therefore duplicated inline. This is the same string already in `src/proxy.ts:44–48`; if you change one, change both. (Yes, this is mildly annoying. It's a Next.js constraint.)

### Verified

- `npm run typecheck` — clean.
- `npm run build` — output now shows `ƒ Proxy (Middleware)` confirming the middleware is registered.
- `src/proxy.ts` itself is unchanged.

Closes #124. Triaged in #234 from `rescue/issue-124-middleware`.

## Test plan

- [x] Build picks up the middleware.
- [ ] CI green.
- [ ] Smoke check after merge: `curl /vendor/dashboard` while logged out should redirect to `/login?callbackUrl=/vendor/dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)