### PR TITLE
seo(jsonld): upgrade vendor schema to LocalBusiness

### DIFF
--- a/src/app/(public)/productores/[slug]/page.tsx
+++ b/src/app/(public)/productores/[slug]/page.tsx
@@ -112,13 +112,18 @@ export default async function VendorPublicPage({ params }: Props) {
   }
   const structuredData = {
     '@context': 'https://schema.org',
-    '@type': 'Organization',
+    '@type': 'LocalBusiness',
+    '@id': absoluteUrl(`/productores/${vendor.slug}#business`),
     name: vendor.displayName,
     description: vendor.description ?? undefined,
     url: absoluteUrl(`/productores/${vendor.slug}`),
     image: vendor.logo ? [absoluteUrl(vendor.logo)] : undefined,
+    logo: vendor.logo ? absoluteUrl(vendor.logo) : undefined,
     address: vendor.location
       ? { '@type': 'PostalAddress', addressLocality: vendor.location, addressCountry: 'ES' }
+      : undefined,
+    areaServed: vendor.location
+      ? { '@type': 'Place', name: vendor.location }
       : undefined,
     aggregateRating: vendor.avgRating
       ? {


### PR DESCRIPTION
## Summary
- Change `@type` from `Organization` → `LocalBusiness` on `/productores/[slug]`.
- Add `areaServed` (derived from `vendor.location`), top-level `logo`, and a stable `@id`.
- `aggregateRating` + `PostalAddress` kept as-is.

Fields like `geo`, `openingHoursSpecification`, `telephone` and `priceRange` are **not added** because the `Vendor` model doesn't store them yet — follow-up tickets can extend the schema once those columns exist.

Closes #279

## Test plan
- [x] `npm run typecheck:app`
- [ ] Validate a couple of vendor pages in https://search.google.com/test/rich-results after deploy