### PR TITLE
fix(vendor-product): allow draft without Stripe + compact upload UI

### DIFF
--- a/src/app/(vendor)/vendor/productos/[id]/page.tsx
+++ b/src/app/(vendor)/vendor/productos/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getMyProduct } from '@/domains/vendors/actions'
+import { getMyProduct, getMyVendorProfile } from '@/domains/vendors/actions'
 import { getCategories } from '@/domains/catalog/queries'
 import { ProductForm } from '@/components/vendor/ProductForm'
 import { notFound } from 'next/navigation'
@@ -9,7 +9,11 @@ export const metadata: Metadata = { title: 'Editar producto' }
 
 export default async function EditProductoPage({ params }: Props) {
   const { id } = await params
-  const [product, categories] = await Promise.all([getMyProduct(id), getCategories()])
+  const [product, categories, vendor] = await Promise.all([
+    getMyProduct(id),
+    getCategories(),
+    getMyVendorProfile(),
+  ])
   if (!product) notFound()
 
   return (
@@ -18,7 +22,7 @@ export default async function EditProductoPage({ params }: Props) {
         <h1 className="text-2xl font-bold text-[var(--foreground)]">Editar producto</h1>
         <p className="text-sm text-[var(--muted)] mt-0.5">{product.name}</p>
       </div>
-      <ProductForm categories={categories} initialData={product} />
+      <ProductForm categories={categories} initialData={product} stripeOnboarded={vendor.stripeOnboarded} />
     </div>
   )
 }

--- a/src/app/(vendor)/vendor/productos/nuevo/page.tsx
+++ b/src/app/(vendor)/vendor/productos/nuevo/page.tsx
@@ -1,11 +1,12 @@
 import { getCategories } from '@/domains/catalog/queries'
+import { getMyVendorProfile } from '@/domains/vendors/actions'
 import { ProductForm } from '@/components/vendor/ProductForm'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = { title: 'Nuevo producto' }
 
 export default async function NuevoProductoPage() {
-  const categories = await getCategories()
+  const [categories, vendor] = await Promise.all([getCategories(), getMyVendorProfile()])
   return (
     <div className="max-w-2xl">
       <div className="mb-6">
@@ -14,7 +15,7 @@ export default async function NuevoProductoPage() {
           Guarda como borrador y envía a revisión cuando esté listo.
         </p>
       </div>
-      <ProductForm categories={categories} />
+      <ProductForm categories={categories} stripeOnboarded={vendor.stripeOnboarded} />
     </div>
   )
 }

--- a/src/components/vendor/ImageUploader.tsx
+++ b/src/components/vendor/ImageUploader.tsx
@@ -128,7 +128,7 @@ export function ImageUploader({ urls, onChange, disabled }: ImageUploaderProps) 
           setDragActive(false)
         }}
         onDrop={handleDrop}
-        className={`flex cursor-pointer flex-col items-center justify-center rounded-2xl border-2 border-dashed px-6 py-10 text-center transition ${
+        className={`flex cursor-pointer items-center gap-3 rounded-xl border border-dashed px-4 py-3 text-left transition ${
           dropZoneDisabled
             ? 'cursor-not-allowed border-[var(--border)] bg-[var(--surface-raised)] opacity-60'
             : dragActive
@@ -136,16 +136,18 @@ export function ImageUploader({ urls, onChange, disabled }: ImageUploaderProps) 
               : 'border-[var(--border)] bg-[var(--surface-raised)] hover:border-emerald-300 dark:hover:border-emerald-700'
         }`}
       >
-        <ArrowUpTrayIcon className="h-8 w-8 text-emerald-600 dark:text-emerald-400" />
-        <p className="mt-3 text-sm font-semibold text-[var(--foreground)]">
-          {t('vendor.upload.title')}
-        </p>
-        <p className="mt-1 text-xs text-[var(--muted)]">
-          {t('vendor.upload.subtitle')}
-        </p>
-        <p className="mt-2 text-xs text-[var(--muted)]">
-          {remainingSlots} / {MAX_IMAGES} {t('vendor.upload.slotsLeft')}
-        </p>
+        <ArrowUpTrayIcon className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[var(--foreground)]">
+            {t('vendor.upload.title')}
+          </p>
+          <p className="truncate text-xs text-[var(--muted)]">
+            {t('vendor.upload.subtitle')}
+          </p>
+        </div>
+        <span className="shrink-0 text-xs text-[var(--muted)]">
+          {remainingSlots}/{MAX_IMAGES}
+        </span>
         <input
           ref={inputRef}
           id="product-image-upload"

--- a/src/components/vendor/ProductForm.tsx
+++ b/src/components/vendor/ProductForm.tsx
@@ -54,13 +54,15 @@ type EditableProduct = Product & {
 interface ProductFormProps {
   categories: Category[]
   initialData?: EditableProduct
+  stripeOnboarded: boolean
 }
 
 
-export function ProductForm({ categories, initialData }: ProductFormProps) {
+export function ProductForm({ categories, initialData, stripeOnboarded }: ProductFormProps) {
   const router = useRouter()
   const [serverError, setServerError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  const [pendingAction, setPendingAction] = useState<'DRAFT' | 'PENDING_REVIEW' | null>(null)
   const t = useT()
 
   const {
@@ -93,7 +95,6 @@ export function ProductForm({ categories, initialData }: ProductFormProps) {
   })
 
   const selectedCertifications = watch('certifications') ?? []
-  const isEditing = Boolean(initialData)
   const imagesTextValue = watch('imagesText')
   const { valid: validImages } = parseAndValidateImages(imagesTextValue)
 
@@ -122,6 +123,7 @@ export function ProductForm({ categories, initialData }: ProductFormProps) {
       router.refresh()
     } catch (error) {
       setServerError(error instanceof Error ? error.message : 'No se pudo guardar el producto')
+      setPendingAction(null)
     }
   }
 
@@ -290,20 +292,7 @@ export function ProductForm({ categories, initialData }: ProductFormProps) {
           )}
         </div>
 
-        <div className="space-y-1.5 sm:col-span-2">
-          <label htmlFor="status" className="block text-sm font-medium text-[var(--foreground)]">
-            {t('vendor.statusLabel')}
-          </label>
-          <select
-            id="status"
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
-            {...register('status')}
-          >
-            <option value="DRAFT">{t('vendor.saveDraft')}</option>
-            <option value="PENDING_REVIEW">{t('vendor.sendReview')}</option>
-          </select>
-          <p className="text-xs text-[var(--muted)]">{t('vendor.statusHint')}</p>
-        </div>
+        <input type="hidden" {...register('status')} />
       </div>
 
       {initialData?.variants?.length ? (
@@ -318,13 +307,41 @@ export function ProductForm({ categories, initialData }: ProductFormProps) {
         </div>
       ) : null}
 
-      <div className="flex flex-wrap items-center justify-end gap-3">
-        <Button type="button" variant="secondary" onClick={() => router.push('/vendor/productos')}>
-          {t('common.cancel')}
-        </Button>
-        <Button type="submit" isLoading={isSubmitting}>
-          {isEditing ? t('vendor.saveChanges') : t('vendor.createProduct')}
-        </Button>
+      <div className="space-y-2 border-t border-[var(--border)] pt-4">
+        <p className="text-xs text-[var(--muted)]">
+          {stripeOnboarded ? t('vendor.statusHint') : t('vendor.draftOnlyHint')}
+        </p>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={() => router.push('/vendor/productos')}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            type="submit"
+            variant="secondary"
+            size="sm"
+            isLoading={isSubmitting && pendingAction === 'DRAFT'}
+            disabled={isSubmitting}
+            onClick={() => {
+              setPendingAction('DRAFT')
+              setValue('status', 'DRAFT')
+            }}
+          >
+            {t('vendor.saveDraft')}
+          </Button>
+          <Button
+            type="submit"
+            size="sm"
+            isLoading={isSubmitting && pendingAction === 'PENDING_REVIEW'}
+            disabled={isSubmitting || !stripeOnboarded}
+            title={stripeOnboarded ? undefined : t('vendor.sendReviewBlocked')}
+            onClick={() => {
+              setPendingAction('PENDING_REVIEW')
+              setValue('status', 'PENDING_REVIEW')
+            }}
+          >
+            {t('vendor.sendReview')}
+          </Button>
+        </div>
       </div>
     </form>
   )

--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -67,9 +67,15 @@ type ProductInput = z.infer<typeof productSchema>
  * Status defaults to DRAFT. Vendor must submit for review explicitly.
  */
 export async function createProduct(input: ProductInput) {
-  const { vendor } = await requireOnboardedVendor()
+  const { vendor } = await requireVendor()
 
   const data = productSchema.parse(input)
+
+  // Drafts can be saved without Stripe onboarding; only submitting for review
+  // (or any non-draft status) requires a payout destination.
+  if (data.status !== 'DRAFT') {
+    assertVendorOnboarded(vendor)
+  }
 
   // Generate unique slug
   let slug = slugify(data.name)
@@ -108,6 +114,10 @@ export async function updateProduct(productId: string, input: Partial<ProductInp
   if (!product) throw new Error('Producto no encontrado')
 
   const data = productSchema.partial().parse(input)
+
+  if (data.status && data.status !== 'DRAFT') {
+    assertVendorOnboarded(vendor)
+  }
 
   const updated = await db.product.update({
     where: { id: productId },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -328,6 +328,8 @@ const en: Record<TranslationKeys, string> = {
   'vendor.saveDraft': 'Save as draft',
   'vendor.sendReview': 'Send for review',
   'vendor.statusHint': 'You can edit drafts and resubmit rejected products later.',
+  'vendor.draftOnlyHint': 'To send for review, first set up Stripe in your profile. Meanwhile, you can save drafts.',
+  'vendor.sendReviewBlocked': 'Set up Stripe before sending for review',
   'vendor.autoTranslateHint': 'Product text is translated automatically for the storefront in the other language. Shoppers will see a badge when they are viewing an automatic translation.',
   'vendor.saveChanges': 'Save changes',
   'vendor.createProduct': 'Create product',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -326,6 +326,8 @@ const es = {
   'vendor.saveDraft': 'Guardar como borrador',
   'vendor.sendReview': 'Enviar a revisión',
   'vendor.statusHint': 'Puedes editar borradores y reenviar productos rechazados más adelante.',
+  'vendor.draftOnlyHint': 'Para enviar a revisión, primero configura Stripe en tu perfil. Mientras tanto, puedes guardar borradores.',
+  'vendor.sendReviewBlocked': 'Configura Stripe antes de enviar a revisión',
   'vendor.autoTranslateHint': 'Los textos del producto se traducen automáticamente para la tienda en el otro idioma. Los compradores verán una insignia cuando estén viendo una traducción automática.',
   'vendor.saveChanges': 'Guardar cambios',
   'vendor.createProduct': 'Crear producto',


### PR DESCRIPTION
## Summary
- Vendors can save product **drafts** without completing Stripe onboarding. The onboarding guard now only fires when `status !== 'DRAFT'` (i.e. submitting for review).
- Replaced the "Estado inicial" dropdown + single "Crear producto" button with two explicit buttons: **Guardar borrador** (always enabled) and **Enviar a revisión** (disabled with tooltip + hint when Stripe is not configured).
- Compacted the `ImageUploader` dropzone into a single-line horizontal row (icon, title/subtitle, slot counter) so it doesn't dominate the form.
- Pages under `/vendor/productos/nuevo` and `/vendor/productos/[id]` now load the vendor profile to pass `stripeOnboarded` into `ProductForm`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 531/531 passing
- [ ] Manual: in demo mode (vendor without Stripe), open `/vendor/productos/nuevo`, fill in fields, click **Guardar borrador** → product is created as DRAFT without the blocking Stripe error
- [ ] Manual: **Enviar a revisión** is disabled with a clear hint when Stripe is missing
- [ ] Manual: once Stripe is onboarded, **Enviar a revisión** works and the product enters PENDING_REVIEW

🤖 Generated with [Claude Code](https://claude.com/claude-code)