### PR TITLE
fix(vendor-profile): cover image, local uploads, circular avatar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# user-uploaded images (LocalUploader writes here in dev/self-hosted)
+/public/uploads/*
+!/public/uploads/.gitkeep
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/src/app/(public)/productores/[slug]/page.tsx
+++ b/src/app/(public)/productores/[slug]/page.tsx
@@ -159,14 +159,14 @@ export default async function VendorPublicPage({ params }: Props) {
         <div className="absolute bottom-0 left-0 right-0 p-5 sm:p-8">
           <div className="flex items-end gap-4 sm:gap-6">
             {/* Logo */}
-            <div className="flex h-20 w-20 sm:h-24 sm:w-24 shrink-0 items-center justify-center rounded-2xl border-2 border-white/30 bg-white/10 text-4xl sm:text-5xl backdrop-blur-md shadow-lg">
+            <div className="flex h-20 w-20 sm:h-24 sm:w-24 shrink-0 items-center justify-center overflow-hidden rounded-full border-2 border-white/30 bg-white/10 text-4xl sm:text-5xl backdrop-blur-md shadow-lg">
               {vendor.logo ? (
                 <Image
                   src={vendor.logo}
                   alt={copy.vendor.logoAlt(vendor.displayName)}
                   width={96}
                   height={96}
-                  className="rounded-2xl object-cover"
+                  className="h-full w-full rounded-full object-cover"
                 />
               ) : (
                 '🌾'

--- a/src/components/vendor/SingleImageUpload.tsx
+++ b/src/components/vendor/SingleImageUpload.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { ArrowUpTrayIcon, XMarkIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { isAllowedImageUrl } from '@/lib/image-validation'
+
+const MAX_BYTES = 5 * 1024 * 1024
+const ACCEPTED = new Set(['image/jpeg', 'image/png', 'image/webp'])
+
+interface Props {
+  label: string
+  hint?: string
+  value: string
+  onChange: (url: string) => void
+  shape?: 'circle' | 'square' | 'banner'
+  id: string
+}
+
+export function SingleImageUpload({ label, hint, value, onChange, shape = 'square', id }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [manualUrl, setManualUrl] = useState(value)
+
+  const previewValid = value !== '' && isAllowedImageUrl(value)
+
+  const previewShapeClass =
+    shape === 'circle'
+      ? 'h-24 w-24 rounded-full'
+      : shape === 'banner'
+        ? 'h-28 w-full rounded-xl'
+        : 'h-24 w-24 rounded-xl'
+
+  async function upload(file: File) {
+    setError(null)
+    if (!ACCEPTED.has(file.type)) {
+      setError('Formato no soportado. Usa JPG, PNG o WebP.')
+      return
+    }
+    if (file.size > MAX_BYTES) {
+      setError('La imagen supera los 5 MB.')
+      return
+    }
+    setUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const res = await fetch('/api/upload', { method: 'POST', body: formData })
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(data.error ?? 'Error al subir la imagen')
+      }
+      const data = (await res.json()) as { url: string }
+      onChange(data.url)
+      setManualUrl(data.url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al subir la imagen')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  function handleRemove() {
+    onChange('')
+    setManualUrl('')
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  function commitManualUrl() {
+    const trimmed = manualUrl.trim()
+    if (trimmed === value) return
+    if (trimmed === '') {
+      onChange('')
+      return
+    }
+    if (!isAllowedImageUrl(trimmed)) {
+      setError('URL no permitida. Usa cloudinary.com, uploadthing.com, unsplash.com o una imagen subida aquí.')
+      return
+    }
+    setError(null)
+    onChange(trimmed)
+  }
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={id} className="block text-sm font-medium text-[var(--foreground)]">
+        {label}
+      </label>
+      {hint && <p className="text-xs text-[var(--muted)]">{hint}</p>}
+
+      <div className="flex items-start gap-4">
+        {previewValid && (
+          <div className={`relative shrink-0 overflow-hidden border border-[var(--border)] bg-[var(--surface-raised,transparent)] ${previewShapeClass}`}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={value} alt="Vista previa" className="h-full w-full object-cover" />
+          </div>
+        )}
+        <div className="flex-1 space-y-2">
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              disabled={uploading}
+              className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-medium text-[var(--foreground)] hover:border-emerald-400 hover:text-emerald-700 disabled:opacity-60 dark:hover:border-emerald-600 dark:hover:text-emerald-300"
+            >
+              {uploading ? (
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-300 border-t-emerald-600" />
+              ) : (
+                <ArrowUpTrayIcon className="h-4 w-4" />
+              )}
+              {uploading ? 'Subiendo...' : 'Subir desde mi equipo'}
+            </button>
+            {previewValid && (
+              <button
+                type="button"
+                onClick={handleRemove}
+                className="inline-flex items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-medium text-red-600 hover:border-red-300 dark:text-red-400 dark:hover:border-red-800"
+              >
+                <XMarkIcon className="h-4 w-4" />
+                Quitar
+              </button>
+            )}
+          </div>
+          <input
+            ref={inputRef}
+            id={`${id}-file`}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={event => {
+              const file = event.target.files?.[0]
+              if (file) void upload(file)
+            }}
+          />
+          <div>
+            <input
+              id={id}
+              type="text"
+              value={manualUrl}
+              onChange={e => setManualUrl(e.target.value)}
+              onBlur={commitManualUrl}
+              placeholder="...o pega una URL (cloudinary, unsplash, uploadthing)"
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
+            />
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-2.5 text-xs text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-400">
+          <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/vendor/VendorProfileForm.tsx
+++ b/src/components/vendor/VendorProfileForm.tsx
@@ -1,26 +1,30 @@
 'use client'
 
 import { useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { updateVendorProfile } from '@/domains/vendors/actions'
 import { isAllowedImageUrl } from '@/lib/image-validation'
+import { SingleImageUpload } from './SingleImageUpload'
 import type { Vendor } from '@/generated/prisma/client'
+
+const imageFieldSchema = z
+  .union([z.string(), z.literal(''), z.undefined()])
+  .transform(v => (v ?? '').trim())
+  .refine(
+    v => v === '' || isAllowedImageUrl(v),
+    'URL inválida. Sube una imagen o usa cloudinary.com, uploadthing.com o unsplash.com (HTTPS)',
+  )
 
 const profileSchema = z.object({
   displayName: z.string().min(3, 'Mínimo 3 caracteres').max(80),
   description: z.string().max(2000).optional(),
   location: z.string().max(100).optional(),
-  logo: z
-    .union([z.string(), z.literal(''), z.undefined()])
-    .transform(v => (v ?? '').trim())
-    .refine(
-      v => v === '' || isAllowedImageUrl(v),
-      'URL inválida. Usa cloudinary.com, uploadthing.com o unsplash.com (HTTPS)',
-    ),
+  logo: imageFieldSchema,
+  coverImage: imageFieldSchema,
   orderCutoffTime: z
     .union([z.string().regex(/^\d{2}:\d{2}$/, 'Formato HH:MM'), z.literal(''), z.undefined()])
     .transform(v => v || undefined),
@@ -43,7 +47,7 @@ export function VendorProfileForm({ vendor }: Props) {
   const {
     register,
     handleSubmit,
-    watch,
+    control,
     formState: { errors, isSubmitting, isDirty },
   } = useForm<ProfileFormInput, unknown, ProfileFormValues>({
     resolver: zodResolver(profileSchema),
@@ -52,15 +56,13 @@ export function VendorProfileForm({ vendor }: Props) {
       description: vendor.description ?? '',
       location: vendor.location ?? '',
       logo: vendor.logo ?? '',
+      coverImage: vendor.coverImage ?? '',
       orderCutoffTime: vendor.orderCutoffTime ?? '',
       preparationDays: vendor.preparationDays ?? 2,
       iban: vendor.iban ?? '',
       bankAccountName: vendor.bankAccountName ?? '',
     },
   })
-
-  const logoUrl = (watch('logo') ?? '').trim()
-  const logoPreviewValid = logoUrl !== '' && isAllowedImageUrl(logoUrl)
 
   async function onSubmit(values: ProfileFormValues) {
     setServerError(null)
@@ -106,26 +108,41 @@ export function VendorProfileForm({ vendor }: Props) {
           {...register('location')}
         />
 
-        <div className="space-y-2">
-          <Input
-            label="Foto del productor (URL)"
-            placeholder="https://res.cloudinary.com/..."
-            hint="Sube tu foto a Cloudinary, UploadThing o Unsplash y pega la URL aquí."
-            error={errors.logo?.message}
-            {...register('logo')}
-          />
-          {logoPreviewValid && (
-            <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3">
-              <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-full border border-[var(--border)] bg-[var(--surface-muted,transparent)]">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={logoUrl} alt="Vista previa" className="h-full w-full object-cover" />
-              </div>
-              <p className="text-xs text-[var(--muted)]">
-                Así se verá tu foto en el listado de productores.
-              </p>
-            </div>
+        <Controller
+          control={control}
+          name="logo"
+          render={({ field }) => (
+            <SingleImageUpload
+              id="vendor-logo"
+              label="Foto de perfil"
+              hint="Se muestra redonda junto al nombre de tu tienda. Sube un JPG/PNG/WebP (máx. 5 MB) o pega una URL."
+              value={field.value ?? ''}
+              onChange={field.onChange}
+              shape="circle"
+            />
           )}
-        </div>
+        />
+        {errors.logo?.message && (
+          <p className="text-xs text-red-600 dark:text-red-400">{errors.logo.message}</p>
+        )}
+
+        <Controller
+          control={control}
+          name="coverImage"
+          render={({ field }) => (
+            <SingleImageUpload
+              id="vendor-cover"
+              label="Imagen de portada"
+              hint="Se usa como fondo del escaparate de tu tienda. Recomendado 1600×500. Si la dejas vacía usaremos una imagen por defecto."
+              value={field.value ?? ''}
+              onChange={field.onChange}
+              shape="banner"
+            />
+          )}
+        />
+        {errors.coverImage?.message && (
+          <p className="text-xs text-red-600 dark:text-red-400">{errors.coverImage.message}</p>
+        )}
       </section>
 
       {/* Logistics */}

--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -295,11 +295,18 @@ const profileSchema = z.object({
   description: z.string().max(2000).optional(),
   location: z.string().max(100).optional(),
   logo: z
-    .union([z.string().url(), z.literal('')])
+    .union([z.string(), z.literal('')])
     .optional()
-    .transform(v => (v ? v : null))
+    .transform(v => (v ? v.trim() : null))
     .refine(v => v === null || isAllowedImageUrl(v), {
-      message: 'Dominio no permitido. Usa cloudinary.com, uploadthing.com o unsplash.com',
+      message: 'Imagen no permitida. Súbela desde tu equipo o pega una URL permitida.',
+    }),
+  coverImage: z
+    .union([z.string(), z.literal('')])
+    .optional()
+    .transform(v => (v ? v.trim() : null))
+    .refine(v => v === null || isAllowedImageUrl(v), {
+      message: 'Imagen no permitida. Súbela desde tu equipo o pega una URL permitida.',
     }),
   orderCutoffTime: z.string().regex(/^\d{2}:\d{2}$/).optional(),
   preparationDays: z.coerce.number().int().min(0).max(30).optional(),


### PR DESCRIPTION
## Summary
- Vendor profile form can now edit **both** `logo` and `coverImage` — the cover field was missing, which is why only one of the two photos in the public escaparate was editable.
- New `SingleImageUpload` component posts to the existing `/api/upload` endpoint. With no `BLOB_READ_WRITE_TOKEN` set, `LocalUploader` writes to `public/uploads/` and the file is served by Next.js — no Cloudinary/UploadThing account needed. URL paste is kept as a fallback.
- Public producer page (`/productores/[slug]`) now renders the avatar as a circle instead of a rounded square.
- `public/uploads/*` added to `.gitignore` (with a `.gitkeep`) so user uploads stay out of git.

## Architecture notes
- Storage abstraction already existed in [src/lib/blob-storage.ts](src/lib/blob-storage.ts): `LocalUploader` (default) → `public/uploads/`, `VercelBlobUploader` when the token is set. No changes needed there.
- `/uploads/...` paths are already allowlisted by [isAllowedImageUrl](src/lib/image-validation.ts#L57), so the Zod validation in the server action accepts them alongside the remote allowlist.
- When the shop outgrows local disk, flipping `BLOB_READ_WRITE_TOKEN` (or adding an S3 `BlobUploader`) switches storage with zero call-site changes.

## Test plan
- [ ] `/vendor/perfil` → upload a new logo from disk → save → reload → avatar shows on `/productores/<slug>` as a circle.
- [ ] Upload a cover image → save → appears as the hero background on the public page.
- [ ] Paste a valid cloudinary/unsplash URL into either field → save works.
- [ ] Paste a disallowed URL → zod rejects with friendly message.
- [ ] Uploading a >5 MB or non-JPG/PNG/WebP file → `/api/upload` rejects and UI shows the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)