### PR TITLE
feat(incidents): SLA progress visualization on buyer pages (#139)

### DIFF
--- a/src/app/(buyer)/cuenta/incidencias/[id]/page.tsx
+++ b/src/app/(buyer)/cuenta/incidencias/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getIncidentDetail } from '@/domains/incidents/actions'
 import { IncidentAuthError } from '@/domains/incidents/errors'
+import { SlaProgress } from '@/components/incidents/SlaProgress'
 import { getServerT } from '@/i18n/server'
 import type { TranslationKeys } from '@/i18n/locales'
 import { IncidentReplyForm } from './IncidentReplyForm'
@@ -42,7 +43,7 @@ export default async function IncidentDetailPage({ params }: Props) {
       </Link>
 
       <div className="mt-4 flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0 flex-1">
           <h1 className="text-2xl font-bold text-[var(--foreground)]">
             {t('incident.list.case')} #{incident.id.slice(-6).toUpperCase()}
           </h1>
@@ -54,6 +55,10 @@ export default async function IncidentDetailPage({ params }: Props) {
         <span className="shrink-0 rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
           {t(statusKey)}
         </span>
+      </div>
+
+      <div className="mt-4">
+        <SlaProgress deadline={new Date(incident.slaDeadline)} hidden={isClosed} />
       </div>
 
       {/* Initial description */}

--- a/src/app/(buyer)/cuenta/incidencias/page.tsx
+++ b/src/app/(buyer)/cuenta/incidencias/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getMyIncidents } from '@/domains/incidents/actions'
 import { getServerT } from '@/i18n/server'
 import type { TranslationKeys } from '@/i18n/locales'
+import { SlaProgress } from '@/components/incidents/SlaProgress'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getServerT()
@@ -28,6 +29,8 @@ export default async function IncidentsListPage() {
           {incidents.map(incident => {
             const typeKey = `incident.type.${incident.type}` as TranslationKeys
             const statusKey = `incident.status.${incident.status}` as TranslationKeys
+            const isClosed =
+              incident.status === 'RESOLVED' || incident.status === 'CLOSED'
             return (
               <li key={incident.id}>
                 <Link
@@ -47,17 +50,21 @@ export default async function IncidentsListPage() {
                     </div>
                     <span
                       className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium ${
-                        incident.slaOverdue
-                          ? 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300'
-                          : incident.status === 'RESOLVED' || incident.status === 'CLOSED'
-                            ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
+                        isClosed
+                          ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
+                          : incident.slaOverdue
+                            ? 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300'
                             : 'bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300'
                       }`}
                     >
-                      {incident.slaOverdue
-                        ? `${t('incident.list.sla')}: ${t('incident.list.slaOverdue')}`
-                        : t(statusKey)}
+                      {t(statusKey)}
                     </span>
+                  </div>
+                  <div className="mt-3">
+                    <SlaProgress
+                      deadline={new Date(incident.slaDeadline)}
+                      hidden={isClosed}
+                    />
                   </div>
                 </Link>
               </li>

--- a/src/components/incidents/SlaProgress.tsx
+++ b/src/components/incidents/SlaProgress.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+/**
+ * SLA progress visualization for incident threads (#139).
+ *
+ * Renders a slim horizontal bar showing how much of the 72h response
+ * window has been consumed, plus a human-readable remaining-time label.
+ * Three states:
+ *
+ *   - on-track  (≥ 25 % remaining)         emerald
+ *   - urgent    (< 25 % remaining)         amber
+ *   - overdue   (deadline already passed)  red
+ *
+ * Pure presentation: takes a Date, derives everything client-side so the
+ * countdown updates correctly across timezones / locale changes without
+ * server round-trips. Closed cases (RESOLVED / CLOSED) hide the bar
+ * entirely — pass `hidden` from the parent.
+ */
+
+import { useMemo } from 'react'
+import { useT } from '@/i18n'
+
+interface Props {
+  /** Absolute SLA deadline. Comes from Incident.slaDeadline. */
+  deadline: Date
+  /** When true, the bar isn't rendered (use for resolved/closed). */
+  hidden?: boolean
+  /**
+   * The full SLA window in hours used to draw the "100%" baseline.
+   * Defaults to 72h to match INCIDENT_SLA_HOURS in src/domains/incidents/errors.ts.
+   * Exposed as a prop so future configurable SLAs don't need a separate component.
+   */
+  windowHours?: number
+}
+
+function formatRemaining(msRemaining: number, t: (key: string) => string): string {
+  if (msRemaining <= 0) {
+    return t('incident.sla.overdue')
+  }
+  const minutes = Math.round(msRemaining / 60_000)
+  if (minutes < 60) {
+    return `${minutes} min`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours} h`
+  }
+  const days = Math.floor(hours / 24)
+  const remHours = hours % 24
+  return remHours > 0 ? `${days} d ${remHours} h` : `${days} d`
+}
+
+export function SlaProgress({ deadline, hidden, windowHours = 72 }: Props) {
+  const t = useT()
+
+  const { fillPct, state, label } = useMemo(() => {
+    const now = Date.now()
+    const deadlineMs = deadline.getTime()
+    const windowMs = windowHours * 60 * 60 * 1000
+    const startMs = deadlineMs - windowMs
+    const elapsedMs = Math.max(0, now - startMs)
+    const remainingMs = deadlineMs - now
+
+    // Bar fills from 0 → 100% as time runs out.
+    const rawPct = (elapsedMs / windowMs) * 100
+    const clampedPct = Math.max(0, Math.min(100, rawPct))
+
+    let nextState: 'on-track' | 'urgent' | 'overdue'
+    if (remainingMs <= 0) {
+      nextState = 'overdue'
+    } else if (remainingMs / windowMs < 0.25) {
+      nextState = 'urgent'
+    } else {
+      nextState = 'on-track'
+    }
+
+    return {
+      fillPct: clampedPct,
+      state: nextState,
+      label: formatRemaining(remainingMs, t as (key: string) => string),
+    }
+  }, [deadline, windowHours, t])
+
+  if (hidden) return null
+
+  const fillClass =
+    state === 'overdue'
+      ? 'bg-red-500 dark:bg-red-400'
+      : state === 'urgent'
+        ? 'bg-amber-500 dark:bg-amber-400'
+        : 'bg-emerald-500 dark:bg-emerald-400'
+
+  const labelClass =
+    state === 'overdue'
+      ? 'text-red-700 dark:text-red-300'
+      : state === 'urgent'
+        ? 'text-amber-700 dark:text-amber-300'
+        : 'text-emerald-700 dark:text-emerald-300'
+
+  return (
+    <div className="space-y-1">
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-raised)]"
+        role="progressbar"
+        aria-valuenow={Math.round(fillPct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={t('incident.sla.label')}
+      >
+        <div
+          className={`h-full transition-all ${fillClass}`}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+      <p className={`text-[11px] font-medium ${labelClass}`}>
+        {t('incident.sla.label')}: {label}
+      </p>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -384,6 +384,8 @@ const en: Record<TranslationKeys, string> = {
   'incident.author.VENDOR': 'Vendor',
   'incident.error.generic': 'We could not complete the operation. Please try again.',
   'incident.error.tooShort': 'The description must be at least 10 characters long.',
+  'incident.sla.label': 'Response deadline',
+  'incident.sla.overdue': 'Overdue',
 
   // Account – nav menu
   'account.nav.orders.label': 'My orders',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -382,6 +382,8 @@ const es = {
   'incident.author.VENDOR': 'Productor',
   'incident.error.generic': 'No pudimos completar la operación. Inténtalo de nuevo.',
   'incident.error.tooShort': 'La descripción debe tener al menos 10 caracteres.',
+  'incident.sla.label': 'Plazo de respuesta',
+  'incident.sla.overdue': 'Vencido',
 
   // Account – nav menu
   'account.nav.orders.label': 'Mis pedidos',


### PR DESCRIPTION
## Summary

#139 lists five wishlist enhancements for the dispute system (SLA dashboard, escalation, communication, evidence, resolution drafts). This PR delivers the **most user-visible one**: an SLA progress bar that turns the abstract `slaDeadline` into a "you have N hours left" cue with three colour states.

### What's in this PR

**`src/components/incidents/SlaProgress.tsx`** (new)

Pure client component. Takes a `Date` deadline + optional `windowHours` (defaults to 72 to match `INCIDENT_SLA_HOURS`). Computes elapsed / remaining client-side so the countdown is accurate regardless of timezone or stale SSR.

Three colour states:

| State | Trigger | Colour |
|---|---|---|
| `on-track` | ≥ 25 % time remaining | emerald |
| `urgent` | < 25 % time remaining | amber |
| `overdue` | deadline passed | red |

Renders a slim progress bar + a human-readable label ("12 h", "45 min", "2 d", "Overdue"). Hides itself entirely when `hidden` is true so the parent can suppress it on `RESOLVED` / `CLOSED` cases.

Accessible: `role="progressbar"`, `aria-valuenow / min / max`, `aria-label`.

### Wired into

- `/cuenta/incidencias` — under each list card. The list also now uses the status badge for active cases (instead of the bespoke "SLA: Vencido" string) because the progress bar carries the deadline information visually.
- `/cuenta/incidencias/[id]` — under the header.

### i18n

`incident.sla.label` / `incident.sla.overdue` in both `es` and `en`.

### Verified

- `npm run typecheck` — clean
- `npm test` — **519/519** passing

### Closes

Closes the **SLA Dashboard** ask from #139. Issue stays open as a tracker for the other four wishlist items:

- Auto-escalation when a case crosses its SLA
- Attachments / evidence upload (the blob storage abstraction from #262 makes this reusable but the UI is its own ticket)
- Resolution draft templates with explanation
- Vendor visibility into incidents (currently buyer + admin only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)