### PR TITLE
fix(payments): use crypto.randomBytes for mock payment intent id

### DIFF
--- a/src/domains/payments/provider.ts
+++ b/src/domains/payments/provider.ts
@@ -3,6 +3,7 @@
  * Supports 'mock' (dev) and 'stripe' (production).
  * Switch via PAYMENT_PROVIDER env var.
  */
+import crypto from 'crypto'
 import { getServerEnv } from '@/lib/env'
 
 export interface PaymentIntent {
@@ -38,7 +39,7 @@ export async function createPaymentIntent(
   const env = getServerEnv()
 
   if (env.paymentProvider === 'mock') {
-    const id = `mock_pi_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const id = `mock_pi_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`
     return { id, clientSecret: `${id}_secret`, amount: amountCents }
   }
 


### PR DESCRIPTION
## Summary
- Replaces `Math.random()` with `crypto.randomBytes(4).toString('hex')` when generating the mock payment intent id.
- Resolves CodeQL alert [#1](https://github.com/juanmixto/marketplace/security/code-scanning/1) (`js/insecure-randomness`).

## Context
The mock branch only runs when `PAYMENT_PROVIDER=mock` (dev/test) and never handles real money, so the finding is not exploitable. Fixing it is still cheap and keeps the code-scanning radar clean for real signals.

The id format (`^mock_pi_`) is unchanged, so existing callers and tests that match the prefix are unaffected.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx tsx --test test/features/payments-provider.test.ts` (4/4 pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)