### PR TITLE
fix(vendor-hero): readable visual-label pill on any hero image

### DIFF
--- a/src/app/(public)/productores/[slug]/page.tsx
+++ b/src/app/(public)/productores/[slug]/page.tsx
@@ -148,8 +148,9 @@ export default async function VendorPublicPage({ params }: Props) {
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
 
-          {/* Visual label badge */}
-          <span className="absolute left-4 top-4 rounded-full bg-white/20 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">
+          {/* Visual label badge — solid dark pill so it stays readable on any
+              hero image (bright/washed-out photos as well as dark ones). */}
+          <span className="absolute left-4 top-4 inline-flex items-center rounded-full bg-black/60 px-3 py-1 text-xs font-semibold text-white shadow-sm ring-1 ring-white/25 backdrop-blur-sm">
             {visualLabel}
           </span>
         </div>


### PR DESCRIPTION
## Summary
- The \"Huerta de temporada\" style badge at the top of the vendor profile hero used \`bg-white/20\` + white text. On bright/washed-out photos the pill disappeared in light mode, and in dark mode the low-contrast translucent white also vanished.
- Swapped it for a solid \`bg-black/60\` pill with a \`ring-1 ring-white/25\` and shadow so the label stays legible over any hero image in both themes.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 531 passing
- [ ] Visual QA: open \`/productores/finca-garcia\` (bright leafy hero) in light and dark mode and confirm the top-left \"Huerta de temporada\" pill is readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)