### PR TITLE
seo(jsonld): BreadcrumbList on product and vendor detail

### DIFF
--- a/src/app/(public)/productores/[slug]/page.tsx
+++ b/src/app/(public)/productores/[slug]/page.tsx
@@ -101,6 +101,15 @@ export default async function VendorPublicPage({ params }: Props) {
     { month: 'long', year: 'numeric' },
   )
 
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: copy.breadcrumbs.home, item: absoluteUrl('/') },
+      { '@type': 'ListItem', position: 2, name: copy.vendor.breadcrumbProducers, item: absoluteUrl('/productores') },
+      { '@type': 'ListItem', position: 3, name: vendor.displayName, item: absoluteUrl(`/productores/${vendor.slug}`) },
+    ],
+  }
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Organization',
@@ -123,6 +132,7 @@ export default async function VendorPublicPage({ params }: Props) {
   return (
     <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <JsonLd data={structuredData} />
+      <JsonLd data={breadcrumbData} />
 
       {/* ── Breadcrumb ── */}
       <nav aria-label="Breadcrumb" className="py-4 text-sm text-[var(--muted)]">

--- a/src/app/(public)/productos/[slug]/page.tsx
+++ b/src/app/(public)/productos/[slug]/page.tsx
@@ -88,6 +88,28 @@ export default async function ProductDetailPage({ params }: Props) {
     limit: 4,
   }).then(r => r.products.filter(p => p.id !== product.id).slice(0, 4))
   const reviewSummary = await getProductReviews(product.id)
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: copy.breadcrumbs.home, item: absoluteUrl('/') },
+      { '@type': 'ListItem', position: 2, name: copy.breadcrumbs.products, item: absoluteUrl('/productos') },
+      ...(product.category
+        ? [{
+            '@type': 'ListItem',
+            position: 3,
+            name: translateCategoryLabel(product.category.slug, product.category.name, locale),
+            item: absoluteUrl(`/productos?categoria=${product.category.slug}`),
+          }]
+        : []),
+      {
+        '@type': 'ListItem',
+        position: product.category ? 4 : 3,
+        name: localizedProduct.name,
+        item: absoluteUrl(`/productos/${product.slug}`),
+      },
+    ],
+  }
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Product',
@@ -115,6 +137,7 @@ export default async function ProductDetailPage({ params }: Props) {
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <JsonLd data={structuredData} />
+      <JsonLd data={breadcrumbData} />
       {/* Breadcrumb */}
       <nav className="mb-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-[var(--muted)]">
         <Link href="/" className="rounded-md hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">{copy.breadcrumbs.home}</Link>


### PR DESCRIPTION
## Summary
- Emit `BreadcrumbList` JSON-LD on `/productos/[slug]` and `/productores/[slug]`, mirroring the existing visual breadcrumbs.
- Reuses `JsonLd` component; no runtime deps added.

Closes #275

## Test plan
- [x] `npm run typecheck:app`
- [ ] Validate both pages in https://search.google.com/test/rich-results after deploy