### PR TITLE
fix(ui): consistent theme toggle position across portals

### DIFF
--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { UserCircleIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 interface Props {
   user: { name?: string | null; email?: string | null; role: string }
@@ -28,7 +29,10 @@ export function AdminHeader({ user }: Props) {
         </Link>
       </div>
 
-      <div className="relative">
+      <div className="flex items-center gap-1">
+        <ThemeToggle />
+
+        <div className="relative">
         <button
           onClick={() => setOpen(v => !v)}
           className="flex items-center gap-2 rounded-xl px-3 py-1.5 text-sm text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
@@ -62,6 +66,7 @@ export function AdminHeader({ user }: Props) {
             </div>
           </>
         )}
+        </div>
       </div>
     </header>
   )

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -10,7 +10,6 @@ import {
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import { adminNavItems } from '@/lib/navigation'
-import { ThemeToggle } from '@/components/ThemeToggle'
 
 const NAV_META = {
   '/admin/dashboard':    HomeIcon,
@@ -80,10 +79,6 @@ export function AdminSidebar() {
           <ArrowTopRightOnSquareIcon className="h-4 w-4" />
           Ver tienda
         </Link>
-        <div className="flex items-center justify-between px-3 py-1">
-          <span className="text-xs text-[var(--muted)]">Tema</span>
-          <ThemeToggle />
-        </div>
       </div>
     </aside>
   )

--- a/src/components/vendor/VendorHeader.tsx
+++ b/src/components/vendor/VendorHeader.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { UserCircleIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 interface Props {
   user: { name?: string | null; email?: string | null }
@@ -34,7 +35,10 @@ export function VendorHeader({ user, vendor }: Props) {
         )}
       </div>
 
-      <div className="relative">
+      <div className="flex items-center gap-1">
+        <ThemeToggle />
+
+        <div className="relative">
         <button
           onClick={() => setOpen(v => !v)}
           className="flex items-center gap-2 rounded-xl px-3 py-1.5 text-sm text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
@@ -65,6 +69,7 @@ export function VendorHeader({ user, vendor }: Props) {
             </div>
           </>
         )}
+        </div>
       </div>
     </header>
   )

--- a/src/components/vendor/VendorSidebar.tsx
+++ b/src/components/vendor/VendorSidebar.tsx
@@ -8,7 +8,6 @@ import {
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import { vendorNavItems } from '@/lib/navigation'
-import { ThemeToggle } from '@/components/ThemeToggle'
 
 const NAV_META = {
   '/vendor/dashboard':    HomeIcon,
@@ -76,8 +75,8 @@ export function VendorSidebar({ vendor }: Props) {
         })}
       </nav>
 
-      <div className="border-t border-[var(--border)] p-2 space-y-0.5">
-        {vendor?.slug && (
+      {vendor?.slug && (
+        <div className="border-t border-[var(--border)] p-2 space-y-0.5">
           <Link
             href={`/productores/${vendor.slug}`}
             target="_blank"
@@ -86,12 +85,8 @@ export function VendorSidebar({ vendor }: Props) {
             <ArrowTopRightOnSquareIcon className="h-4 w-4" />
             Ver mi tienda
           </Link>
-        )}
-        <div className="flex items-center justify-between px-3 py-1">
-          <span className="text-xs text-[var(--muted)]">Tema</span>
-          <ThemeToggle />
         </div>
-      </div>
+      )}
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- Buyer header already had the theme toggle in the top-right action cluster; vendor and admin panels put it at the bottom of the sidebar, forcing users to relearn its position per portal.
- Move `ThemeToggle` into `VendorHeader` and `AdminHeader` next to the user menu, and drop the sidebar "Tema" row.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 519/519 pass
- [ ] Manual: open buyer, vendor, and admin layouts and confirm the theme toggle sits in the top-right in all three