### PR TITLE
fix(deps): override @hono/node-server to ^1.19.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -740,9 +740,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "@hono/node-server": "^1.19.13"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an `overrides` block in `package.json` pinning `@hono/node-server` to `^1.19.13`.
- `npm install` resolves it to `1.19.14` (patched).
- Resolves [Dependabot alert #1](https://github.com/juanmixto/marketplace/security/dependabot/1) — middleware bypass via repeated slashes in `serveStatic` (medium).

## Context
The vulnerable package enters transitively via `prisma → @prisma/dev → @hono/node-server`. `@prisma/dev` is a local-only Prisma tool; it never runs in production, so practical exposure is nil. The override closes the alert *for real* instead of relying on a dismiss, which keeps the security panel honest for the next finding.

Patch bump (1.19.11 → 1.19.14), no API surface change. Should be removed once Prisma bumps `@prisma/dev` past 1.19.13 — noted in the commit message.

## Test plan
- [x] `npm install` clean, `npm ls @hono/node-server` shows `1.19.14 overridden`
- [x] `npm audit`: 0 vulnerabilities
- [x] `npx tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)