### PR TITLE
docs(security): real security policy (private advisories + SLAs)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,73 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+This project follows a trunk-based development model: there are no released
+versions, and the only branch that receives updates is `main`. Security
+fixes are applied to `main` and deployed forward — there is no backporting.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Branch | Supported          |
+| ------ | ------------------ |
+| `main` | :white_check_mark: |
+| Any other branch (forks, feature branches, prior commits) | :x: |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+**Please do not open public GitHub issues for security reports.** Use one of
+the private channels below so the issue can be triaged before disclosure.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+1. **Preferred:** [Open a private security advisory](https://github.com/juanmixto/marketplace/security/advisories/new)
+   via GitHub. This creates a private discussion visible only to maintainers
+   and the reporter.
+2. If GitHub is not an option, contact the repository owner directly through
+   their GitHub profile and request a private channel.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the issue and its potential impact.
+- Step-by-step instructions to reproduce, or a minimal proof of concept.
+- The commit SHA or branch you tested against.
+- Any logs, screenshots, or affected URLs (please redact personal data).
+
+### What to expect
+
+| Stage | Target |
+| ----- | ------ |
+| Acknowledgement that the report was received | within **72 hours** |
+| Initial triage and severity assessment       | within **7 days**   |
+| Fix or mitigation plan communicated          | within **30 days** for high/critical issues |
+| Coordinated public disclosure                | after a fix is deployed, or by mutual agreement |
+
+If a report turns out to be out of scope or a duplicate, you will receive a
+short explanation rather than silence.
+
+## Scope
+
+**In scope** — the code in this repository and the running application it
+produces, including:
+
+- Authentication, authorization, and session handling.
+- Payment, checkout, and webhook flows.
+- Server actions, API routes, and database access.
+- Stored data (orders, users, vendor information).
+
+**Out of scope:**
+
+- Findings that require physical access, social engineering, or compromised
+  user devices.
+- Denial-of-service through volumetric traffic or resource exhaustion.
+- Reports generated solely by automated scanners without a working proof of
+  concept.
+- Issues in third-party dependencies that already have a public CVE — please
+  report those upstream. Dependabot security updates are enabled on this
+  repository.
+- Vulnerabilities in `localhost` development tooling that cannot be reached
+  from a production deployment.
+
+## Safe harbor
+
+Good-faith security research conducted in accordance with this policy will
+not be pursued or reported. Please do not access, modify, or destroy data
+that does not belong to you, and stop testing as soon as you have enough
+information to write a report.
+
+Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
Added a security policy document outlining supported versions and vulnerability reporting.

## Summary

- What changed?
- Why was this needed?

## Validation

- [ ] `npm run typecheck:app`
- [ ] `npm run typecheck:test`
- [ ] `npm run test:parallel`
- [ ] `npm run test:db`
- [ ] `npm run build`

## Database Impact

- [ ] No schema changes
- [ ] Prisma schema changed
- [ ] New migration included
- [ ] Seed data updated

## UI Impact

- [ ] No UI changes
- [ ] Public storefront
- [ ] Buyer area
- [ ] Vendor area
- [ ] Admin area

## Notes

- Risks, follow-ups, rollout notes, or screenshots if useful.
