### PR TITLE
fix(public-header): pass session so vendors see Panel productor link

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,10 +1,12 @@
+import { auth } from '@/lib/auth'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth()
   return (
     <>
-      <Header />
+      <Header user={session?.user} />
       <main className="flex-1">{children}</main>
       <Footer />
     </>


### PR DESCRIPTION
## Summary
- El layout público (`src/app/(public)/layout.tsx`) renderizaba `<Header />` sin `user`, así que en `/productores`, `/productos`, `/` y demás páginas públicas los productores logueados veían la etiqueta "Portal productor" con destino `/login?callbackUrl=%2Fvendor%2Fdashboard` en vez de "Panel productor" apuntando directo a `/vendor/dashboard`.
- Ahora el layout lee `auth()` y lo pasa al header, igual que los layouts de buyer/admin.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (535/535)
- [ ] Logueado como vendor, visitar `/productores` y comprobar que el botón del header dice "Panel productor" y navega a `/vendor/dashboard`