### PR TITLE
fix(auth): resolve dev auth host via request when localhost port drifts

### DIFF
--- a/src/lib/auth-host.ts
+++ b/src/lib/auth-host.ts
@@ -26,7 +26,12 @@ function getPreferredDevAuthUrl(env: NodeJS.ProcessEnv) {
 
   try {
     const parsed = new URL(candidate)
-    return parsed.hostname === '0.0.0.0' ? null : candidate
+    if (parsed.hostname === '0.0.0.0') return null
+    // A private-network candidate is just as likely to be stale as AUTH_URL
+    // (dev port drifts when 3000 is taken). Prefer request-host resolution via
+    // `trustHost: true` in auth.ts instead of pinning a possibly wrong port.
+    if (isPrivateNetworkHost(parsed.hostname)) return null
+    return candidate
   } catch {
     return null
   }

--- a/test/features/auth-host.test.ts
+++ b/test/features/auth-host.test.ts
@@ -44,15 +44,28 @@ test('normalizeAuthHostEnv removes private-network auth urls in development', ()
   assert.equal(env.AUTH_SECRET, 'secret')
 })
 
-test('normalizeAuthHostEnv prefers NEXT_PUBLIC_APP_URL when the dev auth host is stale', () => {
+test('normalizeAuthHostEnv drops dev auth urls even when NEXT_PUBLIC_APP_URL is localhost', () => {
+  // Both AUTH_URL and NEXT_PUBLIC_APP_URL can be stale in dev when the port
+  // drifts. Deleting them lets Auth.js resolve via `trustHost` + request host.
   const env = normalizeAuthHostEnv({
     NODE_ENV: 'development',
     AUTH_URL: 'http://192.168.1.76:3004',
     NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
   })
 
-  assert.equal(env.AUTH_URL, 'http://localhost:3000')
-  assert.equal(env.NEXTAUTH_URL, 'http://localhost:3000')
+  assert.equal('AUTH_URL' in env, false)
+  assert.equal('NEXTAUTH_URL' in env, false)
+})
+
+test('normalizeAuthHostEnv still prefers an external NEXT_PUBLIC_APP_URL', () => {
+  const env = normalizeAuthHostEnv({
+    NODE_ENV: 'development',
+    AUTH_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_APP_URL: 'https://preview.example.com',
+  })
+
+  assert.equal(env.AUTH_URL, 'https://preview.example.com')
+  assert.equal(env.NEXTAUTH_URL, 'https://preview.example.com')
 })
 
 test('normalizeAuthHostEnv keeps external auth url intact', () => {


### PR DESCRIPTION
## Summary
- In dev, `AUTH_URL` / `NEXT_PUBLIC_APP_URL` in `.env.local` can become stale the moment `next dev` picks a different port (3000 busy → 3003, etc.), which made sign-in/out redirect the browser to a dead port.
- `getPreferredDevAuthUrl` now rejects any localhost/private-network candidate, so the normalizer deletes `AUTH_URL`/`NEXTAUTH_URL` entirely and Auth.js falls back to request-host resolution via the existing `trustHost: true`.
- External hosts (cloudflare tunnels, preview URLs) remain pinned exactly as before.

## Test plan
- [x] `npx tsx --test test/features/auth-host.test.ts` — 9/9 pass
- [ ] Start `next dev` on a non-default port (e.g. `PORT=3005 npm run dev`) with `.env.local` pinning `AUTH_URL=http://localhost:3003`, then log in + log out — should stay on the active port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)