### PR TITLE
test(coverage): unhide server-action coverage + buyer/vendor read smoke (#192)

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -6,10 +6,7 @@
   ],
   "exclude": [
     "src/generated/**",
-    "src/domains/**/actions.ts",
-    "src/domains/catalog/queries.ts",
     "src/lib/auth.ts",
-    "src/domains/orders/cart-store.ts",
     "src/lib/constants.ts",
     "src/lib/db.ts"
   ],

--- a/test/integration/buyer-vendor-reads.test.ts
+++ b/test/integration/buyer-vendor-reads.test.ts
@@ -1,0 +1,164 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getMyOrders,
+  getOrderDetail,
+} from '@/domains/orders/actions'
+import {
+  getMyProducts,
+  getMyProduct,
+  getMyVendorProfile,
+} from '@/domains/vendors/actions'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+// ─── orders / buyer reads ───────────────────────────────────────────────────
+
+test('getMyOrders returns [] for unauthenticated callers', async () => {
+  // No useTestSession() — caller is anonymous.
+  const orders = await getMyOrders()
+  assert.deepEqual(orders, [])
+})
+
+test('getMyOrders returns only the authenticated buyers orders', async () => {
+  const customerA = await createUser('CUSTOMER')
+  const customerB = await createUser('CUSTOMER')
+
+  await db.order.create({
+    data: {
+      orderNumber: 'TEST-A-1',
+      customerId: customerA.id,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+    },
+  })
+  await db.order.create({
+    data: {
+      orderNumber: 'TEST-B-1',
+      customerId: customerB.id,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 20,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 20,
+    },
+  })
+
+  useTestSession(buildSession(customerA.id, 'CUSTOMER'))
+  const ordersForA = await getMyOrders()
+  assert.equal(ordersForA.length, 1)
+  assert.equal(ordersForA[0].orderNumber, 'TEST-A-1')
+})
+
+test('getOrderDetail returns null for unauthenticated callers', async () => {
+  const result = await getOrderDetail('any-id')
+  assert.equal(result, null)
+})
+
+test('getOrderDetail returns null when the order belongs to someone else', async () => {
+  const customerA = await createUser('CUSTOMER')
+  const customerB = await createUser('CUSTOMER')
+
+  const orderForA = await db.order.create({
+    data: {
+      orderNumber: 'TEST-A-2',
+      customerId: customerA.id,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+    },
+  })
+
+  useTestSession(buildSession(customerB.id, 'CUSTOMER'))
+  const result = await getOrderDetail(orderForA.id)
+  assert.equal(result, null, 'cross-tenant read must not leak')
+})
+
+test('getOrderDetail returns the order and its lines for the owner', async () => {
+  const customer = await createUser('CUSTOMER')
+  const order = await db.order.create({
+    data: {
+      orderNumber: 'TEST-OWNED',
+      customerId: customer.id,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+    },
+  })
+
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  const result = await getOrderDetail(order.id)
+  assert.ok(result)
+  assert.equal(result?.orderNumber, 'TEST-OWNED')
+})
+
+// ─── vendor reads ───────────────────────────────────────────────────────────
+
+test('getMyVendorProfile returns the authenticated vendors profile', async () => {
+  const { user, vendor } = await createVendorUser()
+  useTestSession(buildSession(user.id, 'VENDOR'))
+
+  const profile = await getMyVendorProfile()
+  assert.ok(profile)
+  assert.equal(profile?.id, vendor.id)
+})
+
+test('getMyProducts returns only products belonging to the authenticated vendor', async () => {
+  const vendorA = await createVendorUser()
+  const vendorB = await createVendorUser()
+  await createActiveProduct(vendorA.vendor.id, { stock: 5 })
+  await createActiveProduct(vendorA.vendor.id, { stock: 5, slug: 'a-second' })
+  await createActiveProduct(vendorB.vendor.id, { stock: 5, slug: 'b-only' })
+
+  useTestSession(buildSession(vendorA.user.id, 'VENDOR'))
+  const productsForA = await getMyProducts()
+  assert.equal(productsForA.length, 2)
+  assert.ok(productsForA.every(product => product.vendorId === vendorA.vendor.id))
+})
+
+test('getMyProduct returns null when the product belongs to a different vendor', async () => {
+  const vendorA = await createVendorUser()
+  const vendorB = await createVendorUser()
+  const productOfB = await createActiveProduct(vendorB.vendor.id, { stock: 5 })
+
+  useTestSession(buildSession(vendorA.user.id, 'VENDOR'))
+  const result = await getMyProduct(productOfB.id)
+  assert.equal(result, null, 'cross-tenant vendor read must not leak')
+})
+
+test('getMyProduct returns the product when it belongs to the caller', async () => {
+  const { user, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { stock: 5 })
+
+  useTestSession(buildSession(user.id, 'VENDOR'))
+  const result = await getMyProduct(product.id)
+  assert.ok(result)
+  assert.equal(result?.id, product.id)
+})

--- a/test/integration/buyer-vendor-reads.test.ts
+++ b/test/integration/buyer-vendor-reads.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
 // ─── orders / buyer reads ───────────────────────────────────────────────────
 
 test('getMyOrders returns [] for unauthenticated callers', async () => {
-  // No useTestSession() — caller is anonymous.
+  useTestSession(null)
   const orders = await getMyOrders()
   assert.deepEqual(orders, [])
 })
@@ -72,6 +72,7 @@ test('getMyOrders returns only the authenticated buyers orders', async () => {
 })
 
 test('getOrderDetail returns null for unauthenticated callers', async () => {
+  useTestSession(null)
   const result = await getOrderDetail('any-id')
   assert.equal(result, null)
 })


### PR DESCRIPTION
## Summary

The c8 config was excluding `src/domains/**/actions.ts` (and a couple of other domain files) from coverage. The existing feature + integration tests were doing real work, but their coverage wasn't being counted. Result: the coverage report looked rosy on files that had **zero** tests, and hid the actual gap on the files the suite was exercising.

This PR makes the gap visible and lifts the baseline a bit on the read paths the suite was skipping entirely.

### `.c8rc.json`

Removes the broad domain exclusions:

- `src/domains/**/actions.ts` — existing tests cover several
- `src/domains/catalog/queries.ts` — covered by feature tests
- `src/domains/orders/cart-store.ts` — has its own dedicated test

Keeps only the genuinely-untestable infra files:

- `src/lib/auth.ts` (NextAuth config)
- `src/lib/constants.ts` (pure data, no logic)
- `src/lib/db.ts` (Prisma client setup)

`check-coverage` stays `false` so removing exclusions can't fail CI while the percentage rises.

### `test/integration/buyer-vendor-reads.test.ts` (new, 9 tests)

Smoke coverage for the read paths the existing suite wasn't touching:

- `getMyOrders` — anonymous → `[]`; cross-tenant isolation
- `getOrderDetail` — anonymous → `null`; cross-tenant → `null`; owner → row
- `getMyVendorProfile` — auth path
- `getMyProducts` — cross-vendor isolation
- `getMyProduct` — cross-vendor → `null`; owner → row

Each test exercises the **auth-and-ownership** half of the action body — exactly the half the issue called out as highest-risk (silent cross-tenant data leaks).

### Out of scope (issue stays open as long-running tech-debt tracker)

- Happy/error coverage for the heavier mutation actions (`createProduct`, `advanceFulfillment`, admin moderation flows). Best added incrementally by whoever touches each domain next, now that coverage is visible.

## Verified

- `npm run typecheck` — clean
- `npm run typecheck:test` — clean
- `npm test` — 519/519 unit/feature tests passing (the 9 new tests live in `test/integration/`, run by the Integration job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)