### PR TITLE
feat(vendor-reviews): respond to customer reviews from portal

### DIFF
--- a/prisma/migrations/20260413090000_review_vendor_response/migration.sql
+++ b/prisma/migrations/20260413090000_review_vendor_response/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN "vendorResponse" TEXT,
+ADD COLUMN "vendorResponseAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -411,6 +411,9 @@ model Review {
   body       String?  @db.Text
   createdAt  DateTime @default(now())
 
+  vendorResponse   String?   @db.Text
+  vendorResponseAt DateTime?
+
   order    Order   @relation(fields: [orderId], references: [id])
   product  Product @relation(fields: [productId], references: [id])
   vendor   Vendor  @relation(fields: [vendorId], references: [id])

--- a/src/app/(public)/productos/[slug]/page.tsx
+++ b/src/app/(public)/productos/[slug]/page.tsx
@@ -376,6 +376,14 @@ export default async function ProductDetailPage({ params }: Props) {
                 {review.body && (
                   <p className="mt-3 text-sm leading-relaxed text-[var(--foreground-soft)]">{review.body}</p>
                 )}
+                {review.vendorResponse && (
+                  <div className="mt-4 rounded-xl border-l-2 border-emerald-500 bg-emerald-50/60 p-3 dark:border-emerald-400 dark:bg-emerald-950/30">
+                    <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+                      {product.vendor.displayName}
+                    </p>
+                    <p className="mt-1 text-sm leading-relaxed text-[var(--foreground-soft)]">{review.vendorResponse}</p>
+                  </div>
+                )}
               </article>
             ))}
           </div>

--- a/src/app/(vendor)/vendor/valoraciones/page.tsx
+++ b/src/app/(vendor)/vendor/valoraciones/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 import { requireVendor } from '@/lib/auth-guard'
 import { db } from '@/lib/db'
-import { VendorReviewsSection } from '@/app/(public)/productores/[slug]/VendorReviewsSection'
+import { VendorReviewsManager } from '@/components/vendor/VendorReviewsManager'
 import { getServerT } from '@/i18n/server'
 
 export const metadata: Metadata = {
@@ -37,6 +37,8 @@ export default async function Valoraciones() {
         rating: true,
         body: true,
         createdAt: true,
+        vendorResponse: true,
+        vendorResponseAt: true,
         customer: {
           select: {
             firstName: true,
@@ -61,22 +63,20 @@ export default async function Valoraciones() {
   return (
     <main className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-[var(--foreground)]">{t('reviews.vendorPage.title')}</h1>
-        <p className="mt-2 text-gray-600 dark:text-[var(--muted)]">{t('reviews.vendorPage.subtitle')}</p>
+        <h1 className="text-3xl font-bold text-[var(--foreground)]">{t('reviews.vendorPage.title')}</h1>
+        <p className="mt-2 text-[var(--muted)]">{t('reviews.vendorPage.subtitle')}</p>
       </div>
 
       {reviews.length === 0 ? (
-        <div className="rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 p-8 text-center dark:border-[var(--border)] dark:bg-[var(--surface-raised)]">
-          <p className="text-lg text-gray-600 dark:text-[var(--muted)]">{t('reviews.vendorPage.empty')}</p>
+        <div className="rounded-lg border-2 border-dashed border-[var(--border)] bg-[var(--surface-raised)] p-8 text-center">
+          <p className="text-lg text-[var(--muted)]">{t('reviews.vendorPage.empty')}</p>
         </div>
       ) : (
-        <div className="rounded-lg bg-white p-6 shadow dark:bg-[var(--surface)] dark:shadow-black/30">
-          <VendorReviewsSection
-            reviews={reviews}
-            avgRating={aggregate._avg.rating ? Number(aggregate._avg.rating) : null}
-            totalReviews={aggregate._count._all}
-          />
-        </div>
+        <VendorReviewsManager
+          reviews={reviews}
+          avgRating={aggregate._avg.rating ? Number(aggregate._avg.rating) : null}
+          totalReviews={aggregate._count._all}
+        />
       )}
     </main>
   )

--- a/src/components/vendor/VendorReviewsManager.tsx
+++ b/src/components/vendor/VendorReviewsManager.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { StarIcon } from '@heroicons/react/24/solid'
+import { ChatBubbleLeftIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { formatDistanceToNow } from 'date-fns'
+import { es as esLocale, enUS as enLocale } from 'date-fns/locale'
+import { useT, useLocale } from '@/i18n'
+import { respondToReview, deleteReviewResponse } from '@/domains/reviews/actions'
+
+interface Review {
+  id: string
+  rating: number
+  body: string | null
+  createdAt: Date
+  vendorResponse: string | null
+  vendorResponseAt: Date | null
+  customer: { firstName: string; lastName: string }
+  product: { name: string; slug: string }
+}
+
+interface Props {
+  reviews: Review[]
+  avgRating: number | null
+  totalReviews: number
+}
+
+export function VendorReviewsManager({ reviews, avgRating, totalReviews }: Props) {
+  const t = useT()
+  const { locale } = useLocale()
+  const dateLocale = locale === 'en' ? enLocale : esLocale
+
+  const totalLabel =
+    totalReviews === 1
+      ? t('reviews.totalOne')
+      : t('reviews.totalOther').replace('{count}', String(totalReviews))
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-sm">
+        <div className="flex items-center gap-6">
+          <div>
+            <div className="text-4xl font-bold text-emerald-600 dark:text-emerald-400">
+              {avgRating ? avgRating.toFixed(1) : '—'}
+            </div>
+            <div className="mt-2 flex gap-1">
+              {[1, 2, 3, 4, 5].map(i => (
+                <StarIcon
+                  key={i}
+                  className={`h-5 w-5 ${
+                    avgRating && i <= Math.round(avgRating)
+                      ? 'text-amber-400 dark:text-amber-300'
+                      : 'text-[var(--border-strong)]'
+                  }`}
+                />
+              ))}
+            </div>
+            <p className="mt-1 text-sm text-[var(--muted)]">{totalLabel}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {reviews.map(review => (
+          <ReviewCard key={review.id} review={review} dateLocale={dateLocale} t={t} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ReviewCard({
+  review,
+  dateLocale,
+  t,
+}: {
+  review: Review
+  dateLocale: typeof esLocale
+  t: ReturnType<typeof useT>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(review.vendorResponse ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const timeAgo = formatDistanceToNow(new Date(review.createdAt), {
+    locale: dateLocale,
+    addSuffix: false,
+  })
+
+  const submit = () => {
+    setError(null)
+    const trimmed = draft.trim()
+    if (!trimmed) {
+      setError('La respuesta no puede estar vacía')
+      return
+    }
+    startTransition(async () => {
+      try {
+        await respondToReview({ reviewId: review.id, response: trimmed })
+        setEditing(false)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error al guardar la respuesta')
+      }
+    })
+  }
+
+  const remove = () => {
+    if (!confirm('¿Eliminar tu respuesta a esta valoración?')) return
+    startTransition(async () => {
+      try {
+        await deleteReviewResponse(review.id)
+        setDraft('')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error al eliminar la respuesta')
+      }
+    })
+  }
+
+  return (
+    <article className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+      <div className="mb-2 flex items-start justify-between gap-4">
+        <div>
+          <p className="font-semibold text-[var(--foreground)]">
+            {review.customer.firstName} {review.customer.lastName}
+          </p>
+          <p className="text-xs text-[var(--muted)]">
+            {review.product.name} · {t('reviews.ago').replace('{time}', timeAgo)}
+          </p>
+        </div>
+        <div className="flex gap-0.5">
+          {[1, 2, 3, 4, 5].map(i => (
+            <StarIcon
+              key={i}
+              className={`h-4 w-4 ${
+                i <= review.rating
+                  ? 'text-amber-400 dark:text-amber-300'
+                  : 'text-[var(--border-strong)]'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {review.body && (
+        <p className="text-sm text-[var(--foreground-soft)]">{review.body}</p>
+      )}
+
+      {/* Existing response (not editing) */}
+      {review.vendorResponse && !editing && (
+        <div className="mt-4 rounded-xl border-l-2 border-emerald-500 bg-emerald-50/60 p-3 dark:border-emerald-400 dark:bg-emerald-950/30">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+                Tu respuesta
+              </p>
+              <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed text-[var(--foreground-soft)]">
+                {review.vendorResponse}
+              </p>
+            </div>
+            <div className="flex shrink-0 gap-1">
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                disabled={pending}
+                className="rounded-md p-1.5 text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+                aria-label="Editar respuesta"
+              >
+                <PencilSquareIcon className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={remove}
+                disabled={pending}
+                className="rounded-md p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/40"
+                aria-label="Eliminar respuesta"
+              >
+                <TrashIcon className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* No response + not editing → show "Responder" button */}
+      {!review.vendorResponse && !editing && (
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--foreground-soft)] hover:border-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-400"
+        >
+          <ChatBubbleLeftIcon className="h-4 w-4" />
+          Responder
+        </button>
+      )}
+
+      {/* Editing form */}
+      {editing && (
+        <div className="mt-4 space-y-2">
+          <textarea
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            rows={3}
+            maxLength={1000}
+            disabled={pending}
+            placeholder="Escribe tu respuesta pública..."
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
+          />
+          {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-[var(--muted)]">{draft.length}/1000</p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setEditing(false)
+                  setDraft(review.vendorResponse ?? '')
+                  setError(null)
+                }}
+                disabled={pending}
+                className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={pending || !draft.trim()}
+                className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 disabled:opacity-50 dark:bg-emerald-500 dark:hover:bg-emerald-400"
+              >
+                {pending ? 'Guardando...' : 'Publicar respuesta'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </article>
+  )
+}

--- a/src/domains/reviews/actions.ts
+++ b/src/domains/reviews/actions.ts
@@ -4,6 +4,10 @@ import { z } from 'zod'
 import { revalidatePath } from 'next/cache'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { isVendor } from '@/lib/roles'
+import { redirect } from 'next/navigation'
+import { safeRevalidatePath } from '@/lib/revalidate'
 
 const createReviewSchema = z.object({
   orderId: z.string().min(1),
@@ -128,6 +132,69 @@ export async function createReview(
   if (vendor?.slug) revalidatePath(`/productores/${vendor.slug}`)
 }
 
+const respondSchema = z.object({
+  reviewId: z.string().min(1),
+  response: z.string().trim().min(1, 'La respuesta no puede estar vacía').max(1000),
+})
+
+export async function respondToReview(input: z.infer<typeof respondSchema>) {
+  const session = await getActionSession()
+  if (!session || !isVendor(session.user.role)) redirect('/login')
+
+  const vendor = await db.vendor.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true, slug: true },
+  })
+  if (!vendor) redirect('/login')
+
+  const data = respondSchema.parse(input)
+
+  const review = await db.review.findUnique({
+    where: { id: data.reviewId },
+    select: { vendorId: true, product: { select: { slug: true } } },
+  })
+  if (!review || review.vendorId !== vendor.id) {
+    throw new Error('No puedes responder a esta valoración')
+  }
+
+  await db.review.update({
+    where: { id: data.reviewId },
+    data: { vendorResponse: data.response, vendorResponseAt: new Date() },
+  })
+
+  safeRevalidatePath('/vendor/valoraciones')
+  if (review.product?.slug) revalidatePath(`/productos/${review.product.slug}`)
+  revalidatePath(`/productores/${vendor.slug}`)
+}
+
+export async function deleteReviewResponse(reviewId: string) {
+  const session = await getActionSession()
+  if (!session || !isVendor(session.user.role)) redirect('/login')
+
+  const vendor = await db.vendor.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true, slug: true },
+  })
+  if (!vendor) redirect('/login')
+
+  const review = await db.review.findUnique({
+    where: { id: reviewId },
+    select: { vendorId: true, product: { select: { slug: true } } },
+  })
+  if (!review || review.vendorId !== vendor.id) {
+    throw new Error('No puedes modificar esta valoración')
+  }
+
+  await db.review.update({
+    where: { id: reviewId },
+    data: { vendorResponse: null, vendorResponseAt: null },
+  })
+
+  safeRevalidatePath('/vendor/valoraciones')
+  if (review.product?.slug) revalidatePath(`/productos/${review.product.slug}`)
+  revalidatePath(`/productores/${vendor.slug}`)
+}
+
 export async function getProductReviews(productId: string) {
   const [reviews, aggregate] = await Promise.all([
     db.review.findMany({
@@ -139,6 +206,8 @@ export async function getProductReviews(productId: string) {
         rating: true,
         body: true,
         createdAt: true,
+        vendorResponse: true,
+        vendorResponseAt: true,
         customer: {
           select: {
             firstName: true,


### PR DESCRIPTION
## Summary
- Add \`vendorResponse\` + \`vendorResponseAt\` fields to the Review model (migration \`20260413090000_review_vendor_response\`).
- New server actions \`respondToReview\` / \`deleteReviewResponse\`, scoped to the owning vendor, revalidate vendor + public pages on change.
- New client component \`VendorReviewsManager\` with per-review inline editor (Responder / Editar / Eliminar) + character counter, used on \`/vendor/valoraciones\`. Replaces the read-only \`VendorReviewsSection\` on the vendor page.
- Public product detail page now surfaces the vendor's response under each review as a branded emerald-bordered card.
- \`getProductReviews\` includes the response fields so public surfaces can render them.

Supersedes #300 (auto-closed when base branch was deleted after #298 merged).

## Test plan
- [ ] Run \`prisma migrate deploy\` in dev.
- [ ] As a vendor, open \`/vendor/valoraciones\`, click \"Responder\" on a review, publish a response, confirm it renders as a branded block with edit/delete buttons.
- [ ] Edit the response; confirm it updates inline.
- [ ] Delete the response; confirm it returns to the \"Responder\" button state.
- [ ] Open the matching product at \`/productos/[slug]\`, confirm the response is shown to customers under the review with vendor displayName.
- [ ] Try to respond to a review from a different vendor → server action rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)