### PR TITLE
fix(fulfillment): restore manual advance path through PREPARING/READY

### DIFF
--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -248,8 +248,17 @@ export async function getMyProduct(productId: string) {
 
 // ─── Fulfillment (pedidos) ────────────────────────────────────────────────────
 
+// Manual advance path for vendors who do NOT use the Sendcloud automation:
+// PENDING → CONFIRMED → PREPARING → READY → SHIPPED. The Sendcloud branch
+// (CONFIRMED → LABEL_REQUESTED → READY | LABEL_FAILED) is driven by webhooks
+// and lives in the shipping domain, not here. LABEL_FAILED falls back to
+// manual so the vendor can print their own label and mark the order READY.
 const VALID_TRANSITIONS: Partial<Record<FulfillmentStatus, FulfillmentStatus>> = {
   PENDING: 'CONFIRMED',
+  CONFIRMED: 'PREPARING',
+  PREPARING: 'READY',
+  LABEL_FAILED: 'READY',
+  READY: 'SHIPPED',
 }
 
 /**


### PR DESCRIPTION
## Summary
- #331 (Sendcloud) added \`PREPARING\`, \`LABEL_REQUESTED\`, \`LABEL_FAILED\` and \`READY\` to the \`FulfillmentStatus\` enum but left \`VALID_TRANSITIONS\` in [\`src/domains/vendors/actions.ts\`](src/domains/vendors/actions.ts) with only \`PENDING → CONFIRMED\`. As a result, any vendor not using the Sendcloud label path was stuck at \`CONFIRMED\` and could never mark an order as shipped.
- This also left 4 integration tests red on \`main\` (\`fulfillment-advance.test.ts\`, \`order-state-machine.test.ts\` — tests 25, 51, 52, 54) which blocked every PR CI run since #331 merged.
- Fix: restore the manual chain \`PENDING → CONFIRMED → PREPARING → READY → SHIPPED\`, and additionally allow \`LABEL_FAILED → READY\` as a manual fallback when Sendcloud rejects a label request. The Sendcloud automation path (\`CONFIRMED → LABEL_REQUESTED → READY | LABEL_FAILED\`) is still owned by the shipping webhooks and is intentionally NOT exposed through \`advanceFulfillment\`.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:integration\` — **125/125 pass** (was 121/125 on main)
- [x] \`fulfillment-advance.test.ts\` — all 5 tests green
- [x] \`order-state-machine.test.ts\` — all green, including "PARTIALLY_SHIPPED" and "SHIPPED" recalculation
- [ ] Manual: as a vendor, advance a test fulfillment through the full chain and confirm \`Order.status\` flips to \`SHIPPED\` when the last fulfillment ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)