### PR TITLE
fix(producer-page): translate hero visual badge via labelKey pattern

### DIFF
--- a/src/app/(public)/HomePageClient.tsx
+++ b/src/app/(public)/HomePageClient.tsx
@@ -11,7 +11,7 @@ import { MapPinIcon, StarIcon } from '@heroicons/react/24/solid'
 import { CheckBadgeIcon, TruckIcon, ShieldCheckIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
 import { useLocale, useT } from '@/i18n'
 import type { TranslationKeys } from '@/i18n'
-import { getVendorHeroImage, getVendorVisualLabel } from '@/domains/vendors/visuals'
+import { getVendorHeroImage, getVendorVisualLabelKey } from '@/domains/vendors/visuals'
 
 interface HomePageClientProps {
   featured: ProductWithVendor[]
@@ -301,7 +301,7 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {vendors.map(v => {
               const heroImage = getVendorHeroImage(v)
-              const visualLabel = getVendorVisualLabel(v)
+              const visualLabel = t(getVendorVisualLabelKey(v))
 
               return (
                 <Link

--- a/src/app/(public)/productores/[slug]/page.tsx
+++ b/src/app/(public)/productores/[slug]/page.tsx
@@ -19,9 +19,9 @@ import { db } from '@/lib/db'
 import { VendorReviewsSection } from './VendorReviewsSection'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { absoluteUrl, buildPageMetadata } from '@/lib/seo'
-import { getServerLocale } from '@/i18n/server'
+import { getServerLocale, getServerT } from '@/i18n/server'
 import { getCatalogCopy, getLocalizedCertificationCopy } from '@/i18n/catalog-copy'
-import { getVendorHeroImage, getVendorVisualLabel } from '@/domains/vendors/visuals'
+import { getVendorHeroImage, getVendorVisualLabelKey } from '@/domains/vendors/visuals'
 import { Badge } from '@/components/ui/badge'
 import { StarRating } from '@/components/reviews/StarRating'
 import { auth } from '@/lib/auth'
@@ -56,11 +56,12 @@ export default async function VendorPublicPage({ params }: Props) {
   const { slug } = await params
   const locale = await getServerLocale()
   const copy = getCatalogCopy(locale)
+  const t = await getServerT()
   const vendor = await getVendorBySlug(slug)
   if (!vendor) notFound()
 
   const heroImage = getVendorHeroImage(vendor)
-  const visualLabel = getVendorVisualLabel(vendor)
+  const visualLabel = t(getVendorVisualLabelKey(vendor))
 
   const [reviews, aggregate] = await Promise.all([
     db.review.findMany({

--- a/src/domains/vendors/visuals.ts
+++ b/src/domains/vendors/visuals.ts
@@ -8,7 +8,6 @@ type VendorVisualInput = {
 type VendorVisualRule = {
   match: RegExp
   image: string
-  label: string
   labelKey: VendorVisualLabelKey
 }
 
@@ -40,43 +39,36 @@ const VENDOR_VISUAL_RULES: VendorVisualRule[] = [
   {
     match: /(obrador|pan|masa madre|panader)/i,
     image: 'https://images.unsplash.com/photo-1517433670267-08bbd4be890f?auto=format&fit=crop&w=1200&q=80',
-    label: 'Panadería artesanal',
     labelKey: 'vendorVisual.bakery',
   },
   {
     match: /(queser|queso|l[aá]cteo|oveja|cabra)/i,
     image: 'https://images.unsplash.com/photo-1516594915697-87eb3b1c14ea?auto=format&fit=crop&w=1200&q=80',
-    label: 'Quesería artesanal',
     labelKey: 'vendorVisual.cheese',
   },
   {
     match: /(bodega|vino|viñedo|tempranillo)/i,
     image: 'https://images.unsplash.com/photo-1506377247377-2a5b3b417ebb?auto=format&fit=crop&w=1200&q=80',
-    label: 'Bodega local',
     labelKey: 'vendorVisual.winery',
   },
   {
     match: /(huerta|fruta|naranja|c[ií]tric|finca|verdura|tomate)/i,
     image: 'https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=1200&q=80',
-    label: 'Huerta de temporada',
     labelKey: 'vendorVisual.orchard',
   },
   {
     match: /(almazara|aceite|oliva)/i,
     image: 'https://images.unsplash.com/photo-1474979266404-7eaacbcd87c5?auto=format&fit=crop&w=1200&q=80',
-    label: 'Aceite y olivar',
     labelKey: 'vendorVisual.oliveOil',
   },
   {
     match: /(granja|huevo|gallina|almendro)/i,
     image: 'https://images.unsplash.com/photo-1548550023-2bdb3c5beed7?auto=format&fit=crop&w=1200&q=80',
-    label: 'Granja familiar',
     labelKey: 'vendorVisual.farm',
   },
   {
     match: /(secano|cereal|campo|sur)/i,
     image: 'https://images.unsplash.com/photo-1500382017468-9049fed747ef?auto=format&fit=crop&w=1200&q=80',
-    label: 'Campo de secano',
     labelKey: 'vendorVisual.dryland',
   },
 ]
@@ -94,10 +86,6 @@ export function getVendorHeroImage(vendor: VendorVisualInput) {
     getVendorVisualRule(vendor)?.image ??
     DEFAULT_VENDOR_IMAGE
   )
-}
-
-export function getVendorVisualLabel(vendor: Pick<VendorVisualInput, 'displayName' | 'description'>) {
-  return getVendorVisualRule(vendor)?.label ?? 'Productor local'
 }
 
 export function getVendorVisualLabelKey(

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -536,6 +536,20 @@ const en: Record<TranslationKeys, string> = {
   'vendor.productForm.variantsNoteOther': 'This product has {count} variants. Variant editing is not yet available in this form.',
   'vendor.productForm.saveError': 'Could not save the product',
 
+  // Vendor – hero upload (cover + logo)
+  'vendor.heroUpload.changeCover': 'Change cover',
+  'vendor.heroUpload.uploadCover': 'Upload cover',
+  'vendor.heroUpload.removeCover': 'Remove cover',
+  'vendor.heroUpload.changeLogo': 'Change profile photo',
+  'vendor.heroUpload.uploadLogo': 'Upload profile photo',
+  'vendor.heroUpload.removeLogo': 'Remove profile photo',
+  'vendor.heroUpload.toggleUrls': 'Paste URL',
+  'vendor.heroUpload.toggleUrlsHide': 'Hide URL',
+  'vendor.heroUpload.unsupported': 'Unsupported format. Use JPG, PNG or WebP.',
+  'vendor.heroUpload.tooLarge': 'Image exceeds 5 MB.',
+  'vendor.heroUpload.uploadError': 'Failed to upload the image',
+  'vendor.heroUpload.urlNotAllowed': 'URL not allowed. Use cloudinary.com, uploadthing.com or unsplash.com.',
+
   // Vendor – reviews manager
   'vendor.reviewsManager.yourResponse': 'Your response',
   'vendor.reviewsManager.reply': 'Reply',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -534,6 +534,20 @@ const es = {
   'vendor.productForm.variantsNoteOther': 'Este producto tiene {count} variantes. La edición de variantes aún no está disponible en este formulario.',
   'vendor.productForm.saveError': 'No se pudo guardar el producto',
 
+  // Vendor – hero upload (cover + logo)
+  'vendor.heroUpload.changeCover': 'Cambiar portada',
+  'vendor.heroUpload.uploadCover': 'Subir portada',
+  'vendor.heroUpload.removeCover': 'Quitar portada',
+  'vendor.heroUpload.changeLogo': 'Cambiar foto de perfil',
+  'vendor.heroUpload.uploadLogo': 'Subir foto de perfil',
+  'vendor.heroUpload.removeLogo': 'Quitar foto de perfil',
+  'vendor.heroUpload.toggleUrls': 'Pegar URL',
+  'vendor.heroUpload.toggleUrlsHide': 'Ocultar URL',
+  'vendor.heroUpload.unsupported': 'Formato no soportado. Usa JPG, PNG o WebP.',
+  'vendor.heroUpload.tooLarge': 'La imagen supera los 5 MB.',
+  'vendor.heroUpload.uploadError': 'Error al subir la imagen',
+  'vendor.heroUpload.urlNotAllowed': 'URL no permitida. Usa cloudinary.com, uploadthing.com o unsplash.com.',
+
   // Vendor – reviews manager
   'vendor.reviewsManager.yourResponse': 'Tu respuesta',
   'vendor.reviewsManager.reply': 'Responder',


### PR DESCRIPTION
## Summary
- `/productores/[slug]` and the homepage producer grid rendered the "Huerta de temporada / Panadería artesanal / Bodega local" badge straight from a Spanish string field, so it didn't swap on locale change.
- Switch both callers to `getVendorVisualLabelKey()` + `t(...)`, drop the now-unused `getVendorVisualLabel()` helper, and remove the `label` field from the rules so future rules can't regress to a hardcoded literal.
- Seeds `vendor.heroUpload.*` keys in `es`/`en` so the in-flight `VendorHeroUpload` refactor (being landed in parallel) can pick them up without a parity failure.

## Test plan
- [x] `npm test` (535 passing)
- [x] `npx tsc --noEmit`
- [ ] Manual: visit `/productores/finca-garcia` in both languages, confirm the badge swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)