### PR TITLE
feat(incidents): buyer-side server actions for the dispute flow (#29)

### DIFF
--- a/src/domains/incidents/actions.ts
+++ b/src/domains/incidents/actions.ts
@@ -1,0 +1,262 @@
+'use server'
+
+/**
+ * Buyer-side incident (dispute) server actions (#29).
+ *
+ * The admin side of the dispute system already exists under
+ * src/app/api/admin/incidents/** and src/app/(admin)/admin/incidencias.
+ * This module adds the buyer-facing half: opening an incident from a
+ * delivered/shipped order, posting messages on it, and listing the
+ * authenticated buyer's own incidents.
+ *
+ * The buyer pages that consume these actions are intentionally a
+ * follow-up PR — the server primitives need to land first so the UI work
+ * can be reviewed and tested in isolation.
+ *
+ * Auth model (mirrors the rest of src/domains/<domain>/actions.ts):
+ *   - openIncident / addIncidentMessage / getMyIncidents
+ *       require an authenticated session; resource ownership is
+ *       enforced per call (an incident's customerId must match the
+ *       caller's user id).
+ *   - Admin-only operations (resolve, internal notes, etc.) live in
+ *       admin actions / API routes; this file is buyer-only.
+ */
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { redirect } from 'next/navigation'
+import { isAdminRole } from '@/lib/roles'
+import { IncidentStatus, IncidentType } from '@/generated/prisma/enums'
+
+// 72h SLA on first response, per the issue.
+export const INCIDENT_SLA_HOURS = 72
+
+export class IncidentAuthError extends Error {
+  constructor(message = 'No autorizado') {
+    super(message)
+    this.name = 'IncidentAuthError'
+  }
+}
+
+export class IncidentValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IncidentValidationError'
+  }
+}
+
+const openIncidentSchema = z.object({
+  orderId: z.string().min(1),
+  type: z.nativeEnum(IncidentType),
+  description: z.string().min(10).max(5000),
+})
+
+const addMessageSchema = z.object({
+  incidentId: z.string().min(1),
+  body: z.string().min(1).max(5000),
+})
+
+export type OpenIncidentInput = z.infer<typeof openIncidentSchema>
+export type AddIncidentMessageInput = z.infer<typeof addMessageSchema>
+
+/**
+ * Buyer opens a new incident on one of their orders.
+ *
+ * Validation:
+ *   - the order must exist and belong to the caller
+ *   - the order's status must be DELIVERED, SHIPPED or PARTIALLY_SHIPPED
+ *     (anything earlier and the buyer can still cancel; anything later
+ *     means the dispute window is closed)
+ *   - description must be substantive (10..5000 chars)
+ *
+ * The incident starts in OPEN status with slaDeadline = now + 72h.
+ */
+export async function openIncident(
+  input: OpenIncidentInput
+): Promise<{ incidentId: string }> {
+  const session = await getActionSession()
+  if (!session) redirect('/login')
+
+  const parsed = openIncidentSchema.parse(input)
+
+  const order = await db.order.findUnique({
+    where: { id: parsed.orderId },
+    select: { id: true, customerId: true, status: true },
+  })
+
+  if (!order || order.customerId !== session.user.id) {
+    // Not exposing whether the order exists prevents enumeration of
+    // other customers' order ids.
+    throw new IncidentAuthError('Pedido no encontrado')
+  }
+
+  const eligibleStatuses: Array<typeof order.status> = [
+    'DELIVERED',
+    'SHIPPED',
+    'PARTIALLY_SHIPPED',
+  ]
+  if (!eligibleStatuses.includes(order.status)) {
+    throw new IncidentValidationError(
+      'Solo puedes abrir una incidencia sobre pedidos enviados o entregados'
+    )
+  }
+
+  const slaDeadline = new Date(Date.now() + INCIDENT_SLA_HOURS * 60 * 60 * 1000)
+
+  const incident = await db.incident.create({
+    data: {
+      orderId: order.id,
+      customerId: session.user.id,
+      type: parsed.type,
+      description: parsed.description,
+      status: IncidentStatus.OPEN,
+      slaDeadline,
+    },
+    select: { id: true },
+  })
+
+  return { incidentId: incident.id }
+}
+
+/**
+ * Add a message to an existing incident thread.
+ *
+ * The buyer can add messages to their own incidents. Admins can add
+ * messages to any incident (the existing admin route already handles
+ * that path; this function lives here so the buyer pages don't need to
+ * call into admin code, and so a future "vendor messaging" extension
+ * has a single chokepoint).
+ *
+ * `authorRole` is inferred from the session — never trusted from the
+ * client.
+ */
+export async function addIncidentMessage(
+  input: AddIncidentMessageInput
+): Promise<{ messageId: string }> {
+  const session = await getActionSession()
+  if (!session) redirect('/login')
+
+  const parsed = addMessageSchema.parse(input)
+
+  const incident = await db.incident.findUnique({
+    where: { id: parsed.incidentId },
+    select: { id: true, customerId: true, status: true },
+  })
+
+  if (!incident) {
+    throw new IncidentAuthError('Incidencia no encontrada')
+  }
+
+  const isOwner = incident.customerId === session.user.id
+  const isAdmin = isAdminRole(session.user.role)
+  if (!isOwner && !isAdmin) {
+    throw new IncidentAuthError('Incidencia no encontrada')
+  }
+
+  const closedStatuses: Array<typeof incident.status> = ['RESOLVED', 'CLOSED']
+  if (closedStatuses.includes(incident.status)) {
+    throw new IncidentValidationError(
+      'No puedes añadir mensajes a una incidencia cerrada'
+    )
+  }
+
+  const message = await db.incidentMessage.create({
+    data: {
+      incidentId: incident.id,
+      authorId: session.user.id,
+      authorRole: session.user.role,
+      body: parsed.body,
+    },
+    select: { id: true },
+  })
+
+  return { messageId: message.id }
+}
+
+/**
+ * Returns the authenticated buyer's incidents, newest first, with the
+ * order number / total joined for the listing UI. The thread itself is
+ * loaded by a separate read so this stays cheap for /cuenta/incidencias.
+ */
+export async function getMyIncidents() {
+  const session = await getActionSession()
+  if (!session) redirect('/login')
+
+  const incidents = await db.incident.findMany({
+    where: { customerId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      type: true,
+      status: true,
+      slaDeadline: true,
+      resolvedAt: true,
+      createdAt: true,
+      order: {
+        select: { id: true, orderNumber: true, grandTotal: true, status: true },
+      },
+      _count: { select: { messages: true } },
+    },
+  })
+
+  return incidents.map(incident => ({
+    id: incident.id,
+    type: incident.type,
+    status: incident.status,
+    slaDeadline: incident.slaDeadline,
+    slaOverdue:
+      incident.status !== 'RESOLVED' &&
+      incident.status !== 'CLOSED' &&
+      incident.slaDeadline.getTime() < Date.now(),
+    resolvedAt: incident.resolvedAt,
+    createdAt: incident.createdAt,
+    order: {
+      id: incident.order.id,
+      orderNumber: incident.order.orderNumber,
+      grandTotal: Number(incident.order.grandTotal),
+      status: incident.order.status,
+    },
+    messageCount: incident._count.messages,
+  }))
+}
+
+/**
+ * Loads a single incident with its full message thread. The caller must
+ * be the buyer who owns it OR an admin. Used by both the buyer detail
+ * page and (eventually) the admin detail page.
+ */
+export async function getIncidentDetail(incidentId: string) {
+  const session = await getActionSession()
+  if (!session) redirect('/login')
+
+  const incident = await db.incident.findUnique({
+    where: { id: incidentId },
+    include: {
+      order: {
+        select: { id: true, orderNumber: true, grandTotal: true, status: true },
+      },
+      messages: {
+        orderBy: { createdAt: 'asc' },
+        select: {
+          id: true,
+          body: true,
+          authorRole: true,
+          createdAt: true,
+        },
+      },
+    },
+  })
+
+  if (!incident) {
+    throw new IncidentAuthError('Incidencia no encontrada')
+  }
+
+  const isOwner = incident.customerId === session.user.id
+  const isAdmin = isAdminRole(session.user.role)
+  if (!isOwner && !isAdmin) {
+    throw new IncidentAuthError('Incidencia no encontrada')
+  }
+
+  return incident
+}

--- a/test/integration/incidents-buyer.test.ts
+++ b/test/integration/incidents-buyer.test.ts
@@ -1,0 +1,248 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  addIncidentMessage,
+  getIncidentDetail,
+  getMyIncidents,
+  IncidentAuthError,
+  IncidentValidationError,
+  INCIDENT_SLA_HOURS,
+  openIncident,
+} from '@/domains/incidents/actions'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+import { IncidentStatus, IncidentType, OrderStatus } from '@/generated/prisma/enums'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+async function createOrderInStatus(customerId: string, status: OrderStatus) {
+  const order = await db.order.create({
+    data: {
+      orderNumber: `TEST-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      customerId,
+      status,
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 25,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 25,
+    },
+  })
+  return order
+}
+
+test('openIncident creates an OPEN incident with a 72h SLA on a delivered order', async () => {
+  const customer = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'DELIVERED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+
+  const before = Date.now()
+  const { incidentId } = await openIncident({
+    orderId: order.id,
+    type: IncidentType.ITEM_DAMAGED,
+    description: 'Llegó roto, faltan piezas dentro del paquete.',
+  })
+  const after = Date.now()
+
+  const incident = await db.incident.findUniqueOrThrow({ where: { id: incidentId } })
+  assert.equal(incident.status, IncidentStatus.OPEN)
+  assert.equal(incident.customerId, customer.id)
+  assert.equal(incident.orderId, order.id)
+
+  // SLA must land within [72h-since-before, 72h-since-after].
+  const slaMs = incident.slaDeadline.getTime()
+  const expectedMin = before + INCIDENT_SLA_HOURS * 60 * 60 * 1000
+  const expectedMax = after + INCIDENT_SLA_HOURS * 60 * 60 * 1000
+  assert.ok(slaMs >= expectedMin && slaMs <= expectedMax, 'slaDeadline ≈ now + 72h')
+})
+
+test('openIncident accepts SHIPPED and PARTIALLY_SHIPPED orders too', async () => {
+  const customer = await createUser('CUSTOMER')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+
+  for (const status of ['SHIPPED', 'PARTIALLY_SHIPPED'] as OrderStatus[]) {
+    const order = await createOrderInStatus(customer.id, status)
+    await assert.doesNotReject(() =>
+      openIncident({
+        orderId: order.id,
+        type: IncidentType.ITEM_NOT_RECEIVED,
+        description: `Pedido ${status}: el seguimiento no avanza.`,
+      })
+    )
+  }
+})
+
+test('openIncident rejects orders not yet shipped', async () => {
+  const customer = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'PLACED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+
+  await assert.rejects(
+    () =>
+      openIncident({
+        orderId: order.id,
+        type: IncidentType.OTHER,
+        description: 'Algo no va bien con este pedido y ya quiero abrir un caso.',
+      }),
+    IncidentValidationError
+  )
+})
+
+test('openIncident refuses to open a case on someone else order (cross-tenant)', async () => {
+  const customerA = await createUser('CUSTOMER')
+  const customerB = await createUser('CUSTOMER')
+  const orderForA = await createOrderInStatus(customerA.id, 'DELIVERED')
+
+  // B is logged in but is trying to open an incident on A's order.
+  useTestSession(buildSession(customerB.id, 'CUSTOMER'))
+
+  await assert.rejects(
+    () =>
+      openIncident({
+        orderId: orderForA.id,
+        type: IncidentType.QUALITY_ISSUE,
+        description: 'Este pedido no es mío pero quiero meter cizaña.',
+      }),
+    IncidentAuthError
+  )
+})
+
+test('addIncidentMessage lets the owner reply but rejects strangers', async () => {
+  const customer = await createUser('CUSTOMER')
+  const stranger = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'DELIVERED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  const { incidentId } = await openIncident({
+    orderId: order.id,
+    type: IncidentType.WRONG_ITEM,
+    description: 'Me han enviado el producto equivocado.',
+  })
+
+  // Owner can post.
+  const { messageId } = await addIncidentMessage({
+    incidentId,
+    body: 'Adjunto fotos del producto recibido.',
+  })
+  const message = await db.incidentMessage.findUniqueOrThrow({ where: { id: messageId } })
+  assert.equal(message.authorId, customer.id)
+  assert.equal(message.authorRole, 'CUSTOMER')
+
+  // Stranger cannot — same not-found error as a missing incident, no info leak.
+  useTestSession(buildSession(stranger.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => addIncidentMessage({ incidentId, body: 'Hola, soy un intruso.' }),
+    IncidentAuthError
+  )
+})
+
+test('addIncidentMessage rejects messages on closed incidents', async () => {
+  const customer = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'DELIVERED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  const { incidentId } = await openIncident({
+    orderId: order.id,
+    type: IncidentType.MISSING_ITEMS,
+    description: 'Falta un artículo del pedido.',
+  })
+
+  await db.incident.update({
+    where: { id: incidentId },
+    data: { status: IncidentStatus.CLOSED, resolvedAt: new Date() },
+  })
+
+  await assert.rejects(
+    () => addIncidentMessage({ incidentId, body: 'Quiero reabrir esto.' }),
+    IncidentValidationError
+  )
+})
+
+test('getMyIncidents returns only the authenticated buyer incidents, newest first', async () => {
+  const customerA = await createUser('CUSTOMER')
+  const customerB = await createUser('CUSTOMER')
+  const orderA1 = await createOrderInStatus(customerA.id, 'DELIVERED')
+  const orderA2 = await createOrderInStatus(customerA.id, 'DELIVERED')
+  const orderB = await createOrderInStatus(customerB.id, 'DELIVERED')
+
+  useTestSession(buildSession(customerA.id, 'CUSTOMER'))
+  await openIncident({ orderId: orderA1.id, type: IncidentType.OTHER, description: 'Caso A1.' })
+  await openIncident({ orderId: orderA2.id, type: IncidentType.OTHER, description: 'Caso A2.' })
+
+  useTestSession(buildSession(customerB.id, 'CUSTOMER'))
+  await openIncident({ orderId: orderB.id, type: IncidentType.OTHER, description: 'Caso B.' })
+
+  // A only sees A's two incidents.
+  useTestSession(buildSession(customerA.id, 'CUSTOMER'))
+  const list = await getMyIncidents()
+  assert.equal(list.length, 2)
+  assert.deepEqual(
+    new Set(list.map(i => i.order.id)),
+    new Set([orderA1.id, orderA2.id])
+  )
+
+  // Newest-first ordering.
+  assert.ok(list[0].createdAt.getTime() >= list[1].createdAt.getTime())
+})
+
+test('getMyIncidents flags overdue items via slaOverdue', async () => {
+  const customer = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'DELIVERED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  const { incidentId } = await openIncident({
+    orderId: order.id,
+    type: IncidentType.OTHER,
+    description: 'Algo pasó y no sé qué.',
+  })
+
+  // Backdate the SLA so it's overdue.
+  await db.incident.update({
+    where: { id: incidentId },
+    data: { slaDeadline: new Date(Date.now() - 60 * 1000) },
+  })
+
+  const [incident] = await getMyIncidents()
+  assert.equal(incident.slaOverdue, true)
+})
+
+test('getIncidentDetail returns the thread for the owner and rejects strangers', async () => {
+  const customer = await createUser('CUSTOMER')
+  const stranger = await createUser('CUSTOMER')
+  const order = await createOrderInStatus(customer.id, 'DELIVERED')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  const { incidentId } = await openIncident({
+    orderId: order.id,
+    type: IncidentType.QUALITY_ISSUE,
+    description: 'La calidad no es la prometida.',
+  })
+  await addIncidentMessage({ incidentId, body: 'Adjunto fotos.' })
+
+  // Owner sees it with messages.
+  const detail = await getIncidentDetail(incidentId)
+  assert.equal(detail.id, incidentId)
+  assert.equal(detail.messages.length, 1)
+  assert.equal(detail.messages[0].body, 'Adjunto fotos.')
+
+  // Stranger sees not-found.
+  useTestSession(buildSession(stranger.id, 'CUSTOMER'))
+  await assert.rejects(() => getIncidentDetail(incidentId), IncidentAuthError)
+})
+
+// `createActiveProduct` and `createVendorUser` are imported above to keep the
+// helper surface aligned with other integration tests, even though this file
+// doesn't strictly need a vendor — the orders here are bare-bones because we
+// only care about status transitions, not the cart.
+void createActiveProduct
+void createVendorUser

--- a/test/integration/incidents-buyer.test.ts
+++ b/test/integration/incidents-buyer.test.ts
@@ -178,11 +178,23 @@ test('getMyIncidents returns only the authenticated buyer incidents, newest firs
   const orderB = await createOrderInStatus(customerB.id, 'DELIVERED')
 
   useTestSession(buildSession(customerA.id, 'CUSTOMER'))
-  await openIncident({ orderId: orderA1.id, type: IncidentType.OTHER, description: 'Caso A1.' })
-  await openIncident({ orderId: orderA2.id, type: IncidentType.OTHER, description: 'Caso A2.' })
+  await openIncident({
+    orderId: orderA1.id,
+    type: IncidentType.OTHER,
+    description: 'Primer caso del cliente A — descripción válida.',
+  })
+  await openIncident({
+    orderId: orderA2.id,
+    type: IncidentType.OTHER,
+    description: 'Segundo caso del cliente A — descripción válida.',
+  })
 
   useTestSession(buildSession(customerB.id, 'CUSTOMER'))
-  await openIncident({ orderId: orderB.id, type: IncidentType.OTHER, description: 'Caso B.' })
+  await openIncident({
+    orderId: orderB.id,
+    type: IncidentType.OTHER,
+    description: 'Único caso del cliente B — descripción válida.',
+  })
 
   // A only sees A's two incidents.
   useTestSession(buildSession(customerA.id, 'CUSTOMER'))


### PR DESCRIPTION
## Summary

The admin half of #29 already exists (`/admin/incidencias` pages, plus API routes under `src/app/api/admin/incidents/**`). What's missing for buyers to actually use the dispute system is the server action layer that the upcoming buyer pages will call. This PR lands it, with full integration coverage.

### What's in this PR

**`src/domains/incidents/actions.ts`** (new) — five server actions:

- **`openIncident({ orderId, type, description })`** — validates the order belongs to the caller and is in `DELIVERED` / `SHIPPED` / `PARTIALLY_SHIPPED`, then creates the incident in `OPEN` status with `slaDeadline = now + 72h`. "Not found" and "not yours" return the same error so order ids can't be enumerated cross-tenant.
- **`addIncidentMessage({ incidentId, body })`** — buyer (owner) OR admin can post. `authorRole` is inferred from the session, never trusted from the client. Closed (`RESOLVED`/`CLOSED`) incidents reject new messages.
- **`getMyIncidents()`** — list for the authenticated buyer with order summary, message count, and a derived `slaOverdue` flag for surfacing breached cases.
- **`getIncidentDetail(incidentId)`** — single-incident read with the full message thread. Accessible to the buyer who owns it OR to any admin.
- **`INCIDENT_SLA_HOURS`** exported as a constant so future automations and the upcoming buyer pages can reference 72 in one place.
- Custom error classes (`IncidentAuthError`, `IncidentValidationError`) so callers can branch cleanly without regex-matching messages.

**`test/integration/incidents-buyer.test.ts`** (new, 9 tests):

- opens with correct SLA on `DELIVERED`
- accepts `SHIPPED` and `PARTIALLY_SHIPPED`
- rejects `PLACED` (dispute window not open yet)
- cross-tenant attempts return `IncidentAuthError`
- owner can post messages
- strangers cannot post messages (same not-found error, no info leak)
- closed incidents reject new messages
- `getMyIncidents` is per-buyer, newest-first
- `slaOverdue` flag fires on a backdated SLA
- `getIncidentDetail` returns the thread for owner, 404s for strangers

### Verified

- `npm run typecheck` — clean
- `npm run typecheck:test` — clean
- `npm test` — 507/507 passing (the new tests live in `test/integration/`, run by the Integration job)

### Out of scope (tracked under #29)

- **Buyer pages**: `/cuenta/pedidos/[id]` "Reportar problema" button, `/cuenta/incidencias` list, `/cuenta/incidencias/[id]` thread. The server primitives need to land first so the UI work can be reviewed in isolation.
- **Refund creation tied to admin `resolveIncident`** — depends on a product decision about whether to call `stripe.refunds.create` directly from the action or queue it via webhook events. Both approaches are valid; need product input.

### Note on git workflow

Initial commit accidentally landed on local `main`. Recovered cleanly per `docs/git-workflow.md`: created `feat/29-incidents-buyer` from the commit, reset local `main` to `origin/main`, rebased the branch onto the latest `main` (which had picked up #259 in the meantime). Origin's main was never touched. Lesson: always re-check `git status` after a previous PR merge bumped main.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:test` — clean
- [x] `npm test` — 507/507
- [ ] CI green (Verify, Build And Migrate, Integration — the new tests run there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)