### PR TITLE
fix(vendor): dynamic sidebar refresh + producer logo on product page

### DIFF
--- a/src/app/(public)/productos/[slug]/page.tsx
+++ b/src/app/(public)/productos/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import Image from 'next/image'
 import { getProductBySlug, getProducts } from '@/domains/catalog/queries'
 import { Badge } from '@/components/ui/badge'
 import { ProductPurchasePanel } from '@/components/catalog/ProductPurchasePanel'
@@ -290,9 +291,19 @@ export default async function ProductDetailPage({ params }: Props) {
               </p>
             </div>
             <div className="flex items-start gap-4 p-5">
-              <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-emerald-100 text-3xl dark:bg-emerald-950/40">
-                🌾
-              </div>
+              {product.vendor.logo ? (
+                <Image
+                  src={product.vendor.logo}
+                  alt={product.vendor.displayName}
+                  width={56}
+                  height={56}
+                  className="h-14 w-14 shrink-0 rounded-2xl object-cover"
+                />
+              ) : (
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-emerald-100 text-3xl dark:bg-emerald-950/40">
+                  🌾
+                </div>
+              )}
               <div className="min-w-0 flex-1">
                 <p className="font-semibold text-[var(--foreground)]">{product.vendor.displayName}</p>
                 {product.vendor.location && (

--- a/src/components/vendor/VendorProfileForm.tsx
+++ b/src/components/vendor/VendorProfileForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -49,6 +50,7 @@ interface Props {
 }
 
 export function VendorProfileForm({ vendor }: Props) {
+  const router = useRouter()
   const [saveState, setSaveState] = useState<SaveState>('idle')
   const [serverError, setServerError] = useState<string | null>(null)
 
@@ -88,12 +90,16 @@ export function VendorProfileForm({ vendor }: Props) {
         await updateVendorProfile(values)
         lastSavedJsonRef.current = JSON.stringify(values)
         setSaveState('saved')
+        // Refresh server components so the vendor layout sidebar (which reads
+        // displayName/logo from the DB) reflects the new values without needing
+        // a full page reload.
+        router.refresh()
       } catch (err) {
         setSaveState('error')
         setServerError(err instanceof Error ? err.message : 'Error al guardar el perfil')
       }
     },
-    [],
+    [router],
   )
 
   useEffect(() => {
@@ -140,8 +146,8 @@ export function VendorProfileForm({ vendor }: Props) {
           </label>
           <textarea
             id="description"
-            rows={4}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
+            rows={8}
+            className="w-full min-h-[12rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
             placeholder="Cuéntanos sobre tu explotación, tus prácticas, tu historia..."
             {...register('description')}
           />


### PR DESCRIPTION
## Summary
- \`VendorProfileForm\` now calls \`router.refresh()\` after autosave so the vendor layout sidebar (which reads \`displayName\` from the DB) reflects edits without a page reload.
- Description textarea enlarged (rows 4→8, \`min-h-[12rem]\`, \`resize-y\`) — the old 4-row box was too cramped.
- Product detail \`/productos/[slug]\` "Conoce al productor" card now renders \`vendor.logo\` when present (previously always showed the 🌾 emoji even when a logo existed). Field was already fetched in the query.

## Test plan
- [ ] Open \`/vendor/perfil\`, edit "Nombre del productor", observe sidebar label update after autosave.
- [ ] Type a long description and confirm the textarea is comfortable + resizable.
- [ ] Upload a profile photo, open a product of that vendor at \`/productos/[slug]\`, confirm logo renders in the vendor card.
- [ ] If no logo, fallback emoji still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)