### PR TITLE
test(e2e): scaffold Playwright + auth.spec.ts (#41)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,50 @@
+# `e2e/` — Playwright end-to-end tests
+
+End-to-end tests covering critical marketplace flows. Complements the contract / feature / integration suites in `test/` (#231).
+
+## Running locally
+
+These tests need:
+
+1. A Postgres database with migrations applied and the seed loaded:
+   ```bash
+   export DATABASE_URL_TEST=postgresql://...
+   npx prisma migrate deploy
+   npm run db:seed
+   ```
+2. Chromium installed by Playwright (one-time):
+   ```bash
+   npx playwright install chromium --with-deps
+   ```
+3. Then:
+   ```bash
+   npm run test:e2e
+   ```
+   Playwright will boot `npm run dev` against `DATABASE_URL_TEST` and run the suite. Pass `E2E_BASE_URL=...` to point at an already-running server instead.
+
+## Test users (seeded)
+
+| Email | Password | Role |
+|---|---|---|
+| `cliente@test.com` | `cliente1234` | CUSTOMER |
+| `productor@test.com` | `vendor1234` | VENDOR |
+| `admin@marketplace.com` | `admin1234` | SUPERADMIN |
+
+These come from `prisma/seed.ts`. Tests should treat them as read-only — never mutate their state in ways that other tests depend on.
+
+## Conventions
+
+- One `*.spec.ts` per critical flow (auth, checkout, vendor onboarding, admin moderation).
+- Reusable login / signup / checkout helpers go in `e2e/helpers/`.
+- Tests should clean up anything they created — order, product, address — in an `afterEach` so the DB stays seedable for re-runs.
+- Use `page.goto('/...')` (relative) so `baseURL` from `playwright.config.ts` controls the target.
+
+## Status
+
+Initial scaffold landed in #41. Future PRs should add:
+
+- `e2e/checkout.spec.ts` — full mock-payment flow
+- `e2e/vendor-onboarding.spec.ts` — vendor signup → product creation → review submission
+- `e2e/admin-moderation.spec.ts` — vendor + product approval
+
+CI integration (a Playwright job in `.github/workflows/ci.yml`) is also a follow-up — see #41 for the full task list.

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import { TEST_USERS, loginAs } from './helpers/auth'
+
+test.describe('auth', () => {
+  test('customer can log in with seeded credentials', async ({ page }) => {
+    await loginAs(page, TEST_USERS.customer)
+    // After a successful customer login, the navbar exposes the "Mi cuenta"
+    // link. Asserting on that beats asserting on a specific destination URL,
+    // which is allowed to change.
+    await expect(page.getByRole('link', { name: /mi cuenta|cuenta/i })).toBeVisible()
+  })
+
+  test('login with wrong credentials surfaces an error', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('Email').fill('cliente@test.com')
+    await page.getByLabel('Contraseña').fill('definitely-wrong-password')
+    await page.getByRole('button', { name: 'Iniciar sesión' }).click()
+    // Stay on /login and show an inline error message. We don't pin the
+    // exact wording — just that something user-facing surfaces.
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.locator('p.text-red-700, p.text-red-300')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('anonymous access to /vendor/dashboard redirects to /login with callbackUrl', async ({ page }) => {
+    await page.goto('/vendor/dashboard')
+    await expect(page).toHaveURL(/\/login\?.*callbackUrl=/)
+  })
+
+  test('anonymous access to /admin/dashboard redirects to /login', async ({ page }) => {
+    await page.goto('/admin/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test'
+
+export interface TestUser {
+  email: string
+  password: string
+}
+
+export const TEST_USERS = {
+  customer: { email: 'cliente@test.com', password: 'cliente1234' },
+  vendor: { email: 'productor@test.com', password: 'vendor1234' },
+  admin: { email: 'admin@marketplace.com', password: 'admin1234' },
+} as const satisfies Record<string, TestUser>
+
+/**
+ * Logs in via the public /login page using the credentials form.
+ * Uses the visible UI (not a request bypass) so the test exercises the
+ * real auth flow including the redirect after a successful submit.
+ */
+export async function loginAs(page: Page, user: TestUser) {
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(user.email)
+  await page.getByLabel('Contraseña').fill(user.password)
+  await page.getByRole('button', { name: 'Iniciar sesión' }).click()
+  // Successful login bounces away from /login. Wait until the URL changes
+  // so callers can immediately assert against the destination.
+  await page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 10_000 })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20.19.39",
         "@types/react": "^19",
@@ -1433,6 +1434,22 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@prisma/adapter-pg": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.7.0.tgz",
@@ -2487,7 +2504,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2497,7 +2513,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2998,7 +3014,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -4842,6 +4857,53 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postal-mime": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
@@ -6189,7 +6251,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:db": "node --env-file-if-exists=.env --env-file-if-exists=.env.test ./scripts/run-node-tests.mjs --db",
     "test:db:parallel": "node --env-file-if-exists=.env --env-file-if-exists=.env.test ./scripts/run-node-tests.mjs --db --parallel",
     "test:integration": "node --env-file-if-exists=.env --env-file-if-exists=.env.test ./scripts/run-integration-tests.mjs",
+    "test:e2e": "playwright test",
     "test:coverage": "c8 node ./scripts/run-node-tests.mjs --parallel",
     "typecheck": "tsc --noEmit",
     "typecheck:app": "tsc -p tsconfig.app.json --noEmit",
@@ -53,6 +54,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20.19.39",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright config for marketplace E2E tests (#41).
+ *
+ * Run with:
+ *   npm run test:e2e
+ *
+ * Required env:
+ *   DATABASE_URL_TEST  Postgres URL for an isolated DB seeded by `npm run db:seed`.
+ *
+ * The dev server is started by Playwright via `webServer`, talking to the
+ * test DB. Tests assume the seed data is present (admin@marketplace.com,
+ * productor@test.com, cliente@test.com — see prisma/seed.ts).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: process.env.E2E_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: {
+          DATABASE_URL: process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL ?? '',
+          NODE_ENV: 'test',
+          PAYMENT_PROVIDER: 'mock',
+        },
+      },
+})


### PR DESCRIPTION
## Summary

Establishes the Playwright E2E scaffold from #41. This is intentionally a **minimal scaffold** — config + helpers + first critical-path spec — leaving the rest of the suite and CI integration as follow-ups so the foundation lands in a reviewable PR.

### What's in this PR

- `playwright.config.ts` — Chromium-only project, 30s timeout, `webServer` boots `npm run dev` against `DATABASE_URL_TEST` with `PAYMENT_PROVIDER=mock`, traces/screenshots/videos kept on failure. Pass `E2E_BASE_URL` to skip the boot and target an existing server.
- `e2e/helpers/auth.ts` — `TEST_USERS` map for the three seeded accounts in `prisma/seed.ts` (cliente / productor / admin) plus a `loginAs(page, user)` helper that exercises the real `/login` form (no request bypass).
- `e2e/auth.spec.ts` — first critical-path spec covering the four auth assertions from the issue:
  - customer login with seeded credentials → "Mi cuenta" link visible
  - wrong password → inline error rendered, URL stays on `/login`
  - anonymous `/vendor/dashboard` → redirected to `/login?callbackUrl=...` (relies on the middleware wired in #253)
  - anonymous `/admin/dashboard` → redirected to `/login`
- `e2e/README.md` — how to run locally, the seeded-user contract, and a status section listing what's pending.
- `package.json`: new `npm run test:e2e` script and `@playwright/test` devDep.

### Verified

- `npm run typecheck` — clean (Playwright types resolve).
- `npm test` — 505/505 still passing.
- `npm run build` — clean; the new `e2e/` folder isn't picked up by `tsconfig.app.json` (which scopes to `src/**`) so it doesn't end up in the Next build.

### Out of scope (tracked in #41 for follow-up)

- `e2e/checkout.spec.ts` — full mock-payment flow (cart → checkout → confirm → /cuenta/pedidos)
- `e2e/vendor-onboarding.spec.ts` — VENDOR signup → product creation → submit for review
- `e2e/admin-moderation.spec.ts` — SUPERADMIN approves vendor + product
- CI integration — adding a Playwright job to `.github/workflows/ci.yml` with browser install (`npx playwright install --with-deps chromium`) and a seeded test DB. Held back until the suite is broader; landing it here would mostly be one passing job that runs four assertions.

Doing it this way means each follow-up PR is small, reviewable, and lands real coverage instead of one huge suite that's hard to merge.

Closes #41 partially — leaving the issue open until the follow-up specs land.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 505/505 passing locally.
- [x] `npm run build` — clean.
- [ ] `npm run test:e2e` end-to-end run against a seeded DB. Out of band — needs `npx playwright install chromium` and a Postgres test DB. Verified the spec compiles; runtime will be exercised once CI is wired or by a maintainer locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)