### PR TITLE
feat(cart): server-side persistence layer for authenticated users (#90)

### DIFF
--- a/src/domains/orders/cart-persistence.ts
+++ b/src/domains/orders/cart-persistence.ts
@@ -1,0 +1,291 @@
+'use server'
+
+/**
+ * Server-side cart persistence (#90).
+ *
+ * Layer 1 (localStorage) is handled by the Zustand `persist` middleware in
+ * `cart-store.ts`. This module is layer 2: a per-user `Cart` row in the
+ * database that survives across devices and browsers.
+ *
+ * Design notes:
+ *
+ * - Mutations are individually upserted/deleted, no whole-cart replace, so
+ *   concurrent activity from a second tab can't clobber an earlier write.
+ * - Merging a local cart into the server cart sums quantities by
+ *   (productId, variantId) — this matches the unique constraint on
+ *   `CartItem` and keeps the rule "the same product + variant is one row
+ *   with a quantity, never two rows".
+ * - All functions take `userId` rather than reading the session themselves
+ *   so the callers (server actions, route handlers) keep auth in one place
+ *   and tests can exercise the logic without mocking auth-config.
+ */
+
+import { db } from '@/lib/db'
+
+export interface CartLineInput {
+  productId: string
+  variantId?: string | null
+  quantity: number
+}
+
+export interface PersistedCartLine {
+  id: string
+  productId: string
+  variantId: string | null
+  quantity: number
+  product: {
+    id: string
+    name: string
+    slug: string
+    images: string[]
+    basePrice: number
+    unit: string
+    vendor: { id: string; slug: string; displayName: string }
+  }
+  variant: {
+    id: string
+    name: string
+    priceModifier: number
+  } | null
+}
+
+function normalizeQuantity(raw: number): number {
+  if (!Number.isFinite(raw)) return 0
+  const n = Math.floor(raw)
+  return n > 0 ? n : 0
+}
+
+async function ensureCart(userId: string) {
+  return db.cart.upsert({
+    where: { userId },
+    create: { userId },
+    update: {},
+    select: { id: true },
+  })
+}
+
+/**
+ * Read the authenticated user's persisted cart, joined with current product
+ * and variant data so the client can render it directly without a second
+ * trip. Returns an empty array (not null) when the user has no cart yet.
+ */
+export async function getServerCart(userId: string): Promise<PersistedCartLine[]> {
+  const cart = await db.cart.findUnique({
+    where: { userId },
+    select: {
+      items: {
+        orderBy: { createdAt: 'asc' },
+        select: {
+          id: true,
+          productId: true,
+          variantId: true,
+          quantity: true,
+          product: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              images: true,
+              basePrice: true,
+              unit: true,
+              vendor: { select: { id: true, slug: true, displayName: true } },
+            },
+          },
+          variant: {
+            select: { id: true, name: true, priceModifier: true },
+          },
+        },
+      },
+    },
+  })
+
+  if (!cart) return []
+
+  return cart.items.map(item => ({
+    id: item.id,
+    productId: item.productId,
+    variantId: item.variantId,
+    quantity: item.quantity,
+    product: {
+      id: item.product.id,
+      name: item.product.name,
+      slug: item.product.slug,
+      images: item.product.images,
+      basePrice: Number(item.product.basePrice),
+      unit: item.product.unit,
+      vendor: item.product.vendor,
+    },
+    variant: item.variant
+      ? {
+          id: item.variant.id,
+          name: item.variant.name,
+          priceModifier: Number(item.variant.priceModifier),
+        }
+      : null,
+  }))
+}
+
+/**
+ * Add or replace a single line in the persisted cart. If the same
+ * (productId, variantId) pair already exists, the quantity is **set**
+ * to the incoming value (not incremented) so the client stays in sync
+ * with what the user sees on screen.
+ *
+ * Note: the @@unique([cartId, productId, variantId]) constraint on
+ * CartItem can't be used directly via Prisma's composite-key where input
+ * because variantId is nullable. We do a find-then-write instead. The
+ * unique constraint still defends against races at the DB level.
+ */
+export async function setServerCartItem(
+  userId: string,
+  input: CartLineInput
+): Promise<void> {
+  const quantity = normalizeQuantity(input.quantity)
+  if (quantity === 0) {
+    await removeServerCartItem(userId, input.productId, input.variantId)
+    return
+  }
+
+  const cart = await ensureCart(userId)
+  const existing = await db.cartItem.findFirst({
+    where: {
+      cartId: cart.id,
+      productId: input.productId,
+      variantId: input.variantId ?? null,
+    },
+    select: { id: true },
+  })
+
+  if (existing) {
+    await db.cartItem.update({
+      where: { id: existing.id },
+      data: { quantity },
+    })
+    return
+  }
+
+  await db.cartItem.create({
+    data: {
+      cartId: cart.id,
+      userId,
+      productId: input.productId,
+      variantId: input.variantId ?? null,
+      quantity,
+    },
+  })
+}
+
+/**
+ * Remove a single line. No-op if the line doesn't exist (matches the
+ * client store's idempotent removeItem behavior).
+ */
+export async function removeServerCartItem(
+  userId: string,
+  productId: string,
+  variantId?: string | null
+): Promise<void> {
+  const cart = await db.cart.findUnique({
+    where: { userId },
+    select: { id: true },
+  })
+  if (!cart) return
+
+  await db.cartItem.deleteMany({
+    where: {
+      cartId: cart.id,
+      productId,
+      variantId: variantId ?? null,
+    },
+  })
+}
+
+/**
+ * Empty the persisted cart. Called after a successful order placement
+ * so the user's next visit doesn't resurrect items they just bought.
+ */
+export async function clearServerCart(userId: string): Promise<void> {
+  const cart = await db.cart.findUnique({
+    where: { userId },
+    select: { id: true },
+  })
+  if (!cart) return
+  await db.cartItem.deleteMany({ where: { cartId: cart.id } })
+}
+
+/**
+ * Merge a local (anonymous) cart into the user's persisted cart on login.
+ *
+ * Rule: for each local line, **sum** its quantity into the matching
+ * (productId, variantId) line on the server. If no matching line exists,
+ * create it. This is the standard "anonymous cart survives login" UX —
+ * the user keeps everything they had before signing in, plus everything
+ * they had on the server from a previous session.
+ *
+ * The function returns the merged cart so the client can hydrate the
+ * Zustand store directly without a second `getServerCart` call.
+ */
+export async function mergeLocalCartIntoServer(
+  userId: string,
+  localItems: CartLineInput[]
+): Promise<PersistedCartLine[]> {
+  if (localItems.length === 0) {
+    return getServerCart(userId)
+  }
+
+  const cart = await ensureCart(userId)
+
+  // Collapse duplicates within the local payload before hitting the DB,
+  // so a malformed client that sent the same line twice doesn't double-add.
+  const collapsed = new Map<string, CartLineInput>()
+  for (const item of localItems) {
+    const key = `${item.productId}::${item.variantId ?? ''}`
+    const existing = collapsed.get(key)
+    const quantity = normalizeQuantity(item.quantity) + normalizeQuantity(existing?.quantity ?? 0)
+    if (quantity > 0) {
+      collapsed.set(key, {
+        productId: item.productId,
+        variantId: item.variantId ?? null,
+        quantity,
+      })
+    }
+  }
+
+  // Same nullable-composite-key workaround as setServerCartItem: find then
+  // update-or-create. We run the whole batch in a single $transaction so
+  // a partial merge can't leave the cart in a half-state if any single
+  // line fails.
+  await db.$transaction(async tx => {
+    for (const item of collapsed.values()) {
+      const quantityToAdd = normalizeQuantity(item.quantity)
+      if (quantityToAdd === 0) continue
+
+      const existing = await tx.cartItem.findFirst({
+        where: {
+          cartId: cart.id,
+          productId: item.productId,
+          variantId: item.variantId ?? null,
+        },
+        select: { id: true, quantity: true },
+      })
+
+      if (existing) {
+        await tx.cartItem.update({
+          where: { id: existing.id },
+          data: { quantity: existing.quantity + quantityToAdd },
+        })
+      } else {
+        await tx.cartItem.create({
+          data: {
+            cartId: cart.id,
+            userId,
+            productId: item.productId,
+            variantId: item.variantId ?? null,
+            quantity: quantityToAdd,
+          },
+        })
+      }
+    }
+  })
+
+  return getServerCart(userId)
+}

--- a/test/integration/cart-persistence.test.ts
+++ b/test/integration/cart-persistence.test.ts
@@ -1,0 +1,176 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  clearServerCart,
+  getServerCart,
+  mergeLocalCartIntoServer,
+  removeServerCartItem,
+  setServerCartItem,
+} from '@/domains/orders/cart-persistence'
+import { db } from '@/lib/db'
+import {
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+} from './helpers'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+test('getServerCart returns an empty array when the user has no Cart row', async () => {
+  const customer = await createUser('CUSTOMER')
+  const items = await getServerCart(customer.id)
+  assert.deepEqual(items, [])
+})
+
+test('setServerCartItem creates a Cart on first write and persists the line', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 3 })
+
+  const items = await getServerCart(customer.id)
+  assert.equal(items.length, 1)
+  assert.equal(items[0].productId, product.id)
+  assert.equal(items[0].quantity, 3)
+  assert.equal(items[0].variantId, null)
+  assert.equal(items[0].product.vendor.id, vendor.id)
+})
+
+test('setServerCartItem on an existing line REPLACES the quantity (not increments)', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 3 })
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 1 })
+
+  const items = await getServerCart(customer.id)
+  assert.equal(items.length, 1, 'still a single line — not duplicated')
+  assert.equal(items[0].quantity, 1, 'quantity replaced, not summed')
+})
+
+test('setServerCartItem with quantity 0 removes the line', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 2 })
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 0 })
+
+  const items = await getServerCart(customer.id)
+  assert.equal(items.length, 0)
+})
+
+test('removeServerCartItem is a no-op for a line that does not exist', async () => {
+  const customer = await createUser('CUSTOMER')
+  await assert.doesNotReject(() =>
+    removeServerCartItem(customer.id, 'product-that-does-not-exist', null)
+  )
+})
+
+test('clearServerCart empties all lines but keeps the Cart row', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const productA = await createActiveProduct(vendor.id, { stock: 10 })
+  const productB = await createActiveProduct(vendor.id, { stock: 10, slug: 'second-product' })
+
+  await setServerCartItem(customer.id, { productId: productA.id, quantity: 1 })
+  await setServerCartItem(customer.id, { productId: productB.id, quantity: 1 })
+
+  await clearServerCart(customer.id)
+
+  const items = await getServerCart(customer.id)
+  assert.deepEqual(items, [])
+
+  // The Cart row itself should still exist so subsequent writes don't
+  // pay the upsert cost again.
+  const cart = await db.cart.findUnique({ where: { userId: customer.id } })
+  assert.ok(cart, 'Cart row still present after clearing items')
+})
+
+test('mergeLocalCartIntoServer SUMS quantities of overlapping (productId, variantId) lines', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 50 })
+
+  // User had 2 of this product on the server already (from a previous device).
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 2 })
+
+  // Now they log in carrying a local cart with 3 more of the same product.
+  const merged = await mergeLocalCartIntoServer(customer.id, [
+    { productId: product.id, quantity: 3 },
+  ])
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].quantity, 5, '2 + 3 = 5 — local + server merged, not replaced')
+})
+
+test('mergeLocalCartIntoServer creates new lines for products not yet on the server', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const productA = await createActiveProduct(vendor.id, { stock: 10 })
+  const productB = await createActiveProduct(vendor.id, { stock: 10, slug: 'second-product' })
+
+  // Server has only product A
+  await setServerCartItem(customer.id, { productId: productA.id, quantity: 1 })
+
+  // Local has both
+  const merged = await mergeLocalCartIntoServer(customer.id, [
+    { productId: productA.id, quantity: 2 },
+    { productId: productB.id, quantity: 4 },
+  ])
+
+  assert.equal(merged.length, 2)
+  const a = merged.find(line => line.productId === productA.id)!
+  const b = merged.find(line => line.productId === productB.id)!
+  assert.equal(a.quantity, 3, 'productA: 1 server + 2 local = 3')
+  assert.equal(b.quantity, 4, 'productB: 0 server + 4 local = 4')
+})
+
+test('mergeLocalCartIntoServer collapses duplicate local lines before writing', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+
+  // A malformed client sends the same line twice — should collapse to one
+  // row with the summed quantity, not two writes.
+  const merged = await mergeLocalCartIntoServer(customer.id, [
+    { productId: product.id, quantity: 1 },
+    { productId: product.id, quantity: 2 },
+  ])
+
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].quantity, 3)
+})
+
+test('mergeLocalCartIntoServer with empty input returns whatever the server already had', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+  await setServerCartItem(customer.id, { productId: product.id, quantity: 4 })
+
+  const merged = await mergeLocalCartIntoServer(customer.id, [])
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].quantity, 4)
+})
+
+test('mergeLocalCartIntoServer ignores lines with zero or negative quantity', async () => {
+  const { vendor } = await createVendorUser()
+  const customer = await createUser('CUSTOMER')
+  const product = await createActiveProduct(vendor.id, { stock: 10 })
+
+  const merged = await mergeLocalCartIntoServer(customer.id, [
+    { productId: product.id, quantity: 0 },
+    { productId: product.id, quantity: -3 },
+  ])
+
+  assert.equal(merged.length, 0, 'no lines created from invalid quantities')
+})


### PR DESCRIPTION
## Summary

Layer 1 of #90 (Zustand `persist` → `localStorage`) is already in place. This PR adds **layer 2**: a per-user `Cart` row in PostgreSQL so the cart survives across devices and browsers, plus the server primitives the upcoming client-side hydration hook will call.

Schema is unchanged — the `Cart` and `CartItem` models with the right `@@unique([cartId, productId, variantId])` constraint were already there waiting to be used.

### What's in this PR

**`src/domains/orders/cart-persistence.ts`** (new, ~250 LOC) — five server actions, each taking `userId` explicitly so callers handle auth in one place and tests can exercise the logic without mocking the session:

| Action | Behavior |
|---|---|
| `getServerCart(userId)` | Returns `PersistedCartLine[]` joined with current product + variant + vendor data. Empty array (not `null`) for users with no Cart row. |
| `setServerCartItem(userId, line)` | Upsert. Quantity 0 deletes the line. Quantity is **set** (not incremented) on existing lines so the client stays in sync with what the user sees. |
| `removeServerCartItem(userId, productId, variantId?)` | Idempotent delete — no-op if the line doesn't exist. |
| `clearServerCart(userId)` | Empties the lines but keeps the `Cart` row so subsequent writes don't pay the upsert cost. |
| `mergeLocalCartIntoServer(userId, items)` | The login-merge UX. **Sums** quantities of overlapping `(productId, variantId)` lines: anonymous-cart-survives-login. Collapses duplicate local lines defensively (so a malformed client that sends the same line twice can't double-add). Whole batch in a single `$transaction` so a partial merge can't leave the cart in a half-state. Returns the merged cart so the client can hydrate without a second round-trip. |

**Implementation note on the composite unique constraint:** `@@unique([cartId, productId, variantId])` can't be queried via Prisma's composite-key `where` input because `variantId` is nullable (`null != null` in SQL composite keys, a known Prisma quirk). The module does find-then-write instead. The DB constraint still defends against races at the database level.

### Tests

**`test/integration/cart-persistence.test.ts`** (new, 11 tests, run by the integration job since they hit Postgres):

- `getServerCart` returns empty for users with no Cart row
- `setServerCartItem` creates the Cart on first write
- repeated `setServerCartItem` **replaces** (does not increment) the quantity
- `setServerCartItem(0)` removes the line
- `removeServerCartItem` is idempotent for non-existent lines
- `clearServerCart` empties lines but keeps the Cart row
- `mergeLocalCartIntoServer` **sums** quantities of overlapping lines (anonymous-cart-survives-login)
- merge creates new lines for products only present locally
- merge collapses duplicate local lines before writing
- merge with empty input returns the existing server cart
- merge ignores zero / negative quantities

### Out of scope (next PR)

- **Wiring these actions into the Zustand store** so mutations sync to the server transparently for authenticated users, and a hydration hook on sign-in calls `mergeLocalCartIntoServer`. That's a UX-heavy change that needs careful staging — it should land with its own PR so it can be tested and rolled back independently. The server primitives need to be stable first so the client work has something to call.
- **Calling `clearServerCart()` at the end of `createOrder()`** so the user's next visit doesn't resurrect items they just bought. Will land with the client wiring.

This PR closes #90 partially — leaving the issue open until the client wiring lands.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run typecheck:test` — clean.
- [x] `npm test` — 507/507 unit tests still passing (new tests are integration, run by the Integration job).
- [ ] CI green (Verify, Build And Migrate, Integration).
- [ ] Manual verification deferred until the client wiring PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)