### PR TITLE
feat(admin-informes): rebuild reports page as interactive analytics dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "19.2.4",
         "react-email": "^5.2.10",
         "react-hook-form": "^7.72.1",
+        "recharts": "^3.8.1",
         "resend": "^6.10.0",
         "stripe": "^22.0.1",
         "tailwind-merge": "^3.5.0",
@@ -2118,6 +2119,42 @@
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -2473,6 +2510,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2518,6 +2618,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3016,6 +3122,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -3069,6 +3296,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -3295,6 +3528,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -3346,6 +3589,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -3643,6 +3892,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -5693,6 +5961,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -5704,6 +5995,51 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remeda": {
@@ -5733,6 +6069,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resend": {
       "version": "6.10.0",
@@ -6183,6 +6525,12 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -6279,6 +6627,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -6328,6 +6685,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-dom": "19.2.4",
     "react-email": "^5.2.10",
     "react-hook-form": "^7.72.1",
+    "recharts": "^3.8.1",
     "resend": "^6.10.0",
     "stripe": "^22.0.1",
     "tailwind-merge": "^3.5.0",

--- a/src/app/(admin)/admin/informes/page.tsx
+++ b/src/app/(admin)/admin/informes/page.tsx
@@ -1,90 +1,107 @@
 import type { Metadata } from 'next'
-import { db } from '@/lib/db'
-import { formatPrice } from '@/lib/utils'
+import { parseFilters } from '@/domains/analytics/filters'
+import { getAnalytics } from '@/domains/analytics/service'
+import { AnalyticsFilters } from '@/components/admin/analytics/AnalyticsFilters'
+import { KpiCard } from '@/components/admin/analytics/KpiCard'
+import { SalesEvolutionChart } from '@/components/admin/analytics/charts/SalesEvolutionChart'
+import { CategoryPieChart } from '@/components/admin/analytics/charts/CategoryPieChart'
+import { RankedBarChart } from '@/components/admin/analytics/charts/RankedBarChart'
+import { InsightsPanel } from '@/components/admin/analytics/InsightsPanel'
+import { OrdersTable } from '@/components/admin/analytics/OrdersTable'
+import type { Insight } from '@/domains/analytics/types'
 
 export const metadata: Metadata = { title: 'Informes | Admin' }
-export const revalidate = 30
+export const dynamic = 'force-dynamic'
 
-export default async function AdminReportsPage() {
-  const [
-    orderTotals,
-    vendorTotals,
-    productTotals,
-    incidentTotals,
-    paymentTotals,
-  ] = await Promise.all([
-    db.order.aggregate({
-      _count: { _all: true },
-      _sum: { grandTotal: true, shippingCost: true, taxAmount: true },
-    }),
-    db.vendor.aggregate({
-      _count: { _all: true },
-      _avg: { avgRating: true },
-    }),
-    db.product.aggregate({
-      _count: { _all: true },
-      _avg: { basePrice: true },
-    }),
-    db.incident.aggregate({
-      _count: { _all: true },
-      _sum: { refundAmount: true },
-    }),
-    db.payment.aggregate({
-      _count: { _all: true },
-      _sum: { amount: true },
-    }),
-  ])
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
 
-  const reportCards = [
-    {
-      label: 'GMV total',
-      value: formatPrice(Number(orderTotals._sum.grandTotal ?? 0)),
-      detail: `${orderTotals._count._all} pedidos`,
-    },
-    {
-      label: 'Pagos procesados',
-      value: formatPrice(Number(paymentTotals._sum.amount ?? 0)),
-      detail: `${paymentTotals._count._all} pagos`,
-    },
-    {
-      label: 'Productores',
-      value: String(vendorTotals._count._all),
-      detail: vendorTotals._avg.avgRating ? `${Number(vendorTotals._avg.avgRating).toFixed(1)}★ media` : 'Sin reviews',
-    },
-    {
-      label: 'Catalogo',
-      value: String(productTotals._count._all),
-      detail: `Precio medio ${formatPrice(Number(productTotals._avg.basePrice ?? 0))}`,
-    },
-    {
-      label: 'Incidencias',
-      value: String(incidentTotals._count._all),
-      detail: `Refunds ${formatPrice(Number(incidentTotals._sum.refundAmount ?? 0))}`,
-    },
-    {
-      label: 'Impuestos cobrados',
-      value: formatPrice(Number(orderTotals._sum.taxAmount ?? 0)),
-      detail: `Envio ${formatPrice(Number(orderTotals._sum.shippingCost ?? 0))}`,
-    },
-  ]
+export default async function AdminReportsPage({ searchParams }: PageProps) {
+  const resolvedParams = await searchParams
+  const filters = parseFilters(resolvedParams)
+  const data = await getAnalytics(filters)
+
+  const initialDraft = {
+    preset: filters.preset,
+    from: filters.from.toISOString().slice(0, 10),
+    to: filters.to.toISOString().slice(0, 10),
+    vendorId: filters.vendorId ?? '',
+    categoryId: filters.categoryId ?? '',
+    status: filters.orderStatus ?? '',
+  }
 
   return (
     <div className="space-y-6">
-      <div>
-        <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">Analitica</p>
+      <header className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">Analítica</p>
         <h1 className="text-2xl font-bold text-[var(--foreground)]">Informes</h1>
-        <p className="mt-1 text-sm text-[var(--muted)]">Vista agregada del rendimiento operativo y financiero.</p>
-      </div>
+        <p className="text-sm text-[var(--muted)]">{data.period.label}</p>
+      </header>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {reportCards.map(card => (
-          <div key={card.label} className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-sm">
-            <p className="text-xs uppercase tracking-wide text-[var(--muted-light)]">{card.label}</p>
-            <p className="mt-3 text-3xl font-bold text-[var(--foreground)]">{card.value}</p>
-            <p className="mt-2 text-sm text-[var(--muted)]">{card.detail}</p>
-          </div>
-        ))}
-      </div>
+      <AnalyticsFilters options={data.filterOptions} initial={initialDraft} />
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <KpiCard label="GMV" metric={data.kpis.gmv} format="currency" />
+        <KpiCard label="Pedidos" metric={data.kpis.orders} format="number" />
+        <KpiCard label="AOV" metric={data.kpis.aov} format="currency" hint="Ticket medio" />
+        <KpiCard label="Comisiones" metric={data.kpis.commission} format="currency" />
+        <KpiCard label="Clientes únicos" metric={data.kpis.uniqueCustomers} format="number" />
+        <KpiCard label="% Repiten compra" metric={data.kpis.repeatRatePct} format="percent" />
+        <KpiCard label="% Incidencias" metric={data.kpis.incidentRatePct} format="percent" />
+        <KpiCard label="Impuestos" metric={data.kpis.tax} format="currency" />
+      </section>
+
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--foreground)]">Evolución de ventas</h2>
+          <p className="text-xs text-[var(--muted)]">GMV y nº pedidos por día</p>
+        </div>
+        <SalesEvolutionChart data={data.salesEvolution} />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <InsightsGrid insights={data.insights} />
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+          <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Ventas por categoría</h2>
+          {data.categoryBreakdown.length === 0 ? (
+            <p className="text-xs text-[var(--muted)]">Sin datos.</p>
+          ) : (
+            <CategoryPieChart data={data.categoryBreakdown} />
+          )}
+        </div>
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm xl:col-span-2">
+          <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Top productos (por ingresos)</h2>
+          {data.topProducts.length === 0 ? (
+            <p className="text-xs text-[var(--muted)]">Sin datos.</p>
+          ) : (
+            <RankedBarChart data={data.topProducts} />
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+        <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Top productores</h2>
+        {data.topVendors.length === 0 ? (
+          <p className="text-xs text-[var(--muted)]">Sin datos.</p>
+        ) : (
+          <RankedBarChart data={data.topVendors} color="#6366f1" />
+        )}
+      </section>
+
+      <OrdersTable rows={data.orders} />
+    </div>
+  )
+}
+
+function InsightsGrid({ insights }: { insights: Insight[] }) {
+  return (
+    <div className="xl:col-span-3">
+      <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Insights del periodo</h2>
+      <InsightsPanel insights={insights} />
     </div>
   )
 }

--- a/src/components/admin/analytics/AnalyticsFilters.tsx
+++ b/src/components/admin/analytics/AnalyticsFilters.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { useEffect, useMemo, useTransition } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import type { PresetRange, FilterOptionSet } from '@/domains/analytics/types'
+import { useAnalyticsFiltersStore } from './useAnalyticsFiltersStore'
+
+const PRESET_LABELS: Array<{ value: PresetRange; label: string }> = [
+  { value: 'today', label: 'Hoy' },
+  { value: '7d', label: '7 días' },
+  { value: '30d', label: '30 días' },
+  { value: 'mtd', label: 'Este mes' },
+  { value: 'custom', label: 'Personalizado' },
+]
+
+const ORDER_STATUSES = [
+  { value: '', label: 'Todos' },
+  { value: 'PAYMENT_CONFIRMED', label: 'Pagado' },
+  { value: 'PROCESSING', label: 'Procesando' },
+  { value: 'SHIPPED', label: 'Enviado' },
+  { value: 'DELIVERED', label: 'Entregado' },
+  { value: 'CANCELLED', label: 'Cancelado' },
+  { value: 'REFUNDED', label: 'Reembolsado' },
+]
+
+interface Props {
+  options: FilterOptionSet
+  initial: {
+    preset: PresetRange
+    from: string
+    to: string
+    vendorId: string
+    categoryId: string
+    status: string
+  }
+}
+
+export function AnalyticsFilters({ options, initial }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  const draft = useAnalyticsFiltersStore(s => s.draft)
+  const setPreset = useAnalyticsFiltersStore(s => s.setPreset)
+  const setField = useAnalyticsFiltersStore(s => s.setField)
+  const reset = useAnalyticsFiltersStore(s => s.reset)
+
+  useEffect(() => {
+    reset(initial)
+  }, [reset, initial])
+
+  const currentQuery = useMemo(() => searchParams.toString(), [searchParams])
+
+  const apply = () => {
+    const params = new URLSearchParams()
+    params.set('preset', draft.preset)
+    if (draft.preset === 'custom') {
+      if (draft.from) params.set('from', draft.from)
+      if (draft.to) params.set('to', draft.to)
+    }
+    if (draft.vendorId) params.set('vendor', draft.vendorId)
+    if (draft.categoryId) params.set('category', draft.categoryId)
+    if (draft.status) params.set('status', draft.status)
+    const next = params.toString()
+    if (next === currentQuery) return
+    startTransition(() => {
+      router.push(`${pathname}?${next}`)
+    })
+  }
+
+  const clear = () => {
+    startTransition(() => {
+      router.push(pathname)
+    })
+  }
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-wrap gap-1.5">
+          {PRESET_LABELS.map(p => {
+            const active = draft.preset === p.value
+            return (
+              <button
+                type="button"
+                key={p.value}
+                onClick={() => setPreset(p.value)}
+                className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
+                  active
+                    ? 'border-emerald-500 bg-emerald-600 text-white'
+                    : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)] hover:border-emerald-300'
+                }`}
+              >
+                {p.label}
+              </button>
+            )
+          })}
+        </div>
+
+        {draft.preset === 'custom' && (
+          <div className="flex items-end gap-2">
+            <label className="flex flex-col text-xs text-[var(--muted)]">
+              Desde
+              <input
+                type="date"
+                value={draft.from}
+                onChange={e => setField('from', e.target.value)}
+                className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+            </label>
+            <label className="flex flex-col text-xs text-[var(--muted)]">
+              Hasta
+              <input
+                type="date"
+                value={draft.to}
+                onChange={e => setField('to', e.target.value)}
+                className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+            </label>
+          </div>
+        )}
+
+        <label className="flex flex-col text-xs text-[var(--muted)]">
+          Productor
+          <select
+            value={draft.vendorId}
+            onChange={e => setField('vendorId', e.target.value)}
+            className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--foreground)]"
+          >
+            <option value="">Todos</option>
+            {options.vendors.map(v => (
+              <option key={v.id} value={v.id}>
+                {v.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col text-xs text-[var(--muted)]">
+          Categoría
+          <select
+            value={draft.categoryId}
+            onChange={e => setField('categoryId', e.target.value)}
+            className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--foreground)]"
+          >
+            <option value="">Todas</option>
+            {options.categories.map(c => (
+              <option key={c.id} value={c.id}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col text-xs text-[var(--muted)]">
+          Estado
+          <select
+            value={draft.status}
+            onChange={e => setField('status', e.target.value)}
+            className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-sm text-[var(--foreground)]"
+          >
+            {ORDER_STATUSES.map(s => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded-md border border-[var(--border)] px-3 py-1.5 text-xs text-[var(--muted)] hover:border-[var(--border-strong)]"
+          >
+            Limpiar
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            disabled={isPending}
+            className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-60"
+          >
+            {isPending ? 'Aplicando…' : 'Aplicar filtros'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/analytics/InsightsPanel.tsx
+++ b/src/components/admin/analytics/InsightsPanel.tsx
@@ -1,0 +1,44 @@
+import type { Insight } from '@/domains/analytics/types'
+
+interface Props {
+  insights: Insight[]
+}
+
+const TONE_STYLES: Record<Insight['tone'], string> = {
+  positive: 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200',
+  neutral: 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground)]',
+}
+
+const TONE_ICON: Record<Insight['tone'], string> = {
+  positive: '↑',
+  warning: '!',
+  neutral: '•',
+}
+
+export function InsightsPanel({ insights }: Props) {
+  if (insights.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-[var(--border)] p-4 text-sm text-[var(--muted)]">
+        Sin insights para este periodo.
+      </div>
+    )
+  }
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {insights.map(i => (
+        <div key={i.id} className={`rounded-xl border p-3 ${TONE_STYLES[i.tone]}`}>
+          <div className="flex items-start gap-2">
+            <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/60 text-sm font-bold dark:bg-black/30">
+              {TONE_ICON[i.tone]}
+            </span>
+            <div>
+              <p className="text-sm font-semibold">{i.title}</p>
+              <p className="mt-1 text-xs opacity-90">{i.body}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/analytics/KpiCard.tsx
+++ b/src/components/admin/analytics/KpiCard.tsx
@@ -1,0 +1,53 @@
+import type { DeltaMetric } from '@/domains/analytics/types'
+import { formatPrice } from '@/lib/utils'
+
+interface Props {
+  label: string
+  metric: DeltaMetric
+  format?: 'currency' | 'number' | 'percent'
+  hint?: string
+}
+
+function formatValue(value: number, format: Props['format']): string {
+  if (format === 'currency') return formatPrice(value)
+  if (format === 'percent') return `${value.toFixed(1)}%`
+  return Math.round(value).toLocaleString('es-ES')
+}
+
+function formatDelta(deltaPct: number | null): { text: string; tone: 'up' | 'down' | 'flat' } {
+  if (deltaPct == null) return { text: 'sin histórico', tone: 'flat' }
+  if (Math.abs(deltaPct) < 0.05) return { text: '0%', tone: 'flat' }
+  const rounded = Math.round(deltaPct * 10) / 10
+  return {
+    text: `${rounded > 0 ? '↑' : '↓'} ${Math.abs(rounded).toFixed(1)}%`,
+    tone: rounded > 0 ? 'up' : 'down',
+  }
+}
+
+export function KpiCard({ label, metric, format = 'number', hint }: Props) {
+  const delta = formatDelta(metric.deltaPct)
+  const toneClass =
+    delta.tone === 'up'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : delta.tone === 'down'
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-[var(--muted)]'
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--muted-light)]">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-bold text-[var(--foreground)]">
+        {formatValue(metric.current, format)}
+      </p>
+      <div className="mt-1 flex items-center justify-between text-xs">
+        <span className={`font-semibold ${toneClass}`}>{delta.text}</span>
+        <span className="text-[var(--muted)]">
+          prev: {formatValue(metric.previous, format)}
+        </span>
+      </div>
+      {hint && <p className="mt-1 text-[11px] text-[var(--muted-light)]">{hint}</p>}
+    </div>
+  )
+}

--- a/src/components/admin/analytics/OrdersTable.tsx
+++ b/src/components/admin/analytics/OrdersTable.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { OrderRow } from '@/domains/analytics/types'
+import { formatPrice } from '@/lib/utils'
+
+interface Props {
+  rows: OrderRow[]
+}
+
+type SortKey = 'placedAt' | 'grandTotal' | 'customerName' | 'vendorName' | 'status'
+type SortDir = 'asc' | 'desc'
+
+const PAGE_SIZE = 20
+
+const STATUS_LABELS: Record<string, string> = {
+  PLACED: 'Realizado',
+  PAYMENT_CONFIRMED: 'Pagado',
+  PROCESSING: 'Procesando',
+  PARTIALLY_SHIPPED: 'Parcial',
+  SHIPPED: 'Enviado',
+  DELIVERED: 'Entregado',
+  CANCELLED: 'Cancelado',
+  REFUNDED: 'Reembolsado',
+}
+
+function toCsv(rows: OrderRow[]): string {
+  const header = ['Nº pedido', 'Fecha', 'Cliente', 'Productor', 'Estado', 'Total']
+  const lines = rows.map(r =>
+    [
+      r.orderNumber,
+      new Date(r.placedAt).toISOString(),
+      `"${r.customerName.replace(/"/g, '""')}"`,
+      `"${r.vendorName.replace(/"/g, '""')}"`,
+      r.status,
+      r.grandTotal.toFixed(2),
+    ].join(','),
+  )
+  return [header.join(','), ...lines].join('\n')
+}
+
+export function OrdersTable({ rows }: Props) {
+  const [query, setQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('placedAt')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [page, setPage] = useState(0)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const base = q
+      ? rows.filter(
+          r =>
+            r.orderNumber.toLowerCase().includes(q) ||
+            r.customerName.toLowerCase().includes(q) ||
+            r.vendorName.toLowerCase().includes(q),
+        )
+      : rows
+    const sorted = [...base].sort((a, b) => {
+      const av = a[sortKey]
+      const bv = b[sortKey]
+      if (av === bv) return 0
+      const cmp = av > bv ? 1 : -1
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+    return sorted
+  }, [rows, query, sortKey, sortDir])
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const pageRows = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  const exportCsv = () => {
+    const csv = toCsv(filtered)
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `pedidos-${new Date().toISOString().slice(0, 10)}.csv`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+  }
+
+  const sortIcon = (key: SortKey) =>
+    sortKey === key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
+      <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border)] p-4">
+        <h3 className="text-sm font-semibold text-[var(--foreground)]">Pedidos en el periodo</h3>
+        <span className="text-xs text-[var(--muted)]">{filtered.length} resultados</span>
+        <div className="ml-auto flex items-center gap-2">
+          <input
+            type="search"
+            value={query}
+            onChange={e => {
+              setQuery(e.target.value)
+              setPage(0)
+            }}
+            placeholder="Buscar nº, cliente, productor…"
+            className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs text-[var(--foreground)]"
+          />
+          <button
+            type="button"
+            onClick={exportCsv}
+            className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-100 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300"
+          >
+            Exportar CSV
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="text-xs uppercase tracking-wide text-[var(--muted-light)]">
+            <tr className="border-b border-[var(--border)]">
+              <th className="px-4 py-2 font-medium">Nº</th>
+              <th className="cursor-pointer px-4 py-2 font-medium" onClick={() => toggleSort('placedAt')}>
+                Fecha{sortIcon('placedAt')}
+              </th>
+              <th className="cursor-pointer px-4 py-2 font-medium" onClick={() => toggleSort('customerName')}>
+                Cliente{sortIcon('customerName')}
+              </th>
+              <th className="cursor-pointer px-4 py-2 font-medium" onClick={() => toggleSort('vendorName')}>
+                Productor{sortIcon('vendorName')}
+              </th>
+              <th className="cursor-pointer px-4 py-2 font-medium" onClick={() => toggleSort('status')}>
+                Estado{sortIcon('status')}
+              </th>
+              <th className="cursor-pointer px-4 py-2 text-right font-medium" onClick={() => toggleSort('grandTotal')}>
+                Total{sortIcon('grandTotal')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map(r => (
+              <tr key={r.id} className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--surface-raised)]">
+                <td className="px-4 py-2 font-mono text-xs">{r.orderNumber}</td>
+                <td className="px-4 py-2 text-xs text-[var(--muted)]">
+                  {new Date(r.placedAt).toLocaleDateString('es-ES', {
+                    day: '2-digit',
+                    month: '2-digit',
+                    year: 'numeric',
+                  })}
+                </td>
+                <td className="px-4 py-2">{r.customerName || '—'}</td>
+                <td className="px-4 py-2 text-[var(--muted)]">{r.vendorName}</td>
+                <td className="px-4 py-2">
+                  <span className="rounded-full bg-[var(--surface-raised)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[var(--foreground)]">
+                    {STATUS_LABELS[r.status] ?? r.status}
+                  </span>
+                </td>
+                <td className="px-4 py-2 text-right font-semibold">{formatPrice(r.grandTotal)}</td>
+              </tr>
+            ))}
+            {pageRows.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-[var(--muted)]">
+                  No hay pedidos para estos filtros.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-3 text-xs text-[var(--muted)]">
+          <span>
+            Página {clampedPage + 1} de {pageCount}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={clampedPage === 0}
+              className="rounded-md border border-[var(--border)] px-3 py-1 disabled:opacity-40"
+            >
+              ← Anterior
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage(p => Math.min(pageCount - 1, p + 1))}
+              disabled={clampedPage >= pageCount - 1}
+              className="rounded-md border border-[var(--border)] px-3 py-1 disabled:opacity-40"
+            >
+              Siguiente →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/analytics/charts/CategoryPieChart.tsx
+++ b/src/components/admin/analytics/charts/CategoryPieChart.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
+import type { CategorySlice } from '@/domains/analytics/types'
+
+interface Props {
+  data: CategorySlice[]
+}
+
+const COLORS = ['#10b981', '#6366f1', '#f59e0b', '#ef4444', '#14b8a6', '#8b5cf6', '#ec4899', '#0ea5e9']
+
+export function CategoryPieChart({ data }: Props) {
+  const chartData = data.slice(0, 8).map(d => ({ name: d.name, value: d.revenue, share: d.sharePct }))
+  return (
+    <div className="h-[280px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={chartData}
+            dataKey="value"
+            nameKey="name"
+            innerRadius={55}
+            outerRadius={90}
+            paddingAngle={2}
+          >
+            {chartData.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: '8px',
+              fontSize: '12px',
+            }}
+            formatter={(value, _name, item) => {
+              const num = Number(value ?? 0)
+              const payload = (item as { payload?: { share?: number } } | undefined)?.payload
+              return [`${num.toFixed(0)} € (${payload?.share?.toFixed(1) ?? '0'}%)`, 'Revenue']
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: '11px' }} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/admin/analytics/charts/RankedBarChart.tsx
+++ b/src/components/admin/analytics/charts/RankedBarChart.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import type { RankedItem } from '@/domains/analytics/types'
+
+interface Props {
+  data: RankedItem[]
+  color?: string
+}
+
+function formatEur(value: number): string {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k €`
+  return `${value.toFixed(0)} €`
+}
+
+export function RankedBarChart({ data, color = '#10b981' }: Props) {
+  const chartData = data.map(d => ({ name: d.name.length > 22 ? `${d.name.slice(0, 20)}…` : d.name, revenue: d.revenue }))
+  return (
+    <div className="h-[320px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} layout="vertical" margin={{ left: 16, right: 16 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" horizontal={false} />
+          <XAxis type="number" tickFormatter={formatEur} stroke="var(--muted)" fontSize={11} />
+          <YAxis type="category" dataKey="name" stroke="var(--muted)" fontSize={11} width={130} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: '8px',
+              fontSize: '12px',
+            }}
+            formatter={value => [formatEur(Number(value ?? 0)), 'Revenue']}
+          />
+          <Bar dataKey="revenue" fill={color} radius={[0, 4, 4, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/admin/analytics/charts/SalesEvolutionChart.tsx
+++ b/src/components/admin/analytics/charts/SalesEvolutionChart.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { SalesPoint } from '@/domains/analytics/types'
+
+interface Props {
+  data: SalesPoint[]
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('es-ES', { day: '2-digit', month: 'short' })
+}
+
+function formatEur(value: number): string {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k €`
+  return `${value.toFixed(0)} €`
+}
+
+export function SalesEvolutionChart({ data }: Props) {
+  return (
+    <div className="h-[320px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+          <defs>
+            <linearGradient id="gmvFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#10b981" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+          <XAxis dataKey="date" tickFormatter={formatDate} stroke="var(--muted)" fontSize={11} />
+          <YAxis
+            yAxisId="gmv"
+            tickFormatter={formatEur}
+            stroke="var(--muted)"
+            fontSize={11}
+            width={60}
+          />
+          <YAxis
+            yAxisId="orders"
+            orientation="right"
+            stroke="var(--muted)"
+            fontSize={11}
+            width={40}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--surface)',
+              border: '1px solid var(--border)',
+              borderRadius: '8px',
+              fontSize: '12px',
+            }}
+            labelFormatter={label => (typeof label === 'string' ? formatDate(label) : String(label ?? ''))}
+            formatter={(value, name) => {
+              const num = Number(value ?? 0)
+              return name === 'GMV' ? [formatEur(num), 'GMV'] : [num.toLocaleString('es-ES'), 'Pedidos']
+            }}
+          />
+          <Legend wrapperStyle={{ fontSize: '12px' }} />
+          <Area
+            yAxisId="gmv"
+            type="monotone"
+            dataKey="gmv"
+            stroke="#10b981"
+            fill="url(#gmvFill)"
+            strokeWidth={2}
+            name="GMV"
+          />
+          <Line
+            yAxisId="orders"
+            type="monotone"
+            dataKey="orders"
+            stroke="#6366f1"
+            strokeWidth={2}
+            dot={false}
+            name="Pedidos"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/admin/analytics/useAnalyticsFiltersStore.ts
+++ b/src/components/admin/analytics/useAnalyticsFiltersStore.ts
@@ -1,0 +1,36 @@
+'use client'
+
+import { create } from 'zustand'
+import type { PresetRange } from '@/domains/analytics/types'
+
+interface DraftFilters {
+  preset: PresetRange
+  from: string // ISO date yyyy-mm-dd
+  to: string // ISO date yyyy-mm-dd
+  vendorId: string
+  categoryId: string
+  status: string
+}
+
+interface FilterStore {
+  draft: DraftFilters
+  setPreset: (preset: PresetRange) => void
+  setField: <K extends keyof DraftFilters>(key: K, value: DraftFilters[K]) => void
+  reset: (next: DraftFilters) => void
+}
+
+const emptyDraft: DraftFilters = {
+  preset: '30d',
+  from: '',
+  to: '',
+  vendorId: '',
+  categoryId: '',
+  status: '',
+}
+
+export const useAnalyticsFiltersStore = create<FilterStore>(set => ({
+  draft: emptyDraft,
+  setPreset: preset => set(state => ({ draft: { ...state.draft, preset } })),
+  setField: (key, value) => set(state => ({ draft: { ...state.draft, [key]: value } })),
+  reset: next => set({ draft: next }),
+}))

--- a/src/domains/analytics/actions.ts
+++ b/src/domains/analytics/actions.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { getActionSession } from '@/lib/action-session'
+import { isAdmin } from '@/lib/roles'
+import { redirect } from 'next/navigation'
+import { parseFilters } from './filters'
+import { getAnalytics } from './service'
+
+export async function exportOrdersCsv(rawParams: Record<string, string | undefined>): Promise<string> {
+  const session = await getActionSession()
+  if (!session || !isAdmin(session.user.role)) redirect('/login')
+
+  const filters = parseFilters(rawParams)
+  const data = await getAnalytics(filters)
+
+  const header = ['orderNumber', 'placedAt', 'customer', 'vendor', 'status', 'grandTotal']
+  const rows = data.orders.map(o =>
+    [
+      o.orderNumber,
+      o.placedAt,
+      `"${o.customerName.replace(/"/g, '""')}"`,
+      `"${o.vendorName.replace(/"/g, '""')}"`,
+      o.status,
+      o.grandTotal.toFixed(2),
+    ].join(','),
+  )
+  return [header.join(','), ...rows].join('\n')
+}

--- a/src/domains/analytics/filters.ts
+++ b/src/domains/analytics/filters.ts
@@ -1,0 +1,132 @@
+import type { OrderStatus } from '@/generated/prisma/enums'
+import type { AnalyticsFilters, PresetRange, SerializableFilters } from './types'
+
+const ORDER_STATUS_VALUES: readonly OrderStatus[] = [
+  'PLACED',
+  'PAYMENT_CONFIRMED',
+  'PROCESSING',
+  'PARTIALLY_SHIPPED',
+  'SHIPPED',
+  'DELIVERED',
+  'CANCELLED',
+  'REFUNDED',
+]
+
+const PRESETS: readonly PresetRange[] = ['today', '7d', '30d', 'mtd', 'custom']
+
+function startOfDay(d: Date): Date {
+  const r = new Date(d)
+  r.setHours(0, 0, 0, 0)
+  return r
+}
+
+function endOfDay(d: Date): Date {
+  const r = new Date(d)
+  r.setHours(23, 59, 59, 999)
+  return r
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+export function rangeForPreset(preset: PresetRange, now: Date = new Date()): { from: Date; to: Date } {
+  const to = endOfDay(now)
+  switch (preset) {
+    case 'today':
+      return { from: startOfDay(now), to }
+    case '7d': {
+      const from = startOfDay(now)
+      from.setDate(from.getDate() - 6)
+      return { from, to }
+    }
+    case 'mtd': {
+      const from = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0)
+      return { from, to }
+    }
+    case '30d':
+    default: {
+      const from = startOfDay(now)
+      from.setDate(from.getDate() - 29)
+      return { from, to }
+    }
+  }
+}
+
+export function parseFilters(params: Record<string, string | string[] | undefined>): AnalyticsFilters {
+  const raw = (key: string): string | undefined => {
+    const v = params[key]
+    return Array.isArray(v) ? v[0] : v
+  }
+
+  const presetRaw = raw('preset')
+  const preset: PresetRange = PRESETS.includes(presetRaw as PresetRange)
+    ? (presetRaw as PresetRange)
+    : '30d'
+
+  let from: Date
+  let to: Date
+
+  if (preset === 'custom') {
+    const parsedFrom = parseDate(raw('from'))
+    const parsedTo = parseDate(raw('to'))
+    if (parsedFrom && parsedTo) {
+      from = startOfDay(parsedFrom)
+      to = endOfDay(parsedTo)
+    } else {
+      ;({ from, to } = rangeForPreset('30d'))
+    }
+  } else {
+    ;({ from, to } = rangeForPreset(preset))
+  }
+
+  const orderStatusRaw = raw('status')
+  const orderStatus = ORDER_STATUS_VALUES.includes(orderStatusRaw as OrderStatus)
+    ? (orderStatusRaw as OrderStatus)
+    : undefined
+
+  return {
+    preset,
+    from,
+    to,
+    vendorId: raw('vendor') || undefined,
+    categoryId: raw('category') || undefined,
+    orderStatus,
+  }
+}
+
+export function previousPeriod(filters: AnalyticsFilters): { from: Date; to: Date } {
+  const spanMs = filters.to.getTime() - filters.from.getTime()
+  const to = new Date(filters.from.getTime() - 1)
+  const from = new Date(to.getTime() - spanMs)
+  return { from, to }
+}
+
+export function describeRange(filters: AnalyticsFilters): string {
+  const fmt = (d: Date) => d.toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' })
+  switch (filters.preset) {
+    case 'today':
+      return `Hoy · ${fmt(filters.from)}`
+    case '7d':
+      return `Últimos 7 días · ${fmt(filters.from)} – ${fmt(filters.to)}`
+    case '30d':
+      return `Últimos 30 días · ${fmt(filters.from)} – ${fmt(filters.to)}`
+    case 'mtd':
+      return `Este mes · ${fmt(filters.from)} – ${fmt(filters.to)}`
+    case 'custom':
+      return `${fmt(filters.from)} – ${fmt(filters.to)}`
+  }
+}
+
+export function toSerializable(filters: AnalyticsFilters): SerializableFilters {
+  return {
+    preset: filters.preset,
+    from: filters.from.toISOString(),
+    to: filters.to.toISOString(),
+    vendorId: filters.vendorId,
+    categoryId: filters.categoryId,
+    orderStatus: filters.orderStatus,
+  }
+}

--- a/src/domains/analytics/insights.ts
+++ b/src/domains/analytics/insights.ts
@@ -1,0 +1,97 @@
+import type {
+  CategorySlice,
+  Insight,
+  Kpis,
+  RankedItem,
+  SalesPoint,
+} from './types'
+
+interface BuildInsightsInput {
+  kpis: Kpis
+  topProducts: RankedItem[]
+  topVendors: RankedItem[]
+  categoryBreakdown: CategorySlice[]
+  salesEvolution: SalesPoint[]
+}
+
+function formatPct(value: number | null): string {
+  if (value == null) return '—'
+  const rounded = Math.round(value * 10) / 10
+  const sign = rounded > 0 ? '+' : ''
+  return `${sign}${rounded.toFixed(1)}%`
+}
+
+export function buildInsights(input: BuildInsightsInput): Insight[] {
+  const { kpis, topProducts, topVendors, categoryBreakdown } = input
+  const insights: Insight[] = []
+
+  if (kpis.gmv.deltaPct != null) {
+    const tone = kpis.gmv.deltaPct >= 0 ? 'positive' : 'warning'
+    insights.push({
+      id: 'gmv-trend',
+      tone,
+      title: `GMV ${kpis.gmv.deltaPct >= 0 ? 'crece' : 'cae'} ${formatPct(kpis.gmv.deltaPct)}`,
+      body: 'Variación respecto al periodo anterior de la misma duración.',
+    })
+  }
+
+  if (topProducts[0]) {
+    insights.push({
+      id: 'top-product',
+      tone: 'neutral',
+      title: `Producto estrella: ${topProducts[0].name}`,
+      body: topProducts[0].secondary
+        ? `De ${topProducts[0].secondary}. ${topProducts[0].count} unidades vendidas.`
+        : `${topProducts[0].count} unidades vendidas.`,
+    })
+  }
+
+  if (topVendors[0]) {
+    const totalVendorRevenue = topVendors.reduce((s, v) => s + v.revenue, 0)
+    const share = totalVendorRevenue > 0 ? (topVendors[0].revenue / totalVendorRevenue) * 100 : 0
+    if (share >= 30) {
+      insights.push({
+        id: 'vendor-concentration',
+        tone: 'warning',
+        title: `${topVendors[0].name} concentra ${share.toFixed(0)}% del revenue`,
+        body: 'Alta dependencia de un único productor. Considera diversificar.',
+      })
+    } else {
+      insights.push({
+        id: 'top-vendor',
+        tone: 'positive',
+        title: `Líder: ${topVendors[0].name}`,
+        body: `Representa ${share.toFixed(0)}% del revenue del top 10.`,
+      })
+    }
+  }
+
+  if (kpis.incidentRatePct.current >= 5) {
+    insights.push({
+      id: 'incident-rate',
+      tone: 'warning',
+      title: `Ratio de incidencias elevado: ${kpis.incidentRatePct.current.toFixed(1)}%`,
+      body: 'Revisa la categoría o productores implicados para contener el impacto.',
+    })
+  }
+
+  if (kpis.repeatRatePct.deltaPct != null && kpis.repeatRatePct.deltaPct > 10) {
+    insights.push({
+      id: 'repeat-customers',
+      tone: 'positive',
+      title: `Repetición de clientes al alza (${formatPct(kpis.repeatRatePct.deltaPct)})`,
+      body: 'Señal de fidelización — buen momento para campañas de retención.',
+    })
+  }
+
+  if (categoryBreakdown[0] && categoryBreakdown[0].sharePct >= 50) {
+    insights.push({
+      id: 'category-concentration',
+      tone: 'warning',
+      title: `${categoryBreakdown[0].name} acapara ${categoryBreakdown[0].sharePct.toFixed(0)}% del GMV`,
+      body: 'Concentración de ventas en una sola categoría.',
+    })
+  }
+
+  return insights
+}

--- a/src/domains/analytics/service.ts
+++ b/src/domains/analytics/service.ts
@@ -1,0 +1,422 @@
+import { db } from '@/lib/db'
+import { Prisma } from '@/generated/prisma/client'
+import type { OrderStatus } from '@/generated/prisma/enums'
+import { describeRange, previousPeriod } from './filters'
+import { buildInsights } from './insights'
+import type {
+  AnalyticsFilters,
+  AnalyticsPayload,
+  CategorySlice,
+  DeltaMetric,
+  Kpis,
+  OrderRow,
+  OrderStatusSlice,
+  RankedItem,
+  SalesPoint,
+} from './types'
+
+const EXCLUDED_STATUSES: OrderStatus[] = ['CANCELLED']
+
+function toNumber(value: Prisma.Decimal | number | null | undefined): number {
+  if (value == null) return 0
+  return typeof value === 'number' ? value : Number(value)
+}
+
+function delta(current: number, previous: number): DeltaMetric {
+  const deltaPct = previous === 0 ? (current === 0 ? 0 : null) : ((current - previous) / previous) * 100
+  return { current, previous, deltaPct }
+}
+
+function buildOrderWhere(filters: AnalyticsFilters, from: Date, to: Date): Prisma.OrderWhereInput {
+  const where: Prisma.OrderWhereInput = {
+    placedAt: { gte: from, lte: to },
+  }
+  if (filters.orderStatus) {
+    where.status = filters.orderStatus
+  } else {
+    where.status = { notIn: EXCLUDED_STATUSES }
+  }
+  const lineFilters: Prisma.OrderLineWhereInput = {}
+  if (filters.vendorId) lineFilters.vendorId = filters.vendorId
+  if (filters.categoryId) lineFilters.product = { categoryId: filters.categoryId }
+  if (Object.keys(lineFilters).length > 0) {
+    where.lines = { some: lineFilters }
+  }
+  return where
+}
+
+async function aggregateTotals(where: Prisma.OrderWhereInput) {
+  const [agg, customersRaw] = await Promise.all([
+    db.order.aggregate({
+      where,
+      _sum: { grandTotal: true, taxAmount: true },
+      _count: { _all: true },
+    }),
+    db.order.findMany({ where, select: { customerId: true } }),
+  ])
+  const gmv = toNumber(agg._sum.grandTotal)
+  const orders = agg._count._all
+  const tax = toNumber(agg._sum.taxAmount)
+  const uniqueCustomerIds = new Set(customersRaw.map(o => o.customerId))
+  return { gmv, orders, tax, uniqueCustomers: uniqueCustomerIds.size }
+}
+
+async function computeRepeatRate(where: Prisma.OrderWhereInput): Promise<number> {
+  const grouped = await db.order.groupBy({
+    by: ['customerId'],
+    where,
+    _count: { _all: true },
+  })
+  if (grouped.length === 0) return 0
+  const repeat = grouped.filter(g => g._count._all > 1).length
+  return (repeat / grouped.length) * 100
+}
+
+async function computeIncidentRate(orderCount: number, from: Date, to: Date, filters: AnalyticsFilters): Promise<number> {
+  if (orderCount === 0) return 0
+  const incidentWhere: Prisma.IncidentWhereInput = { createdAt: { gte: from, lte: to } }
+  if (filters.vendorId || filters.categoryId) {
+    incidentWhere.order = buildOrderWhere(filters, from, to)
+  }
+  const count = await db.incident.count({ where: incidentWhere })
+  return (count / orderCount) * 100
+}
+
+async function computeCommission(where: Prisma.OrderWhereInput): Promise<number> {
+  const lines = await db.orderLine.findMany({
+    where: { order: where },
+    select: { quantity: true, unitPrice: true, vendorId: true },
+  })
+  if (lines.length === 0) return 0
+  const vendorIds = Array.from(new Set(lines.map(l => l.vendorId)))
+  const vendors = await db.vendor.findMany({
+    where: { id: { in: vendorIds } },
+    select: { id: true, commissionRate: true },
+  })
+  const rateMap = new Map(vendors.map(v => [v.id, toNumber(v.commissionRate)]))
+  let total = 0
+  for (const line of lines) {
+    const gross = toNumber(line.unitPrice) * line.quantity
+    total += gross * (rateMap.get(line.vendorId) ?? 0)
+  }
+  return total
+}
+
+async function computeKpis(filters: AnalyticsFilters): Promise<Kpis> {
+  const prev = previousPeriod(filters)
+  const currentWhere = buildOrderWhere(filters, filters.from, filters.to)
+  const previousWhere = buildOrderWhere(filters, prev.from, prev.to)
+
+  const [curr, prv] = await Promise.all([aggregateTotals(currentWhere), aggregateTotals(previousWhere)])
+  const [currRepeat, prvRepeat] = await Promise.all([
+    computeRepeatRate(currentWhere),
+    computeRepeatRate(previousWhere),
+  ])
+  const [currIncident, prvIncident] = await Promise.all([
+    computeIncidentRate(curr.orders, filters.from, filters.to, filters),
+    computeIncidentRate(prv.orders, prev.from, prev.to, filters),
+  ])
+  const [currCommission, prvCommission] = await Promise.all([
+    computeCommission(currentWhere),
+    computeCommission(previousWhere),
+  ])
+
+  const currAov = curr.orders > 0 ? curr.gmv / curr.orders : 0
+  const prvAov = prv.orders > 0 ? prv.gmv / prv.orders : 0
+
+  return {
+    gmv: delta(curr.gmv, prv.gmv),
+    orders: delta(curr.orders, prv.orders),
+    aov: delta(currAov, prvAov),
+    uniqueCustomers: delta(curr.uniqueCustomers, prv.uniqueCustomers),
+    repeatRatePct: delta(currRepeat, prvRepeat),
+    incidentRatePct: delta(currIncident, prvIncident),
+    commission: delta(currCommission, prvCommission),
+    tax: delta(curr.tax, prv.tax),
+  }
+}
+
+async function computeSalesEvolution(filters: AnalyticsFilters): Promise<SalesPoint[]> {
+  const excluded = Prisma.sql`ARRAY['CANCELLED']::"OrderStatus"[]`
+  const statusClause = filters.orderStatus
+    ? Prisma.sql`o."status" = ${filters.orderStatus}::"OrderStatus"`
+    : Prisma.sql`o."status" <> ALL (${excluded})`
+
+  const vendorClause = filters.vendorId
+    ? Prisma.sql`AND EXISTS (SELECT 1 FROM "OrderLine" l WHERE l."orderId" = o."id" AND l."vendorId" = ${filters.vendorId})`
+    : Prisma.empty
+  const categoryClause = filters.categoryId
+    ? Prisma.sql`AND EXISTS (
+        SELECT 1 FROM "OrderLine" l
+        JOIN "Product" p ON p."id" = l."productId"
+        WHERE l."orderId" = o."id" AND p."categoryId" = ${filters.categoryId}
+      )`
+    : Prisma.empty
+
+  const rows = await db.$queryRaw<Array<{ bucket: Date; gmv: Prisma.Decimal; orders: bigint }>>(
+    Prisma.sql`
+      SELECT
+        date_trunc('day', o."placedAt") AS bucket,
+        COALESCE(SUM(o."grandTotal"), 0) AS gmv,
+        COUNT(*)::bigint AS orders
+      FROM "Order" o
+      WHERE o."placedAt" BETWEEN ${filters.from} AND ${filters.to}
+        AND ${statusClause}
+        ${vendorClause}
+        ${categoryClause}
+      GROUP BY bucket
+      ORDER BY bucket ASC
+    `,
+  )
+
+  const byDate = new Map<string, SalesPoint>()
+  for (const row of rows) {
+    const key = new Date(row.bucket).toISOString().slice(0, 10)
+    byDate.set(key, { date: key, gmv: toNumber(row.gmv), orders: Number(row.orders) })
+  }
+
+  const out: SalesPoint[] = []
+  const cursor = new Date(filters.from)
+  cursor.setHours(0, 0, 0, 0)
+  const last = new Date(filters.to)
+  last.setHours(0, 0, 0, 0)
+  while (cursor.getTime() <= last.getTime()) {
+    const key = cursor.toISOString().slice(0, 10)
+    out.push(byDate.get(key) ?? { date: key, gmv: 0, orders: 0 })
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return out
+}
+
+async function computeTopProducts(filters: AnalyticsFilters): Promise<RankedItem[]> {
+  const where = buildOrderWhere(filters, filters.from, filters.to)
+  const grouped = await db.orderLine.groupBy({
+    by: ['productId'],
+    where: {
+      order: where,
+      ...(filters.vendorId ? { vendorId: filters.vendorId } : {}),
+      ...(filters.categoryId ? { product: { categoryId: filters.categoryId } } : {}),
+    },
+    _sum: { quantity: true },
+    orderBy: { _sum: { quantity: 'desc' } },
+    take: 10,
+  })
+  if (grouped.length === 0) return []
+
+  const products = await db.product.findMany({
+    where: { id: { in: grouped.map(g => g.productId) } },
+    select: { id: true, name: true, vendor: { select: { displayName: true } } },
+  })
+  const productMap = new Map(products.map(p => [p.id, p]))
+
+  const lineSums = await db.orderLine.groupBy({
+    by: ['productId'],
+    where: {
+      productId: { in: grouped.map(g => g.productId) },
+      order: where,
+    },
+    _sum: { quantity: true },
+  })
+  const qtyMap = new Map(lineSums.map(l => [l.productId, Number(l._sum.quantity ?? 0)]))
+
+  const lines = await db.orderLine.findMany({
+    where: { productId: { in: grouped.map(g => g.productId) }, order: where },
+    select: { productId: true, quantity: true, unitPrice: true },
+  })
+  const revenueMap = new Map<string, number>()
+  for (const l of lines) {
+    const r = revenueMap.get(l.productId) ?? 0
+    revenueMap.set(l.productId, r + toNumber(l.unitPrice) * l.quantity)
+  }
+
+  return grouped
+    .map(g => {
+      const p = productMap.get(g.productId)
+      return {
+        id: g.productId,
+        name: p?.name ?? 'Producto eliminado',
+        revenue: revenueMap.get(g.productId) ?? 0,
+        count: qtyMap.get(g.productId) ?? 0,
+        secondary: p?.vendor.displayName,
+      }
+    })
+    .sort((a, b) => b.revenue - a.revenue)
+}
+
+async function computeTopVendors(filters: AnalyticsFilters): Promise<RankedItem[]> {
+  const where = buildOrderWhere(filters, filters.from, filters.to)
+  const lines = await db.orderLine.findMany({
+    where: {
+      order: where,
+      ...(filters.vendorId ? { vendorId: filters.vendorId } : {}),
+      ...(filters.categoryId ? { product: { categoryId: filters.categoryId } } : {}),
+    },
+    select: { vendorId: true, orderId: true, quantity: true, unitPrice: true },
+  })
+  const revenueMap = new Map<string, number>()
+  const orderSet = new Map<string, Set<string>>()
+  for (const l of lines) {
+    revenueMap.set(l.vendorId, (revenueMap.get(l.vendorId) ?? 0) + toNumber(l.unitPrice) * l.quantity)
+    const set = orderSet.get(l.vendorId) ?? new Set<string>()
+    set.add(l.orderId)
+    orderSet.set(l.vendorId, set)
+  }
+  if (revenueMap.size === 0) return []
+  const vendors = await db.vendor.findMany({
+    where: { id: { in: Array.from(revenueMap.keys()) } },
+    select: { id: true, displayName: true },
+  })
+  const nameMap = new Map(vendors.map(v => [v.id, v.displayName]))
+  return Array.from(revenueMap.entries())
+    .map(([id, revenue]) => ({
+      id,
+      name: nameMap.get(id) ?? 'Productor eliminado',
+      revenue,
+      count: orderSet.get(id)?.size ?? 0,
+    }))
+    .sort((a, b) => b.revenue - a.revenue)
+    .slice(0, 10)
+}
+
+async function computeCategoryBreakdown(filters: AnalyticsFilters): Promise<CategorySlice[]> {
+  const where = buildOrderWhere(filters, filters.from, filters.to)
+  const lines = await db.orderLine.findMany({
+    where: {
+      order: where,
+      ...(filters.vendorId ? { vendorId: filters.vendorId } : {}),
+      ...(filters.categoryId ? { product: { categoryId: filters.categoryId } } : {}),
+    },
+    select: {
+      quantity: true,
+      unitPrice: true,
+      product: { select: { category: { select: { id: true, name: true } } } },
+    },
+  })
+  const revenueMap = new Map<string, { id: string; name: string; revenue: number }>()
+  for (const l of lines) {
+    const cat = l.product.category
+    const key = cat?.id ?? '__none__'
+    const label = cat?.name ?? 'Sin categoría'
+    const existing = revenueMap.get(key) ?? { id: key, name: label, revenue: 0 }
+    existing.revenue += toNumber(l.unitPrice) * l.quantity
+    revenueMap.set(key, existing)
+  }
+  const total = Array.from(revenueMap.values()).reduce((s, c) => s + c.revenue, 0)
+  return Array.from(revenueMap.values())
+    .map(c => ({ ...c, sharePct: total > 0 ? (c.revenue / total) * 100 : 0 }))
+    .sort((a, b) => b.revenue - a.revenue)
+}
+
+async function computeStatusBreakdown(filters: AnalyticsFilters): Promise<OrderStatusSlice[]> {
+  const baseFilters = { ...filters, orderStatus: undefined }
+  const where = buildOrderWhere(baseFilters, filters.from, filters.to)
+  const grouped = await db.order.groupBy({
+    by: ['status'],
+    where,
+    _count: { _all: true },
+  })
+  return grouped.map(g => ({ status: g.status, count: g._count._all }))
+}
+
+async function computeRecentOrders(filters: AnalyticsFilters): Promise<OrderRow[]> {
+  const where = buildOrderWhere(filters, filters.from, filters.to)
+  const rows = await db.order.findMany({
+    where,
+    orderBy: { placedAt: 'desc' },
+    take: 200,
+    select: {
+      id: true,
+      orderNumber: true,
+      grandTotal: true,
+      status: true,
+      placedAt: true,
+      customer: { select: { firstName: true, lastName: true } },
+      lines: { take: 1, select: { vendorId: true } },
+    },
+  })
+  const vendorIds = Array.from(new Set(rows.flatMap(r => r.lines.map(l => l.vendorId))))
+  const vendors = vendorIds.length
+    ? await db.vendor.findMany({
+        where: { id: { in: vendorIds } },
+        select: { id: true, displayName: true },
+      })
+    : []
+  const vendorNameMap = new Map(vendors.map(v => [v.id, v.displayName]))
+  return rows.map(r => ({
+    id: r.id,
+    orderNumber: r.orderNumber,
+    customerName: `${r.customer.firstName} ${r.customer.lastName}`.trim(),
+    vendorName: r.lines[0]?.vendorId ? (vendorNameMap.get(r.lines[0].vendorId) ?? '—') : '—',
+    grandTotal: toNumber(r.grandTotal),
+    status: r.status,
+    placedAt: r.placedAt.toISOString(),
+  }))
+}
+
+async function getFilterOptions() {
+  const [vendors, categories] = await Promise.all([
+    db.vendor.findMany({
+      where: { status: 'ACTIVE' },
+      select: { id: true, displayName: true },
+      orderBy: { displayName: 'asc' },
+    }),
+    db.category.findMany({
+      where: { isActive: true, parentId: null },
+      select: { id: true, name: true },
+      orderBy: { sortOrder: 'asc' },
+    }),
+  ])
+  return {
+    vendors: vendors.map(v => ({ id: v.id, label: v.displayName })),
+    categories: categories.map(c => ({ id: c.id, label: c.name })),
+  }
+}
+
+export async function getAnalytics(filters: AnalyticsFilters): Promise<AnalyticsPayload> {
+  const prev = previousPeriod(filters)
+  const [
+    kpis,
+    salesEvolution,
+    topProducts,
+    topVendors,
+    categoryBreakdown,
+    orderStatusBreakdown,
+    orders,
+    filterOptions,
+  ] = await Promise.all([
+    computeKpis(filters),
+    computeSalesEvolution(filters),
+    computeTopProducts(filters),
+    computeTopVendors(filters),
+    computeCategoryBreakdown(filters),
+    computeStatusBreakdown(filters),
+    computeRecentOrders(filters),
+    getFilterOptions(),
+  ])
+
+  const insights = buildInsights({
+    kpis,
+    topProducts,
+    topVendors,
+    categoryBreakdown,
+    salesEvolution,
+  })
+
+  return {
+    period: {
+      from: filters.from.toISOString(),
+      to: filters.to.toISOString(),
+      label: describeRange(filters),
+    },
+    previousPeriod: { from: prev.from.toISOString(), to: prev.to.toISOString() },
+    kpis,
+    salesEvolution,
+    topProducts,
+    topVendors,
+    categoryBreakdown,
+    orderStatusBreakdown,
+    orders,
+    insights,
+    filterOptions,
+  }
+}

--- a/src/domains/analytics/types.ts
+++ b/src/domains/analytics/types.ts
@@ -1,0 +1,100 @@
+import type { OrderStatus } from '@/generated/prisma/enums'
+
+export type PresetRange = 'today' | '7d' | '30d' | 'mtd' | 'custom'
+
+export interface AnalyticsFilters {
+  preset: PresetRange
+  from: Date
+  to: Date
+  vendorId?: string
+  categoryId?: string
+  orderStatus?: OrderStatus
+}
+
+export interface SerializableFilters {
+  preset: PresetRange
+  from: string
+  to: string
+  vendorId?: string
+  categoryId?: string
+  orderStatus?: OrderStatus
+}
+
+export interface DeltaMetric {
+  current: number
+  previous: number
+  deltaPct: number | null
+}
+
+export interface Kpis {
+  gmv: DeltaMetric
+  orders: DeltaMetric
+  aov: DeltaMetric
+  uniqueCustomers: DeltaMetric
+  repeatRatePct: DeltaMetric
+  incidentRatePct: DeltaMetric
+  commission: DeltaMetric
+  tax: DeltaMetric
+}
+
+export interface SalesPoint {
+  date: string
+  gmv: number
+  orders: number
+}
+
+export interface RankedItem {
+  id: string
+  name: string
+  revenue: number
+  count: number
+  secondary?: string
+}
+
+export interface CategorySlice {
+  id: string
+  name: string
+  revenue: number
+  sharePct: number
+}
+
+export interface OrderStatusSlice {
+  status: OrderStatus
+  count: number
+}
+
+export interface OrderRow {
+  id: string
+  orderNumber: string
+  customerName: string
+  vendorName: string
+  grandTotal: number
+  status: OrderStatus
+  placedAt: string
+}
+
+export interface Insight {
+  id: string
+  tone: 'positive' | 'warning' | 'neutral'
+  title: string
+  body: string
+}
+
+export interface FilterOptionSet {
+  vendors: Array<{ id: string; label: string }>
+  categories: Array<{ id: string; label: string }>
+}
+
+export interface AnalyticsPayload {
+  period: { from: string; to: string; label: string }
+  previousPeriod: { from: string; to: string }
+  kpis: Kpis
+  salesEvolution: SalesPoint[]
+  topProducts: RankedItem[]
+  topVendors: RankedItem[]
+  categoryBreakdown: CategorySlice[]
+  orderStatusBreakdown: OrderStatusSlice[]
+  orders: OrderRow[]
+  insights: Insight[]
+  filterOptions: FilterOptionSet
+}


### PR DESCRIPTION
## Summary
- Replaces the 6 static cards in /admin/informes with a full analytics dashboard: period-over-period KPIs (GMV, orders, AOV, unique customers, repeat rate, incident rate, commission, tax), recharts visualisations (GMV+orders evolution, category pie, top products/vendors bar charts), auto-generated insights, and a client-side orders data grid with sort/search/pagination/CSV export.
- New \`src/domains/analytics\` domain with service (optimised time-series via single \`date_trunc\` \`\$queryRaw\`), filter parser, and insights builder.
- Filter bar (preset, custom date range, vendor, category, status) syncs state via URL search params with a lightweight Zustand draft store.

## Test plan
- [x] \`npm run build\` — compiles; /admin/informes rendered as dynamic route
- [x] \`npm test\` — 535/535 passing
- [x] \`tsc --noEmit\` clean
- [ ] Manual smoke in browser: load /admin/informes, change presets, apply filters, sort/search/export in the orders table

🤖 Generated with [Claude Code](https://claude.com/claude-code)