### PR TITLE
feat(payments): Stripe Connect destination charges for single-vendor orders (#48)

### DIFF
--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -120,7 +120,17 @@ export async function createOrder(
   const products = await db.product.findMany({
     where: { id: { in: validatedItems.map(i => i.productId) }, ...getAvailableProductWhere() },
     include: {
-      vendor: { select: { id: true, slug: true, displayName: true } },
+      vendor: {
+        select: {
+          id: true,
+          slug: true,
+          displayName: true,
+          // Stripe Connect fields drive destination charges below (#48).
+          stripeAccountId: true,
+          stripeOnboarded: true,
+          commissionRate: true,
+        },
+      },
       variants: { where: { isActive: true } },
     },
   })
@@ -232,14 +242,40 @@ export async function createOrder(
     shippingCost
   )
 
+  // Determine unique vendors (used both for the order record and for the
+  // Stripe Connect destination-charge decision below).
+  const vendorIds = [...new Set(lines.map(l => l.vendorId))]
+
+  // Stripe Connect destination charges (#48):
+  // For single-vendor orders where that vendor has completed Stripe Connect
+  // onboarding, route the funds straight to the vendor's Express account
+  // and keep the platform commission as `application_fee_amount`. Stripe
+  // does the split atomically — no separate transfer call needed.
+  //
+  // Multi-vendor orders intentionally fall back to the current behavior
+  // (funds stay on the platform account, paid out via the existing
+  // settlement system). Stripe destination charges only support a single
+  // recipient per Payment Intent.
+  let connectDestination: { vendorAccountId: string; applicationFeeAmountCents: number } | undefined
+  if (vendorIds.length === 1) {
+    const onlyVendor = products.find(p => p.vendor.id === vendorIds[0])?.vendor
+    if (onlyVendor?.stripeOnboarded && onlyVendor.stripeAccountId) {
+      const grandTotalCents = Math.round(grandTotal * 100)
+      const commissionRate = Number(onlyVendor.commissionRate)
+      const applicationFeeAmountCents = Math.round(grandTotalCents * commissionRate)
+      connectDestination = {
+        vendorAccountId: onlyVendor.stripeAccountId,
+        applicationFeeAmountCents,
+      }
+    }
+  }
+
   // Create payment intent (mock or Stripe)
   const payment = await createPaymentIntent(
     Math.round(grandTotal * 100), // cents
-    { userId: sessionUserId }
+    { userId: sessionUserId },
+    connectDestination ? { connect: connectDestination } : undefined
   )
-
-  // Determine unique vendors
-  const vendorIds = [...new Set(lines.map(l => l.vendorId))]
 
   // Create order in transaction
   const env = getServerEnv()

--- a/src/domains/payments/provider.ts
+++ b/src/domains/payments/provider.ts
@@ -11,9 +11,29 @@ export interface PaymentIntent {
   amount: number
 }
 
+/**
+ * Optional Stripe Connect destination data for single-vendor orders.
+ *
+ * When provided AND the active provider is `stripe`, the Payment Intent is
+ * created with `transfer_data.destination = vendorAccountId` and an
+ * `application_fee_amount` equal to the platform commission. Stripe routes
+ * the funds directly to the vendor's Express account on capture, minus the
+ * fee, with no extra transfer call required.
+ *
+ * Multi-vendor orders intentionally do NOT pass this — they keep funds on
+ * the platform account and rely on the existing settlement system to pay
+ * each vendor periodically. (Stripe's destination charges only support a
+ * single recipient per Payment Intent.)
+ */
+export interface ConnectDestination {
+  vendorAccountId: string
+  applicationFeeAmountCents: number
+}
+
 export async function createPaymentIntent(
   amountCents: number,
-  metadata: Record<string, string>
+  metadata: Record<string, string>,
+  options?: { connect?: ConnectDestination }
 ): Promise<PaymentIntent> {
   const env = getServerEnv()
 
@@ -33,6 +53,10 @@ export async function createPaymentIntent(
         currency: 'eur',
         metadata,
         automatic_payment_methods: { enabled: true },
+        ...(options?.connect && {
+          application_fee_amount: options.connect.applicationFeeAmountCents,
+          transfer_data: { destination: options.connect.vendorAccountId },
+        }),
       })
 
       return {
@@ -45,6 +69,7 @@ export async function createPaymentIntent(
       console.error('[checkout] stripe payment intent creation failed', {
         amountCents,
         attempt,
+        connectDestination: options?.connect?.vendorAccountId ?? null,
         error,
       })
     }

--- a/test/features/orders-checkout.test.ts
+++ b/test/features/orders-checkout.test.ts
@@ -179,6 +179,28 @@ test('createOrder still validates stock atomically inside the transaction (#133)
   assert.match(actions, /Stock insuficiente para/, 'transactional check must still throw on shortage')
 })
 
+test('createOrder builds Stripe Connect destination data for single-vendor orders (#48)', () => {
+  const actions = readSource('../../src/domains/orders/actions.ts')
+
+  // The vendor select must include the Connect fields used to route money.
+  // Without these on the loaded vendor record, the destination charge logic
+  // below has nothing to read.
+  assert.match(actions, /stripeAccountId:\s*true/, 'vendor select must load stripeAccountId')
+  assert.match(actions, /stripeOnboarded:\s*true/, 'vendor select must load stripeOnboarded')
+  assert.match(actions, /commissionRate:\s*true/, 'vendor select must load commissionRate')
+
+  // The destination-charge branch must only fire when the order has exactly
+  // one vendor AND that vendor has finished Stripe onboarding. Multi-vendor
+  // orders fall back to the platform-account flow + settlement system.
+  assert.match(actions, /vendorIds\.length === 1/, 'destination charges must gate on single-vendor orders')
+  assert.match(actions, /stripeOnboarded\s*&&\s*[a-zA-Z]+\.stripeAccountId/, 'must require completed onboarding')
+
+  // The commission must come out as application_fee_amount, not be silently
+  // dropped or split per-line. Verify the math hits commissionRate.
+  assert.match(actions, /applicationFeeAmountCents/, 'commission must be passed as application_fee_amount')
+  assert.match(actions, /commissionRate/, 'commission rate must drive the fee calculation')
+})
+
 test('checkout success redirects to the confirmation page instead of leaving the buyer without feedback', () => {
   const checkoutClient = readSource('../../src/components/buyer/CheckoutPageClient.tsx')
   const stripeForm = readSource('../../src/components/checkout/StripeCheckoutForm.tsx')

--- a/test/features/payments-provider.test.ts
+++ b/test/features/payments-provider.test.ts
@@ -26,6 +26,21 @@ test('createPaymentIntent returns a mock client secret in mock mode', async () =
   })
 })
 
+test('createPaymentIntent ignores connect destination in mock mode (#48)', async () => {
+  // Connect destination charges only apply when PAYMENT_PROVIDER=stripe.
+  // In mock mode the option is harmlessly ignored — the same mock intent
+  // shape is returned, so the orders action can pass `connect` unconditionally.
+  await withMockEnv(async () => {
+    const intent = await createPaymentIntent(
+      2495,
+      { orderId: 'ord_123' },
+      { connect: { vendorAccountId: 'acct_test_123', applicationFeeAmountCents: 300 } }
+    )
+    assert.match(intent.id, /^mock_pi_/)
+    assert.equal(intent.amount, 2495)
+  })
+})
+
 test('confirmMockPayment accepts mock payment intents', async () => {
   await assert.doesNotReject(() => confirmMockPayment('mock_pi_123_secret'))
 })


### PR DESCRIPTION
## Summary

The Connect **onboarding** half of #48 was already in place (`createStripeConnectLink`, `verifyStripeOnboarding`, `getStripeAccountStatus` in `src/domains/vendors/stripe.ts`, plus `StripeConnectUI` on `/vendor/perfil`). What was missing was the **money-routing** half — Payment Intents kept funds on the platform account regardless of which vendor the buyer was paying.

This PR wires destination charges into the checkout flow:

### `src/domains/payments/provider.ts`

- New optional `connect: { vendorAccountId, applicationFeeAmountCents }` parameter on `createPaymentIntent`.
- In Stripe mode, when `connect` is provided, the Payment Intent is created with:
  ```ts
  transfer_data: { destination: vendorAccountId },
  application_fee_amount: applicationFeeAmountCents,
  ```
  Stripe atomically routes the funds to the vendor's Express account on capture and keeps `application_fee_amount` for the platform.
- In mock mode the option is ignored, so callers can pass it unconditionally without a behavior change in dev.

### `src/domains/orders/actions.ts`

- Vendor select now loads `stripeAccountId`, `stripeOnboarded`, `commissionRate`.
- Before calling `createPaymentIntent`, computes a `connectDestination` iff:
  - `vendorIds.length === 1` (single-vendor order), AND
  - that vendor has `stripeOnboarded === true` AND a non-null `stripeAccountId`.
- The application fee is `Math.round(grandTotalCents * Number(vendor.commissionRate))`.
- Multi-vendor orders intentionally fall back to the existing platform-account flow. Stripe destination charges only support one recipient per Payment Intent — splitting across multiple vendors needs separate transfers, which is what the existing settlement system already handles periodically.

### Tests (507/507 passing)

- `test/features/payments-provider.test.ts` — new test asserting that the `connect` option is harmlessly ignored in mock mode (mock id shape preserved, amount unchanged).
- `test/features/orders-checkout.test.ts` — new contract test asserting that `createOrder`:
  - loads `stripeAccountId` / `stripeOnboarded` / `commissionRate` on the vendor select,
  - gates the destination-charge branch on `vendorIds.length === 1` AND completed onboarding,
  - feeds `commissionRate` into `applicationFeeAmountCents`.

Closes #48 partially (closes the destination-charges acceptance criterion).

## Out of scope (intentional, separate follow-ups)

- **Warning UI on `/vendor/productos`** when the vendor has active products but no completed Stripe onboarding. The acceptance criterion is in #48 but it's a UX surface, not a payments-correctness change — best as a focused follow-up.
- **Multi-vendor settlements via `stripe.transfers.create`** post-confirmation. Today the existing settlement system already handles this; if/when we want immediate per-vendor transfers on multi-vendor orders, that's a separate design decision.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — 507/507 passing.
- [ ] CI green.
- [ ] Manual smoke (post-merge, requires real Stripe test account):
  - Vendor completes Connect onboarding → `stripeOnboarded = true`.
  - Buyer purchases a single product from that vendor → Stripe dashboard shows the Payment Intent with `transfer_data.destination` set and the application fee on the platform account.
  - Buyer purchases two products from two different vendors → falls back to the no-`connect` path (platform-account flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)