### PR TITLE
feat(promotions): phase 2 — checkout discount evaluation + coupon UX

### DIFF
--- a/prisma/migrations/20260414180000_promotions_phase_2/migration.sql
+++ b/prisma/migrations/20260414180000_promotions_phase_2/migration.sql
@@ -1,0 +1,18 @@
+-- Phase 2 of the promotions RFC (docs/rfcs/0001-promotions-and-subscriptions.md).
+-- Wires promotions into the checkout flow: orders now remember which
+-- promotion was applied per vendor fulfillment and how much was discounted,
+-- and the order-level aggregate is denormalized into Order.discountTotal for
+-- reporting and display.
+
+-- AlterTable: Order
+ALTER TABLE "Order" ADD COLUMN "discountTotal" DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+-- AlterTable: VendorFulfillment
+ALTER TABLE "VendorFulfillment" ADD COLUMN "promotionId" TEXT;
+ALTER TABLE "VendorFulfillment" ADD COLUMN "discountAmount" DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "VendorFulfillment_promotionId_idx" ON "VendorFulfillment"("promotionId");
+
+-- AddForeignKey
+ALTER TABLE "VendorFulfillment" ADD CONSTRAINT "VendorFulfillment_promotionId_fkey" FOREIGN KEY ("promotionId") REFERENCES "Promotion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -426,6 +426,7 @@ model Order {
   status                  OrderStatus   @default(PLACED)
   paymentStatus           PaymentStatus @default(PENDING)
   subtotal                Decimal       @db.Decimal(10, 2)
+  discountTotal           Decimal       @default(0) @db.Decimal(10, 2)
   shippingCost            Decimal       @default(0) @db.Decimal(10, 2)
   taxAmount               Decimal       @db.Decimal(10, 2)
   grandTotal              Decimal       @db.Decimal(10, 2)
@@ -508,14 +509,22 @@ model VendorFulfillment {
 
   vendorAddressId String?
 
+  // Phase 2 of the promotions RFC: one promotion per vendor fulfillment,
+  // locked at order time. Free shipping promotions zero the vendor's share
+  // of the shipping line via Order.shippingCost recalculation, not here.
+  promotionId    String?
+  discountAmount Decimal           @default(0) @db.Decimal(10, 2)
+
   order         Order          @relation(fields: [orderId], references: [id])
   vendor        Vendor         @relation(fields: [vendorId], references: [id])
   vendorAddress VendorAddress? @relation(fields: [vendorAddressId], references: [id])
   shipment      Shipment?
+  promotion     Promotion?     @relation(fields: [promotionId], references: [id])
 
   @@index([orderId])
   @@index([vendorId, status])
   @@index([vendorId, createdAt])
+  @@index([promotionId])
 }
 
 model Shipment {
@@ -758,6 +767,8 @@ model Promotion {
 
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
+
+  fulfillments    VendorFulfillment[]
 
   @@unique([vendorId, code])
   @@index([vendorId, archivedAt])

--- a/src/components/buyer/CheckoutPageClient.tsx
+++ b/src/components/buyer/CheckoutPageClient.tsx
@@ -9,6 +9,7 @@ import { z } from 'zod'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { createCheckoutOrder } from '@/domains/orders/actions'
+import { previewPromotionsForCart, type PromotionPreviewResult } from '@/domains/promotions/checkout'
 import { formatPrice } from '@/lib/utils'
 import { SafeImage } from '@/components/catalog/SafeImage'
 import {
@@ -133,7 +134,7 @@ export function CheckoutPageClient({
   const watchedProvince = useWatch({ control, name: 'province' }) ?? ''
   const watchedPhone = useWatch({ control, name: 'phone' }) ?? ''
 
-  const shipping = watchedPostalCode.length === 5
+  const baseShipping = watchedPostalCode.length === 5
     ? calculateShippingCostFromTables({
         postalCode: watchedPostalCode,
         subtotal: sub,
@@ -142,7 +143,72 @@ export function CheckoutPageClient({
         fallbackCost: fallbackShippingCost,
       })
     : fallbackShippingCost
-  const total = sub + shipping
+
+  // Phase 2 of the promotions RFC — coupon input + discount preview.
+  const [promoCodeInput, setPromoCodeInput] = useState('')
+  const [appliedCode, setAppliedCode] = useState<string | null>(null)
+  const [promoPreview, setPromoPreview] = useState<PromotionPreviewResult | null>(null)
+  const [promoError, setPromoError] = useState<string | null>(null)
+  const [promoPending, setPromoPending] = useState(false)
+
+  const subtotalDiscount = promoPreview?.subtotalDiscount ?? 0
+  const shippingDiscount = promoPreview?.shippingDiscount ?? 0
+  const shipping = Math.max(0, baseShipping - shippingDiscount)
+  const total = Math.max(0, sub - subtotalDiscount + shipping)
+
+  useEffect(() => {
+    let cancelled = false
+    if (items.length === 0) {
+      setPromoPreview(null)
+      return
+    }
+
+    setPromoPending(true)
+    previewPromotionsForCart({
+      items: items.map(i => ({
+        productId: i.productId,
+        variantId: i.variantId,
+        quantity: i.quantity,
+      })),
+      code: appliedCode,
+      shippingCost: baseShipping,
+    })
+      .then(result => {
+        if (cancelled) return
+        setPromoPreview(result)
+        if (appliedCode && result.unknownCodes.includes(appliedCode.toUpperCase())) {
+          setPromoError(t('checkout.promo.invalidCode').replace('{code}', appliedCode))
+          setAppliedCode(null)
+        } else {
+          setPromoError(null)
+        }
+      })
+      .catch(() => {
+        if (cancelled) return
+        setPromoPreview(null)
+      })
+      .finally(() => {
+        if (!cancelled) setPromoPending(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [items, appliedCode, baseShipping, t])
+
+  function handleApplyPromoCode() {
+    const trimmed = promoCodeInput.trim().toUpperCase()
+    if (!trimmed) return
+    setPromoError(null)
+    setAppliedCode(trimmed)
+  }
+
+  function handleClearPromoCode() {
+    setPromoCodeInput('')
+    setAppliedCode(null)
+    setPromoError(null)
+  }
+
   const hasTrackedCheckoutRef = useRef(false)
 
   useEffect(() => {
@@ -267,11 +333,15 @@ export function CheckoutPageClient({
         quantity: i.quantity,
       }))
 
-      const result = await createCheckoutOrder(cartItems, {
-        address: data,
-        saveAddress: data.saveAddress,
-        selectedAddressId: selectedAddressId ?? undefined,
-      })
+      const result = await createCheckoutOrder(
+        cartItems,
+        {
+          address: data,
+          saveAddress: data.saveAddress,
+          selectedAddressId: selectedAddressId ?? undefined,
+        },
+        { promotionCode: appliedCode }
+      )
 
       if (!result.ok) {
         setServerError(result.error)
@@ -510,15 +580,79 @@ export function CheckoutPageClient({
               <div className="flex justify-between text-[var(--foreground-soft)]">
                 <span>{t('cart.subtotal')}</span><span>{formatPrice(sub)}</span>
               </div>
+              {subtotalDiscount > 0 && (
+                <div className="flex justify-between text-emerald-700 dark:text-emerald-400">
+                  <span className="flex items-center gap-1">
+                    {t('checkout.promo.discountLine')}
+                    {promoPreview?.appliedByVendor[0]?.name && (
+                      <span className="text-xs text-[var(--muted)]">
+                        ({promoPreview.appliedByVendor[0].name}
+                        {promoPreview.appliedByVendor.length > 1 ? '…' : ''})
+                      </span>
+                    )}
+                  </span>
+                  <span>−{formatPrice(subtotalDiscount)}</span>
+                </div>
+              )}
               <div className="flex justify-between text-[var(--foreground-soft)]">
                 <span>{t('cart.shipping')}</span>
                 <span>{shipping === 0 ? <span className="text-emerald-600 dark:text-emerald-400">{t('cart.shippingFree')}</span> : formatPrice(shipping)}</span>
               </div>
-              {shipping > 0 && (
+              {shippingDiscount > 0 && (
+                <p className="text-xs text-emerald-700 dark:text-emerald-400">
+                  {t('checkout.promo.freeShippingApplied')}
+                </p>
+              )}
+              {shipping > 0 && shippingDiscount === 0 && (
                 <p className="text-xs text-[var(--muted-light)]">
                   {t('checkout.shippingHint')}
                 </p>
               )}
+
+              {/* Coupon code input */}
+              <div className="mt-3 border-t border-[var(--border)] pt-3">
+                <label className="block text-xs font-medium text-[var(--foreground-soft)]">
+                  {t('checkout.promo.label')}
+                </label>
+                {appliedCode ? (
+                  <div className="mt-1 flex items-center justify-between gap-2 rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs dark:border-emerald-800 dark:bg-emerald-950/40">
+                    <span className="font-mono font-semibold text-emerald-800 dark:text-emerald-300">
+                      {appliedCode}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleClearPromoCode}
+                      className="text-emerald-700 underline-offset-2 hover:underline dark:text-emerald-300"
+                    >
+                      {t('checkout.promo.remove')}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-1 flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={promoCodeInput}
+                      onChange={e => setPromoCodeInput(e.target.value.toUpperCase())}
+                      placeholder={t('checkout.promo.placeholder')}
+                      className="h-9 flex-1 rounded-md border border-[var(--border)] bg-[var(--surface)] px-2 font-mono text-xs uppercase text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleApplyPromoCode}
+                      disabled={!promoCodeInput.trim() || promoPending}
+                      className="h-9 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-xs font-semibold text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] disabled:opacity-60"
+                    >
+                      {t('checkout.promo.apply')}
+                    </button>
+                  </div>
+                )}
+                {promoError && (
+                  <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+                    {promoError}
+                  </p>
+                )}
+              </div>
+
               <div className="flex justify-between border-t border-[var(--border)] pt-2 text-base font-bold text-[var(--foreground)]">
                 <span>{t('cart.total')}</span><span>{formatPrice(total)}</span>
               </div>

--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -8,7 +8,6 @@ import { generateOrderNumber } from '@/lib/utils'
 import { createPaymentIntent } from '@/domains/payments/provider'
 import {
   calculateOrderPricing,
-  calculateOrderTotalsWithShippingCost,
   checkoutSchema,
   orderItemsSchema,
   type CheckoutFormData,
@@ -28,6 +27,11 @@ import { getShippingCost } from '@/domains/shipping/calculator'
 import { getActionSession } from '@/lib/action-session'
 import { revalidateCatalogExperience, safeRevalidatePath } from '@/lib/revalidate'
 import { createPaymentConfirmedEventPayload } from '@/domains/orders/order-event-payload'
+import {
+  evaluatePromotions,
+  type EvaluableCartLine,
+} from '@/domains/promotions/evaluation'
+import { countBuyerRedemptions, loadEvaluablePromotions } from '@/domains/promotions/loader'
 
 export interface CartItemInput {
   productId: string
@@ -47,6 +51,10 @@ export type CreateCheckoutOrderResult =
     error: string
   }
 
+function roundCurrency2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
 function isMissingShippingAddressSnapshotColumnError(error: unknown) {
   return error instanceof Error
     && /P2022|column .*does not exist|shippingAddressSnapshot/i.test(error.message)
@@ -60,7 +68,7 @@ function getCheckoutErrorMessage(error: unknown) {
   if (error instanceof Error) {
     const message = error.message.trim()
 
-    if (/stock insuficiente|carrito vac[íi]o|no disponible|ya no esta disponible|ya no está disponible|debes seleccionar una variante|c[óo]digo postal|requerid/i.test(message)) {
+    if (/stock insuficiente|carrito vac[íi]o|no disponible|ya no esta disponible|ya no está disponible|debes seleccionar una variante|c[óo]digo postal|requerid|promoci[óo]n|c[óo]digo "/i.test(message)) {
       return message
     }
 
@@ -107,7 +115,8 @@ function getCheckoutErrorMessage(error: unknown) {
  */
 export async function createOrder(
   items: CartItemInput[],
-  formData: CheckoutFormData
+  formData: CheckoutFormData,
+  options: { promotionCode?: string | null } = {}
 ): Promise<{ orderId: string; clientSecret: string; orderNumber: string }> {
   const session = await getActionSession()
   if (!session) redirect('/login')
@@ -115,6 +124,7 @@ export async function createOrder(
 
   const validatedItems = orderItemsSchema.parse(items)
   const validated = checkoutSchema.parse(formData)
+  const promotionCode = options.promotionCode?.trim().toUpperCase() || null
 
   // Load products with current prices
   const products = await db.product.findMany({
@@ -232,19 +242,74 @@ export async function createOrder(
       taxRate: Number(line.taxRate),
     }))
   )
-  const shippingCost = await getShippingCost(validated.address.postalCode, pricing.subtotal)
-  const { subtotal, taxAmount, grandTotal } = calculateOrderTotalsWithShippingCost(
-    lines.map(line => ({
-      unitPrice: Number(line.unitPrice),
-      quantity: line.quantity,
-      taxRate: Number(line.taxRate),
-    })),
-    shippingCost
-  )
+  const baseShippingCost = await getShippingCost(validated.address.postalCode, pricing.subtotal)
 
   // Determine unique vendors (used both for the order record and for the
   // Stripe Connect destination-charge decision below).
   const vendorIds = [...new Set(lines.map(l => l.vendorId))]
+
+  // Phase 2 of the promotions RFC: evaluate promotions, compute per-vendor
+  // discounts and apply them to the order totals. This block is OPTIMISTIC:
+  // it reads the redemption counts without a lock. The lock + atomic
+  // redemption increment runs inside the order transaction below, so a race
+  // that makes a promotion unredeemable between now and then throws and
+  // rolls the whole thing back before we charge the buyer.
+  const productMetaById = new Map(products.map(p => [p.id, p]))
+  const evaluableLines: EvaluableCartLine[] = lines.map(line => {
+    const product = productMetaById.get(line.productId)
+    return {
+      productId: line.productId,
+      vendorId: line.vendorId,
+      categoryId: product?.categoryId ?? null,
+      quantity: line.quantity,
+      unitPrice: Number(line.unitPrice),
+    }
+  })
+  const evaluationNow = new Date()
+  const candidatePromotions = await loadEvaluablePromotions({
+    vendorIds,
+    code: promotionCode,
+    now: evaluationNow,
+  })
+  const buyerRedemptions = await countBuyerRedemptions(
+    sessionUserId,
+    candidatePromotions.map(p => p.id)
+  )
+  const evaluation = evaluatePromotions({
+    lines: evaluableLines,
+    promotions: candidatePromotions,
+    code: promotionCode,
+    now: evaluationNow,
+    shippingCost: baseShippingCost,
+    buyerRedemptionsByPromotionId: buyerRedemptions,
+  })
+
+  const appliedByVendorId = evaluation.applied
+  const discountTotal = evaluation.subtotalDiscount
+  const shippingCost = roundCurrency2(
+    Math.max(0, baseShippingCost - evaluation.shippingDiscount)
+  )
+
+  // Reject the order upfront if the buyer typed a code that did not match
+  // any eligible promotion — otherwise the buyer would go through checkout
+  // and silently not receive the discount they expected.
+  if (promotionCode && evaluation.unknownCodes.length > 0) {
+    throw new Error(
+      `El código "${promotionCode}" no es válido o ya no está disponible.`
+    )
+  }
+
+  // Apply discount to subtotal for the downstream grand total. Tax is
+  // included in unit prices, so we reduce the reported taxAmount
+  // proportionally — keeps the reporting honest without changing the
+  // accounting model.
+  const subtotalBeforeDiscount = pricing.subtotal
+  const subtotalAfterDiscount = roundCurrency2(subtotalBeforeDiscount - discountTotal)
+  const taxRatio =
+    subtotalBeforeDiscount > 0 ? subtotalAfterDiscount / subtotalBeforeDiscount : 1
+  const subtotal = subtotalAfterDiscount
+  const taxAmount = roundCurrency2(pricing.taxAmount * taxRatio)
+  const grandTotal = roundCurrency2(subtotal + shippingCost)
 
   // Stripe Connect destination charges (#48):
   // For single-vendor orders where that vendor has completed Stripe Connect
@@ -405,6 +470,31 @@ export async function createOrder(
         }
       }
 
+      // Phase 2 promotions: atomically claim the redemption budget for
+      // every promotion we plan to apply. If another order drained the
+      // budget between the evaluation read and this write, the UPDATE
+      // affects 0 rows and we throw, rolling back stock + order. The
+      // guard uses an explicit WHERE clause so maxRedemptions is enforced
+      // at the SQL level rather than trusted from the in-memory snapshot.
+      for (const applied of appliedByVendorId.values()) {
+        const updated = await (tx.$executeRaw as any)`
+          UPDATE "Promotion"
+          SET "redemptionCount" = "redemptionCount" + 1,
+              "updatedAt" = NOW()
+          WHERE id = ${applied.promotionId}
+            AND "archivedAt" IS NULL
+            AND (
+              "maxRedemptions" IS NULL
+              OR "redemptionCount" < "maxRedemptions"
+            )
+        `
+        if (updated === 0) {
+          throw new Error(
+            'La promoción seleccionada ya no está disponible. Recarga el carrito e inténtalo de nuevo.'
+          )
+        }
+      }
+
       return tx.order.create({
         data: {
           orderNumber: generateOrderNumber(),
@@ -412,6 +502,7 @@ export async function createOrder(
           addressId: addressId ?? null,
           ...(includeShippingAddressSnapshot ? { shippingAddressSnapshot } : {}),
           subtotal,
+          discountTotal,
           shippingCost,
           taxAmount,
           grandTotal,
@@ -428,7 +519,17 @@ export async function createOrder(
             },
           },
           fulfillments: {
-            create: vendorIds.map(vendorId => ({ vendorId, status: 'PENDING' })),
+            create: vendorIds.map(vendorId => {
+              const applied = appliedByVendorId.get(vendorId)
+              return {
+                vendorId,
+                status: 'PENDING' as const,
+                promotionId: applied?.promotionId ?? null,
+                discountAmount: applied
+                  ? roundCurrency2(applied.discountAmount + applied.shippingDiscount)
+                  : 0,
+              }
+            }),
           },
         },
       })
@@ -472,10 +573,11 @@ export async function createOrder(
 
 export async function createCheckoutOrder(
   items: CartItemInput[],
-  formData: CheckoutFormData
+  formData: CheckoutFormData,
+  options: { promotionCode?: string | null } = {}
 ): Promise<CreateCheckoutOrderResult> {
   try {
-    const created = await createOrder(items, formData)
+    const created = await createOrder(items, formData, options)
 
     if (created.clientSecret.startsWith('mock_')) {
       try {

--- a/src/domains/promotions/checkout.ts
+++ b/src/domains/promotions/checkout.ts
@@ -1,0 +1,164 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { getAvailableProductWhere } from '@/domains/catalog/availability'
+import { assertVariantPriceChargeable, getDefaultVariant, getSelectedVariant, getVariantAdjustedPrice, productRequiresVariantSelection } from '@/domains/catalog/variants'
+import {
+  evaluatePromotions,
+  type EvaluableCartLine,
+} from '@/domains/promotions/evaluation'
+import { countBuyerRedemptions, loadEvaluablePromotions } from '@/domains/promotions/loader'
+
+const previewInputSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        productId: z.string().min(1),
+        variantId: z.string().min(1).optional(),
+        quantity: z.number().int().positive(),
+      })
+    )
+    .min(1),
+  code: z.string().trim().max(40).optional().nullable(),
+  shippingCost: z.coerce.number().min(0).default(0),
+})
+
+export type PromotionPreviewInput = z.infer<typeof previewInputSchema>
+
+export interface PromotionPreviewResult {
+  ok: boolean
+  subtotalDiscount: number
+  shippingDiscount: number
+  /** Per vendor: { promotionId, kind, discountAmount, shippingDiscount }. */
+  appliedByVendor: Array<{
+    vendorId: string
+    promotionId: string
+    kind: 'PERCENTAGE' | 'FIXED_AMOUNT' | 'FREE_SHIPPING'
+    discountAmount: number
+    shippingDiscount: number
+    name: string
+    code: string | null
+  }>
+  unknownCodes: string[]
+}
+
+/**
+ * Server action that previews the discount for a cart without creating an
+ * order. The checkout page calls this to show the buyer the savings before
+ * they confirm. It is purely read-only — no DB writes, no side effects —
+ * so rate limiting is not necessary.
+ *
+ * This mirrors the calculation done inside `createOrder` (see
+ * `applyPromotionsToLines`) so both paths agree on the number before the
+ * buyer is charged.
+ */
+export async function previewPromotionsForCart(
+  input: PromotionPreviewInput
+): Promise<PromotionPreviewResult> {
+  const session = await getActionSession()
+  const buyerId = session?.user.id ?? null
+
+  const { items, code, shippingCost } = previewInputSchema.parse(input)
+
+  const productIds = [...new Set(items.map(i => i.productId))]
+  const products = await db.product.findMany({
+    where: { id: { in: productIds }, ...getAvailableProductWhere() },
+    include: { variants: { where: { isActive: true } } },
+  })
+
+  const lines: EvaluableCartLine[] = []
+  for (const item of items) {
+    const product = products.find(p => p.id === item.productId)
+    if (!product) continue
+
+    const purchasableProduct = {
+      basePrice: Number(product.basePrice),
+      stock: product.stock,
+      trackStock: product.trackStock,
+      variants: product.variants.map(variant => ({
+        id: variant.id,
+        name: variant.name,
+        priceModifier: Number(variant.priceModifier),
+        stock: variant.stock,
+        isActive: variant.isActive,
+      })),
+    }
+    const fallbackVariant = getDefaultVariant(purchasableProduct)
+    const selectedVariant =
+      getSelectedVariant(purchasableProduct, item.variantId) ??
+      (!item.variantId ? fallbackVariant : null)
+
+    if (item.variantId && !selectedVariant) continue
+    if (productRequiresVariantSelection(purchasableProduct) && !selectedVariant) continue
+
+    const unitPrice = getVariantAdjustedPrice(Number(product.basePrice), selectedVariant)
+    assertVariantPriceChargeable(unitPrice, product.name)
+
+    lines.push({
+      productId: product.id,
+      vendorId: product.vendorId,
+      categoryId: product.categoryId,
+      quantity: item.quantity,
+      unitPrice,
+    })
+  }
+
+  if (lines.length === 0) {
+    return {
+      ok: false,
+      subtotalDiscount: 0,
+      shippingDiscount: 0,
+      appliedByVendor: [],
+      unknownCodes: [],
+    }
+  }
+
+  const vendorIds = [...new Set(lines.map(l => l.vendorId))]
+  const now = new Date()
+  const promotions = await loadEvaluablePromotions({ vendorIds, code, now })
+  const buyerRedemptions = buyerId
+    ? await countBuyerRedemptions(
+        buyerId,
+        promotions.map(p => p.id)
+      )
+    : new Map<string, number>()
+
+  const result = evaluatePromotions({
+    lines,
+    promotions,
+    code,
+    now,
+    shippingCost,
+    buyerRedemptionsByPromotionId: buyerRedemptions,
+  })
+
+  // Hydrate the applied rows with promotion name + code for UI display.
+  const promoRows = await db.promotion.findMany({
+    where: { id: { in: [...result.applied.values()].map(a => a.promotionId) } },
+    select: { id: true, name: true, code: true },
+  })
+  const metaById = new Map(promoRows.map(r => [r.id, r]))
+
+  const appliedByVendor = [...result.applied.values()].map(applied => {
+    const meta = metaById.get(applied.promotionId)
+    return {
+      vendorId: applied.vendorId,
+      promotionId: applied.promotionId,
+      kind: applied.kind,
+      discountAmount: applied.discountAmount,
+      shippingDiscount: applied.shippingDiscount,
+      name: meta?.name ?? '',
+      code: meta?.code ?? null,
+    }
+  })
+
+  return {
+    ok: true,
+    subtotalDiscount: result.subtotalDiscount,
+    shippingDiscount: result.shippingDiscount,
+    appliedByVendor,
+    unknownCodes: result.unknownCodes,
+  }
+}

--- a/src/domains/promotions/evaluation.ts
+++ b/src/domains/promotions/evaluation.ts
@@ -1,0 +1,304 @@
+/**
+ * Phase 2 — promotion evaluation engine.
+ *
+ * Pure, stateless, DB-less. Given a cart (vendor-scoped lines), a set of
+ * candidate promotions (already filtered to vendors present in the cart and
+ * pre-loaded from the DB), and an optional code entered by the buyer,
+ * returns the best applicable promotion per vendor along with the computed
+ * discount amount.
+ *
+ * Stacking rule (phase 1 RFC decision): at most ONE promotion per vendor.
+ * The cheapest-eligible-for-the-buyer one wins, i.e. the one with the
+ * biggest absolute discount. If the buyer typed a code, any promotion that
+ * matches that code is considered alongside the automatic ones — it does
+ * NOT exclude the automatic promotions, it just joins the pool for its
+ * vendor. So if the buyer has a VENDOR-wide 5% auto-promo and enters a
+ * 10% code for the same vendor, the 10% wins.
+ *
+ * FREE_SHIPPING is only applicable when the cart contains items from a
+ * single vendor. In a multi-vendor cart we silently skip it — a proper
+ * per-vendor shipping split lives in a follow-up RFC.
+ */
+
+export type PromotionKind = 'PERCENTAGE' | 'FIXED_AMOUNT' | 'FREE_SHIPPING'
+export type PromotionScope = 'PRODUCT' | 'VENDOR' | 'CATEGORY'
+
+/** Minimal promotion shape used by the evaluator — DB rows are mapped to this. */
+export interface EvaluablePromotion {
+  id: string
+  vendorId: string
+  kind: PromotionKind
+  scope: PromotionScope
+  value: number
+  code: string | null
+  productId: string | null
+  categoryId: string | null
+  minSubtotal: number | null
+  maxRedemptions: number | null
+  redemptionCount: number
+  perUserLimit: number | null
+  startsAt: Date
+  endsAt: Date
+  archivedAt: Date | null
+}
+
+/** Minimal cart line shape used by the evaluator. */
+export interface EvaluableCartLine {
+  productId: string
+  vendorId: string
+  categoryId: string | null
+  quantity: number
+  unitPrice: number   // already includes tax — consistent with the rest of the codebase
+}
+
+export interface EvaluationContext {
+  lines: EvaluableCartLine[]
+  promotions: EvaluablePromotion[]
+  code?: string | null
+  now?: Date
+  /** Per-promotion count of how many times this buyer has already redeemed it. */
+  buyerRedemptionsByPromotionId?: Map<string, number>
+  /** Shipping cost of the order — used only by FREE_SHIPPING promotions. */
+  shippingCost?: number
+}
+
+export interface AppliedPromotion {
+  promotionId: string
+  vendorId: string
+  kind: PromotionKind
+  /** Amount in EUR subtracted from the vendor-scoped subtotal. Always ≥ 0. */
+  discountAmount: number
+  /** When FREE_SHIPPING applies, the shipping amount that should be nulled. */
+  shippingDiscount: number
+  reasonCode: string
+}
+
+export interface EvaluationResult {
+  /** Per-vendor winning promotion. Vendors without any applicable promo are absent. */
+  applied: Map<string, AppliedPromotion>
+  /** Total EUR discount applied across all vendors (sum of discountAmount). */
+  subtotalDiscount: number
+  /** Total EUR shipping discount (0 or the full shipping cost today). */
+  shippingDiscount: number
+  /** Codes the buyer entered that matched no eligible promotion — for UI feedback. */
+  unknownCodes: string[]
+}
+
+/**
+ * Returns the per-vendor subtotal of the cart (sum of unitPrice * quantity).
+ * Exported because the caller may need it for UX (e.g. showing a min
+ * subtotal hint).
+ */
+export function vendorSubtotals(
+  lines: EvaluableCartLine[]
+): Map<string, number> {
+  const subtotals = new Map<string, number>()
+  for (const line of lines) {
+    const current = subtotals.get(line.vendorId) ?? 0
+    subtotals.set(line.vendorId, round2(current + line.unitPrice * line.quantity))
+  }
+  return subtotals
+}
+
+/** Rounds a number to 2 decimal places, avoiding FP noise. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/**
+ * Returns `true` iff the promotion is time-eligible at the given moment and
+ * has not been archived, exhausted, or otherwise knocked out by a
+ * non-cart-specific check. Cart-specific checks (scope, minSubtotal, code
+ * gating) live further down in `evaluateVendorPromotion`.
+ */
+function isTimeWindowValid(promo: EvaluablePromotion, now: Date): boolean {
+  if (promo.archivedAt !== null) return false
+  if (now.getTime() < promo.startsAt.getTime()) return false
+  if (now.getTime() > promo.endsAt.getTime()) return false
+  return true
+}
+
+function isRedemptionBudgetAvailable(
+  promo: EvaluablePromotion,
+  buyerRedemptions: number
+): boolean {
+  if (
+    promo.maxRedemptions !== null &&
+    promo.redemptionCount >= promo.maxRedemptions
+  ) {
+    return false
+  }
+  if (promo.perUserLimit !== null && buyerRedemptions >= promo.perUserLimit) {
+    return false
+  }
+  return true
+}
+
+/** Picks the lines this promotion applies to, given its scope. */
+function matchesScope(
+  promo: EvaluablePromotion,
+  vendorLines: EvaluableCartLine[]
+): EvaluableCartLine[] {
+  if (promo.scope === 'VENDOR') return vendorLines
+  if (promo.scope === 'PRODUCT') {
+    return vendorLines.filter(l => l.productId === promo.productId)
+  }
+  if (promo.scope === 'CATEGORY') {
+    return vendorLines.filter(l => l.categoryId === promo.categoryId)
+  }
+  return []
+}
+
+/** Sum of unitPrice * quantity for a given set of lines. */
+function sumLines(lines: EvaluableCartLine[]): number {
+  return round2(lines.reduce((acc, l) => acc + l.unitPrice * l.quantity, 0))
+}
+
+/** Computes the raw discount a promotion would apply against a subtotal. */
+function computeDiscount(
+  promo: EvaluablePromotion,
+  applicableSubtotal: number,
+  shippingCost: number
+): { discount: number; shippingDiscount: number } {
+  if (applicableSubtotal <= 0 && promo.kind !== 'FREE_SHIPPING') {
+    return { discount: 0, shippingDiscount: 0 }
+  }
+
+  switch (promo.kind) {
+    case 'PERCENTAGE': {
+      // value is 0..100; bound by the applicable subtotal to avoid rounding over-discount
+      const raw = (applicableSubtotal * promo.value) / 100
+      return { discount: round2(Math.min(raw, applicableSubtotal)), shippingDiscount: 0 }
+    }
+    case 'FIXED_AMOUNT': {
+      // Never discount more than the applicable subtotal.
+      return { discount: round2(Math.min(promo.value, applicableSubtotal)), shippingDiscount: 0 }
+    }
+    case 'FREE_SHIPPING': {
+      return { discount: 0, shippingDiscount: round2(shippingCost) }
+    }
+  }
+}
+
+/** Core evaluation pass per vendor. */
+function evaluateVendorPromotion(
+  vendorId: string,
+  vendorLines: EvaluableCartLine[],
+  candidates: EvaluablePromotion[],
+  now: Date,
+  buyerRedemptionsByPromotionId: Map<string, number>,
+  shippingCost: number,
+  isSingleVendorCart: boolean
+): AppliedPromotion | null {
+  const vendorSubtotal = sumLines(vendorLines)
+  let best: AppliedPromotion | null = null
+
+  for (const promo of candidates) {
+    if (promo.vendorId !== vendorId) continue
+    if (!isTimeWindowValid(promo, now)) continue
+    if (
+      !isRedemptionBudgetAvailable(
+        promo,
+        buyerRedemptionsByPromotionId.get(promo.id) ?? 0
+      )
+    ) continue
+
+    // FREE_SHIPPING is skipped in multi-vendor carts — see file header.
+    if (promo.kind === 'FREE_SHIPPING' && !isSingleVendorCart) continue
+
+    if (promo.minSubtotal !== null && vendorSubtotal < promo.minSubtotal) {
+      continue
+    }
+
+    const applicableLines = matchesScope(promo, vendorLines)
+    if (applicableLines.length === 0) continue
+
+    const applicableSubtotal = sumLines(applicableLines)
+    const { discount, shippingDiscount } = computeDiscount(
+      promo,
+      applicableSubtotal,
+      shippingCost
+    )
+
+    if (discount <= 0 && shippingDiscount <= 0) continue
+
+    const totalSaving = discount + shippingDiscount
+    const bestSaving = best ? best.discountAmount + best.shippingDiscount : -1
+
+    if (totalSaving > bestSaving) {
+      best = {
+        promotionId: promo.id,
+        vendorId,
+        kind: promo.kind,
+        discountAmount: discount,
+        shippingDiscount,
+        reasonCode: promo.code ? 'code' : 'auto',
+      }
+    }
+  }
+
+  return best
+}
+
+/**
+ * Entry point — runs the evaluation pass across every vendor in the cart
+ * and returns the aggregated result.
+ */
+export function evaluatePromotions(ctx: EvaluationContext): EvaluationResult {
+  const now = ctx.now ?? new Date()
+  const shippingCost = ctx.shippingCost ?? 0
+  const buyerRedemptions = ctx.buyerRedemptionsByPromotionId ?? new Map<string, number>()
+  const code = ctx.code ? ctx.code.trim().toUpperCase() : null
+
+  const vendorIds = new Set<string>()
+  for (const line of ctx.lines) vendorIds.add(line.vendorId)
+  const isSingleVendorCart = vendorIds.size === 1
+
+  // Filter the candidate pool: a promotion with a code is only considered
+  // if the buyer typed that code. A promotion without a code is always a
+  // candidate.
+  const candidates = ctx.promotions.filter(p => {
+    if (p.code === null) return true
+    return code !== null && p.code === code
+  })
+
+  const applied = new Map<string, AppliedPromotion>()
+  for (const vendorId of vendorIds) {
+    const vendorLines = ctx.lines.filter(l => l.vendorId === vendorId)
+    const winner = evaluateVendorPromotion(
+      vendorId,
+      vendorLines,
+      candidates,
+      now,
+      buyerRedemptions,
+      shippingCost,
+      isSingleVendorCart
+    )
+    if (winner) applied.set(vendorId, winner)
+  }
+
+  let subtotalDiscount = 0
+  let shippingDiscount = 0
+  for (const a of applied.values()) {
+    subtotalDiscount += a.discountAmount
+    shippingDiscount += a.shippingDiscount
+  }
+
+  // Unknown codes — only meaningful when the buyer actually typed one. A
+  // code is reported as "unknown" when the candidate pool does not contain
+  // any promotion with that code for any of the vendors in the cart. A code
+  // that matches an existing promotion but loses to a better auto-promo is
+  // silently dropped: the buyer gets the best deal either way.
+  const unknownCodes: string[] = []
+  if (code !== null) {
+    const codeMatchedAnyVendor = ctx.promotions.some(p => p.code === code)
+    if (!codeMatchedAnyVendor) unknownCodes.push(code)
+  }
+
+  return {
+    applied,
+    subtotalDiscount: round2(subtotalDiscount),
+    shippingDiscount: round2(shippingDiscount),
+    unknownCodes,
+  }
+}

--- a/src/domains/promotions/loader.ts
+++ b/src/domains/promotions/loader.ts
@@ -1,0 +1,87 @@
+import { db } from '@/lib/db'
+import type { EvaluablePromotion } from '@/domains/promotions/evaluation'
+
+/**
+ * Loads every non-archived promotion that could possibly apply to the given
+ * vendors at the given time, plus any code-gated promotion that matches the
+ * buyer-entered code. The returned rows are mapped to the `EvaluablePromotion`
+ * shape so the pure engine can evaluate them without hitting the DB.
+ *
+ * This intentionally fetches a slightly wider set than strictly necessary
+ * (the time window is enforced both in SQL and re-checked in the engine) so
+ * the evaluator's unit tests can cover the window logic without mocking the
+ * DB.
+ */
+export async function loadEvaluablePromotions({
+  vendorIds,
+  code,
+  now,
+}: {
+  vendorIds: string[]
+  code?: string | null
+  now: Date
+}): Promise<EvaluablePromotion[]> {
+  if (vendorIds.length === 0) return []
+
+  const normalizedCode = code ? code.trim().toUpperCase() : null
+
+  const rows = await db.promotion.findMany({
+    where: {
+      vendorId: { in: vendorIds },
+      archivedAt: null,
+      startsAt: { lte: now },
+      endsAt: { gte: now },
+      OR: [
+        { code: null },
+        ...(normalizedCode ? [{ code: normalizedCode }] : []),
+      ],
+    },
+  })
+
+  return rows.map(row => ({
+    id: row.id,
+    vendorId: row.vendorId,
+    kind: row.kind,
+    scope: row.scope,
+    value: Number(row.value),
+    code: row.code,
+    productId: row.productId,
+    categoryId: row.categoryId,
+    minSubtotal: row.minSubtotal !== null ? Number(row.minSubtotal) : null,
+    maxRedemptions: row.maxRedemptions,
+    redemptionCount: row.redemptionCount,
+    perUserLimit: row.perUserLimit,
+    startsAt: row.startsAt,
+    endsAt: row.endsAt,
+    archivedAt: row.archivedAt,
+  }))
+}
+
+/**
+ * For each of the provided promotionIds, counts how many times the given
+ * buyer has already used it. Used by the evaluator to enforce per-user
+ * limits before the order is written.
+ */
+export async function countBuyerRedemptions(
+  buyerId: string,
+  promotionIds: string[]
+): Promise<Map<string, number>> {
+  if (promotionIds.length === 0) return new Map()
+
+  const rows = await db.vendorFulfillment.groupBy({
+    by: ['promotionId'],
+    where: {
+      promotionId: { in: promotionIds },
+      order: { customerId: buyerId },
+    },
+    _count: { promotionId: true },
+  })
+
+  const map = new Map<string, number>()
+  for (const row of rows) {
+    if (row.promotionId) {
+      map.set(row.promotionId, row._count.promotionId)
+    }
+  }
+  return map
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -225,6 +225,13 @@ const en: Record<TranslationKeys, string> = {
   'checkout.processing': 'Processing order...',
   'checkout.yourOrder': 'Your order',
   'checkout.shippingHint': 'Cost is adjusted automatically based on the postal code and shipping zone.',
+  'checkout.promo.label': 'Have a promo code?',
+  'checkout.promo.placeholder': 'Enter your code',
+  'checkout.promo.apply': 'Apply',
+  'checkout.promo.remove': 'Remove',
+  'checkout.promo.discountLine': 'Discount',
+  'checkout.promo.freeShippingApplied': 'Free shipping applied via promotion',
+  'checkout.promo.invalidCode': 'The code "{code}" is not valid or no longer available',
 
   // Order detail
   'order.confirmed': 'Order confirmed!',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -223,6 +223,13 @@ const es = {
   'checkout.processing': 'Procesando pedido...',
   'checkout.yourOrder': 'Tu pedido',
   'checkout.shippingHint': 'El coste se ajusta automáticamente según el código postal y la zona de envío.',
+  'checkout.promo.label': '¿Tienes un código de descuento?',
+  'checkout.promo.placeholder': 'Introduce tu código',
+  'checkout.promo.apply': 'Aplicar',
+  'checkout.promo.remove': 'Quitar',
+  'checkout.promo.discountLine': 'Descuento',
+  'checkout.promo.freeShippingApplied': 'Envío gratis aplicado gracias a la promoción',
+  'checkout.promo.invalidCode': 'El código "{code}" no es válido o ya no está disponible',
 
   // Order detail
   'order.confirmed': '¡Pedido confirmado!',

--- a/test/features/promotions-evaluation.test.ts
+++ b/test/features/promotions-evaluation.test.ts
@@ -1,0 +1,349 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  evaluatePromotions,
+  vendorSubtotals,
+  type EvaluableCartLine,
+  type EvaluablePromotion,
+} from '@/domains/promotions/evaluation'
+
+/**
+ * Phase 2 of the promotions RFC — pure evaluation engine.
+ * Every test here works against plain data structures, no DB.
+ */
+
+const VENDOR_A = 'vendor-a'
+const VENDOR_B = 'vendor-b'
+
+function line(overrides: Partial<EvaluableCartLine> = {}): EvaluableCartLine {
+  return {
+    productId: 'prod-1',
+    vendorId: VENDOR_A,
+    categoryId: 'cat-1',
+    quantity: 1,
+    unitPrice: 10,
+    ...overrides,
+  }
+}
+
+function promo(overrides: Partial<EvaluablePromotion> = {}): EvaluablePromotion {
+  return {
+    id: 'promo-1',
+    vendorId: VENDOR_A,
+    kind: 'PERCENTAGE',
+    scope: 'VENDOR',
+    value: 10,
+    code: null,
+    productId: null,
+    categoryId: null,
+    minSubtotal: null,
+    maxRedemptions: null,
+    redemptionCount: 0,
+    perUserLimit: null,
+    startsAt: new Date('2026-01-01'),
+    endsAt: new Date('2026-12-31'),
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
+const fixedNow = new Date('2026-04-15')
+
+test('vendorSubtotals sums line.unitPrice * quantity per vendor', () => {
+  const subs = vendorSubtotals([
+    line({ vendorId: VENDOR_A, quantity: 2, unitPrice: 10 }),
+    line({ vendorId: VENDOR_A, quantity: 1, unitPrice: 5 }),
+    line({ vendorId: VENDOR_B, quantity: 3, unitPrice: 4 }),
+  ])
+  assert.equal(subs.get(VENDOR_A), 25)
+  assert.equal(subs.get(VENDOR_B), 12)
+})
+
+test('no promotions → empty result', () => {
+  const result = evaluatePromotions({
+    lines: [line()],
+    promotions: [],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.size, 0)
+  assert.equal(result.subtotalDiscount, 0)
+  assert.equal(result.shippingDiscount, 0)
+  assert.deepEqual(result.unknownCodes, [])
+})
+
+test('PERCENTAGE auto-promo applied to vendor-wide cart', () => {
+  const result = evaluatePromotions({
+    lines: [line({ quantity: 2, unitPrice: 10 })], // subtotal 20
+    promotions: [promo({ value: 25 })], // 25%
+    now: fixedNow,
+  })
+  assert.equal(result.applied.size, 1)
+  const applied = result.applied.get(VENDOR_A)!
+  assert.equal(applied.promotionId, 'promo-1')
+  assert.equal(applied.discountAmount, 5) // 25% of 20
+  assert.equal(applied.kind, 'PERCENTAGE')
+  assert.equal(applied.reasonCode, 'auto')
+  assert.equal(result.subtotalDiscount, 5)
+})
+
+test('FIXED_AMOUNT promo never exceeds applicable subtotal', () => {
+  const result = evaluatePromotions({
+    lines: [line({ unitPrice: 5 })],
+    promotions: [promo({ kind: 'FIXED_AMOUNT', value: 999 })],
+    now: fixedNow,
+  })
+  const applied = result.applied.get(VENDOR_A)!
+  assert.equal(applied.discountAmount, 5)
+})
+
+test('PRODUCT-scoped promo discounts only the matching line', () => {
+  const result = evaluatePromotions({
+    lines: [
+      line({ productId: 'p-target', unitPrice: 10 }),
+      line({ productId: 'p-other',  unitPrice: 10 }),
+    ],
+    promotions: [
+      promo({
+        scope: 'PRODUCT',
+        productId: 'p-target',
+        kind: 'PERCENTAGE',
+        value: 50,
+      }),
+    ],
+    now: fixedNow,
+  })
+  const applied = result.applied.get(VENDOR_A)!
+  assert.equal(applied.discountAmount, 5) // 50% of the 10€ line only
+})
+
+test('CATEGORY-scoped promo discounts only lines in that category', () => {
+  const result = evaluatePromotions({
+    lines: [
+      line({ productId: 'p-1', categoryId: 'cat-target', unitPrice: 20 }),
+      line({ productId: 'p-2', categoryId: 'cat-other',  unitPrice: 20 }),
+    ],
+    promotions: [
+      promo({
+        scope: 'CATEGORY',
+        categoryId: 'cat-target',
+        kind: 'FIXED_AMOUNT',
+        value: 7,
+      }),
+    ],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.get(VENDOR_A)?.discountAmount, 7)
+})
+
+test('archived promotion is never applied', () => {
+  const result = evaluatePromotions({
+    lines: [line()],
+    promotions: [promo({ archivedAt: new Date('2026-01-01') })],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.size, 0)
+})
+
+test('promotion outside the date window is never applied', () => {
+  const beforeStart = evaluatePromotions({
+    lines: [line()],
+    promotions: [promo({ startsAt: new Date('2099-01-01') })],
+    now: fixedNow,
+  })
+  const afterEnd = evaluatePromotions({
+    lines: [line()],
+    promotions: [promo({ endsAt: new Date('2020-01-01') })],
+    now: fixedNow,
+  })
+  assert.equal(beforeStart.applied.size, 0)
+  assert.equal(afterEnd.applied.size, 0)
+})
+
+test('minSubtotal guard skips promos below threshold', () => {
+  const result = evaluatePromotions({
+    lines: [line({ unitPrice: 10 })], // subtotal 10
+    promotions: [promo({ minSubtotal: 20 })],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.size, 0)
+})
+
+test('maxRedemptions exhausted → promo is skipped', () => {
+  const result = evaluatePromotions({
+    lines: [line()],
+    promotions: [promo({ maxRedemptions: 10, redemptionCount: 10 })],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.size, 0)
+})
+
+test('perUserLimit exhausted → promo is skipped', () => {
+  const buyerRedemptions = new Map([['promo-1', 2]])
+  const result = evaluatePromotions({
+    lines: [line()],
+    promotions: [promo({ perUserLimit: 2 })],
+    now: fixedNow,
+    buyerRedemptionsByPromotionId: buyerRedemptions,
+  })
+  assert.equal(result.applied.size, 0)
+})
+
+test('the biggest eligible discount wins per vendor (no stacking)', () => {
+  const result = evaluatePromotions({
+    lines: [line({ quantity: 1, unitPrice: 100 })],
+    promotions: [
+      promo({ id: 'small', value: 5 }), // 5€
+      promo({ id: 'big', value: 40 }), // 40€
+    ],
+    now: fixedNow,
+  })
+  const applied = result.applied.get(VENDOR_A)!
+  assert.equal(applied.promotionId, 'big')
+  assert.equal(applied.discountAmount, 40)
+})
+
+test('coded promo ignored unless the buyer enters the matching code', () => {
+  const lines = [line({ quantity: 1, unitPrice: 100 })]
+  const promos = [promo({ id: 'secret', code: 'SECRET10', value: 20 })]
+
+  const withoutCode = evaluatePromotions({ lines, promotions: promos, now: fixedNow })
+  assert.equal(withoutCode.applied.size, 0)
+
+  const withWrongCode = evaluatePromotions({
+    lines, promotions: promos, now: fixedNow, code: 'WRONG',
+  })
+  assert.equal(withWrongCode.applied.size, 0)
+  assert.deepEqual(withWrongCode.unknownCodes, ['WRONG'])
+
+  const withCode = evaluatePromotions({
+    lines, promotions: promos, now: fixedNow, code: 'secret10',
+  })
+  assert.equal(withCode.applied.size, 1)
+  const applied = withCode.applied.get(VENDOR_A)!
+  assert.equal(applied.reasonCode, 'code')
+})
+
+test('buyer-entered code beats an auto-promo if it is a better deal', () => {
+  const result = evaluatePromotions({
+    lines: [line({ quantity: 1, unitPrice: 100 })],
+    promotions: [
+      promo({ id: 'auto', value: 5 }),
+      promo({ id: 'coded', code: 'BIG30', value: 30 }),
+    ],
+    now: fixedNow,
+    code: 'BIG30',
+  })
+  assert.equal(result.applied.get(VENDOR_A)?.promotionId, 'coded')
+  assert.equal(result.applied.get(VENDOR_A)?.discountAmount, 30)
+})
+
+test('auto-promo wins when the buyer-entered code is the smaller deal', () => {
+  const result = evaluatePromotions({
+    lines: [line({ quantity: 1, unitPrice: 100 })],
+    promotions: [
+      promo({ id: 'auto', value: 40 }),
+      promo({ id: 'coded', code: 'SMALL5', value: 5 }),
+    ],
+    now: fixedNow,
+    code: 'SMALL5',
+  })
+  assert.equal(result.applied.get(VENDOR_A)?.promotionId, 'auto')
+  // Buyer still got the best deal, so the code is not reported as unknown.
+  assert.deepEqual(result.applied.get(VENDOR_A)?.reasonCode, 'auto')
+})
+
+test('multi-vendor cart applies one promo per vendor independently', () => {
+  const lines = [
+    line({ vendorId: VENDOR_A, unitPrice: 50 }),
+    line({ vendorId: VENDOR_B, unitPrice: 80 }),
+  ]
+  const promotions: EvaluablePromotion[] = [
+    promo({ id: 'a', vendorId: VENDOR_A, value: 20 }), // 10 off
+    promo({ id: 'b', vendorId: VENDOR_B, kind: 'FIXED_AMOUNT', value: 15 }), // 15 off
+  ]
+  const result = evaluatePromotions({ lines, promotions, now: fixedNow })
+
+  assert.equal(result.applied.size, 2)
+  assert.equal(result.applied.get(VENDOR_A)?.discountAmount, 10)
+  assert.equal(result.applied.get(VENDOR_B)?.discountAmount, 15)
+  assert.equal(result.subtotalDiscount, 25)
+})
+
+test('a vendor without an eligible promo does not block other vendors', () => {
+  const lines = [
+    line({ vendorId: VENDOR_A, unitPrice: 50 }),
+    line({ vendorId: VENDOR_B, unitPrice: 80 }),
+  ]
+  const promotions: EvaluablePromotion[] = [
+    promo({ id: 'b', vendorId: VENDOR_B, value: 10 }),
+  ]
+  const result = evaluatePromotions({ lines, promotions, now: fixedNow })
+  assert.equal(result.applied.size, 1)
+  assert.equal(result.applied.get(VENDOR_B)?.discountAmount, 8)
+})
+
+test('FREE_SHIPPING applied in a single-vendor cart zeroes shipping', () => {
+  const result = evaluatePromotions({
+    lines: [line({ unitPrice: 50 })],
+    promotions: [promo({ kind: 'FREE_SHIPPING', value: 0 })],
+    now: fixedNow,
+    shippingCost: 4.95,
+  })
+  const applied = result.applied.get(VENDOR_A)!
+  assert.equal(applied.kind, 'FREE_SHIPPING')
+  assert.equal(applied.discountAmount, 0)
+  assert.equal(applied.shippingDiscount, 4.95)
+  assert.equal(result.shippingDiscount, 4.95)
+})
+
+test('FREE_SHIPPING is skipped in a multi-vendor cart', () => {
+  const lines = [
+    line({ vendorId: VENDOR_A, unitPrice: 30 }),
+    line({ vendorId: VENDOR_B, unitPrice: 30 }),
+  ]
+  const promotions: EvaluablePromotion[] = [
+    promo({ id: 'a', vendorId: VENDOR_A, kind: 'FREE_SHIPPING', value: 0 }),
+  ]
+  const result = evaluatePromotions({
+    lines, promotions, now: fixedNow, shippingCost: 4.95,
+  })
+  assert.equal(result.applied.size, 0)
+  assert.equal(result.shippingDiscount, 0)
+})
+
+test('PERCENTAGE beats FIXED_AMOUNT when it produces a larger discount', () => {
+  const result = evaluatePromotions({
+    lines: [line({ unitPrice: 100 })],
+    promotions: [
+      promo({ id: 'fixed', kind: 'FIXED_AMOUNT', value: 5 }),
+      promo({ id: 'percent', kind: 'PERCENTAGE', value: 20 }),
+    ],
+    now: fixedNow,
+  })
+  assert.equal(result.applied.get(VENDOR_A)?.promotionId, 'percent')
+  assert.equal(result.applied.get(VENDOR_A)?.discountAmount, 20)
+})
+
+test('PERCENTAGE value is clamped at the applicable subtotal (no negative totals)', () => {
+  const result = evaluatePromotions({
+    lines: [line({ unitPrice: 10 })],
+    promotions: [promo({ value: 200 })], // pathological > 100
+    now: fixedNow,
+  })
+  assert.equal(result.applied.get(VENDOR_A)?.discountAmount, 10)
+})
+
+test('unknown codes are reported only when no promo in the pool matches', () => {
+  const lines = [line()]
+  const promos = [promo({ code: 'KNOWN', value: 10 })]
+
+  const unknown = evaluatePromotions({
+    lines, promotions: promos, now: fixedNow, code: 'UNKNOWN',
+  })
+  assert.deepEqual(unknown.unknownCodes, ['UNKNOWN'])
+
+  const known = evaluatePromotions({
+    lines, promotions: promos, now: fixedNow, code: 'KNOWN',
+  })
+  assert.deepEqual(known.unknownCodes, [])
+})

--- a/test/integration/promotions-checkout.test.ts
+++ b/test/integration/promotions-checkout.test.ts
@@ -1,0 +1,351 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createOrder } from '@/domains/orders/actions'
+import { createPromotion } from '@/domains/promotions/actions'
+import { previewPromotionsForCart } from '@/domains/promotions/checkout'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Phase 2 of the promotions RFC. These tests cover the actual checkout
+ * integration: promotion candidate loading, discount math, race-safe
+ * redemption bookkeeping, the coupon-code UX, and the VendorFulfillment
+ * linkage. The pure engine math is covered in
+ * test/features/promotions-evaluation.test.ts.
+ */
+
+const ADDRESS = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  line1: 'Calle Mayor 1',
+  city: 'Madrid',
+  province: 'Madrid',
+  postalCode: '28001',
+}
+
+const in30Days = () => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+const inThePast = () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+const now = () => new Date().toISOString()
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  resetServerEnvCache()
+})
+
+async function setupVendorAndProduct(opts: { price?: number; stock?: number } = {}) {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, {
+    stock: opts.stock ?? 10,
+    basePrice: opts.price ?? 20,
+  })
+  return { vendorUser, vendor, product }
+}
+
+async function createCustomerSession() {
+  const customer = await createUser('CUSTOMER')
+  useTestSession(buildSession(customer.id, 'CUSTOMER'))
+  return customer
+}
+
+async function createPromoAs(
+  vendorUserId: string,
+  overrides: Partial<Parameters<typeof createPromotion>[0]>
+) {
+  useTestSession(buildSession(vendorUserId, 'VENDOR'))
+  return createPromotion({
+    name: overrides.name ?? 'Campaign',
+    code: overrides.code ?? null,
+    kind: overrides.kind ?? 'PERCENTAGE',
+    value: overrides.value ?? 10,
+    scope: overrides.scope ?? 'VENDOR',
+    productId: overrides.productId ?? null,
+    categoryId: overrides.categoryId ?? null,
+    minSubtotal: overrides.minSubtotal ?? null,
+    maxRedemptions: overrides.maxRedemptions ?? null,
+    perUserLimit: overrides.perUserLimit ?? 1,
+    startsAt: overrides.startsAt ?? now(),
+    endsAt: overrides.endsAt ?? in30Days(),
+  })
+}
+
+test('createOrder applies an auto vendor-wide percentage promo and persists discount fields', async () => {
+  const { vendorUser, vendor, product } = await setupVendorAndProduct({ price: 50, stock: 5 })
+  await createPromoAs(vendorUser.id, { value: 20 }) // 20% off
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 2 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+
+  const order = await db.order.findUnique({
+    where: { id: created.orderId },
+    include: { fulfillments: true },
+  })
+  assert.ok(order)
+  assert.equal(Number(order!.discountTotal), 20) // 20% of 100
+  assert.equal(Number(order!.subtotal), 80)
+  assert.equal(order!.fulfillments.length, 1)
+  assert.equal(Number(order!.fulfillments[0].discountAmount), 20)
+  assert.ok(order!.fulfillments[0].promotionId)
+
+  // Promotion redemption was bumped
+  const promo = await db.promotion.findFirst({ where: { vendorId: vendor.id } })
+  assert.equal(promo?.redemptionCount, 1)
+
+  // Grand total is subtotal + shipping
+  assert.equal(
+    Number(order!.grandTotal),
+    Number(order!.subtotal) + Number(order!.shippingCost)
+  )
+})
+
+test('createOrder applies a fixed-amount promo and clamps against subtotal', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 4, stock: 2 })
+  await createPromoAs(vendorUser.id, { kind: 'FIXED_AMOUNT', value: 50 })
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({ where: { id: created.orderId } })
+  // Cart has a single 4€ line; the 50€ promo is clamped to 4€
+  assert.equal(Number(order!.discountTotal), 4)
+  assert.equal(Number(order!.subtotal), 0)
+})
+
+test('createOrder uses a buyer-entered code when it is a better deal than the auto promo', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 50, stock: 5 })
+  await createPromoAs(vendorUser.id, { name: 'Auto 5', value: 5, perUserLimit: 100 })
+  await createPromoAs(vendorUser.id, {
+    name: 'Coded 40',
+    code: 'BIG40',
+    value: 40,
+    perUserLimit: 100,
+  })
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 2 }],
+    { address: ADDRESS, saveAddress: false },
+    { promotionCode: 'BIG40' }
+  )
+
+  const order = await db.order.findUnique({
+    where: { id: created.orderId },
+    include: { fulfillments: true },
+  })
+  assert.equal(Number(order!.discountTotal), 40) // 40% of 100
+  const applied = await db.promotion.findFirst({
+    where: { id: order!.fulfillments[0].promotionId! },
+  })
+  assert.equal(applied?.code, 'BIG40')
+})
+
+test('createOrder rejects a coupon code that does not match any promotion', async () => {
+  const { product } = await setupVendorAndProduct()
+  await createCustomerSession()
+
+  await assert.rejects(
+    () =>
+      createOrder(
+        [{ productId: product.id, quantity: 1 }],
+        { address: ADDRESS, saveAddress: false },
+        { promotionCode: 'NOPE' }
+      ),
+    /NOPE/
+  )
+})
+
+test('createOrder skips expired promotions', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 30, stock: 3 })
+  await createPromoAs(vendorUser.id, {
+    value: 25,
+    startsAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+    endsAt: inThePast(),
+  })
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({ where: { id: created.orderId } })
+  assert.equal(Number(order!.discountTotal), 0)
+})
+
+test('createOrder skips archived promotions', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 30, stock: 3 })
+  const promo = await createPromoAs(vendorUser.id, { value: 25 })
+  // archive by direct db write (cheaper than calling the action with session juggling)
+  await db.promotion.update({
+    where: { id: promo.id },
+    data: { archivedAt: new Date() },
+  })
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({ where: { id: created.orderId } })
+  assert.equal(Number(order!.discountTotal), 0)
+})
+
+test('createOrder enforces maxRedemptions atomically', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 40, stock: 10 })
+  await createPromoAs(vendorUser.id, { value: 10, maxRedemptions: 1, perUserLimit: 100 })
+
+  // First buyer consumes the single redemption budget.
+  const firstBuyer = await createCustomerSession()
+  await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+
+  // Second buyer should place the order WITHOUT the discount (no rollback
+  // on the order itself, just no promo applied).
+  const secondBuyer = await createUser('CUSTOMER')
+  useTestSession(buildSession(secondBuyer.id, 'CUSTOMER'))
+  const created = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({ where: { id: created.orderId } })
+  assert.equal(Number(order!.discountTotal), 0)
+
+  // Safety: the promo counter never exceeds maxRedemptions
+  const promo = await db.promotion.findFirst({ where: { vendorId: (await db.product.findUnique({ where: { id: product.id } }))!.vendorId } })
+  assert.equal(promo?.redemptionCount, 1)
+
+  // Silence the unused reference for lint
+  void firstBuyer
+})
+
+test('createOrder enforces perUserLimit', async () => {
+  const { vendorUser, product } = await setupVendorAndProduct({ price: 40, stock: 10 })
+  await createPromoAs(vendorUser.id, { value: 10, perUserLimit: 1 })
+
+  const buyer = await createCustomerSession()
+
+  const first = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const firstOrder = await db.order.findUnique({ where: { id: first.orderId } })
+  assert.equal(Number(firstOrder!.discountTotal), 4)
+
+  // Same buyer, second order — the promo must NOT apply again.
+  const second = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const secondOrder = await db.order.findUnique({ where: { id: second.orderId } })
+  assert.equal(Number(secondOrder!.discountTotal), 0)
+
+  // Silence the unused reference for lint
+  void buyer
+})
+
+test('createOrder scopes promotions per vendor in a multi-vendor cart', async () => {
+  const { vendorUser: vuA, vendor: vendorA, product: productA } =
+    await setupVendorAndProduct({ price: 30, stock: 5 })
+  const { vendorUser: vuB, vendor: vendorB, product: productB } =
+    await setupVendorAndProduct({ price: 50, stock: 5 })
+
+  await createPromoAs(vuA.id, { name: 'A 10%', value: 10 })
+  await createPromoAs(vuB.id, { name: 'B fixed 7', kind: 'FIXED_AMOUNT', value: 7 })
+
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [
+      { productId: productA.id, quantity: 1 }, // 30
+      { productId: productB.id, quantity: 1 }, // 50
+    ],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({
+    where: { id: created.orderId },
+    include: { fulfillments: { orderBy: { createdAt: 'asc' } } },
+  })
+  assert.ok(order)
+  // Vendor A: 10% of 30 = 3. Vendor B: fixed 7.
+  const byVendor = new Map(
+    order!.fulfillments.map(f => [f.vendorId, Number(f.discountAmount)])
+  )
+  assert.equal(byVendor.get(vendorA.id), 3)
+  assert.equal(byVendor.get(vendorB.id), 7)
+  assert.equal(Number(order!.discountTotal), 10)
+})
+
+test('createOrder skips FREE_SHIPPING promotions in multi-vendor carts', async () => {
+  const { vendorUser: vuA, product: productA } = await setupVendorAndProduct({ price: 30, stock: 5 })
+  const { product: productB } = await setupVendorAndProduct({ price: 50, stock: 5 })
+
+  await createPromoAs(vuA.id, { name: 'Free ship A', kind: 'FREE_SHIPPING', value: 0 })
+  await createCustomerSession()
+
+  const created = await createOrder(
+    [
+      { productId: productA.id, quantity: 1 },
+      { productId: productB.id, quantity: 1 },
+    ],
+    { address: ADDRESS, saveAddress: false }
+  )
+  const order = await db.order.findUnique({ where: { id: created.orderId } })
+  assert.ok(Number(order!.shippingCost) > 0)
+  assert.equal(Number(order!.discountTotal), 0)
+})
+
+test('previewPromotionsForCart returns the applied discount without writing anything', async () => {
+  const { vendorUser, vendor, product } = await setupVendorAndProduct({ price: 50, stock: 5 })
+  await createPromoAs(vendorUser.id, { value: 20, perUserLimit: 100 })
+  await createCustomerSession()
+
+  const preview = await previewPromotionsForCart({
+    items: [{ productId: product.id, quantity: 2 }],
+    code: null,
+    shippingCost: 4.95,
+  })
+
+  assert.equal(preview.ok, true)
+  assert.equal(preview.subtotalDiscount, 20)
+  assert.equal(preview.appliedByVendor.length, 1)
+  assert.equal(preview.appliedByVendor[0].vendorId, vendor.id)
+  assert.equal(preview.appliedByVendor[0].discountAmount, 20)
+
+  // No rows were created / mutated
+  const orders = await db.order.count()
+  assert.equal(orders, 0)
+  const promo = await db.promotion.findFirst({ where: { vendorId: vendor.id } })
+  assert.equal(promo?.redemptionCount, 0)
+})
+
+test('previewPromotionsForCart surfaces an unknown code without crashing', async () => {
+  const { product } = await setupVendorAndProduct()
+  await createCustomerSession()
+
+  const preview = await previewPromotionsForCart({
+    items: [{ productId: product.id, quantity: 1 }],
+    code: 'TYPO',
+    shippingCost: 0,
+  })
+  assert.equal(preview.subtotalDiscount, 0)
+  assert.deepEqual(preview.unknownCodes, ['TYPO'])
+})


### PR DESCRIPTION
## Summary
Wires phase 1's dormant promotion CRUD into the actual checkout flow. The buyer now sees auto-applicable discounts the moment they land on checkout, can optionally enter a coupon code, and the order that gets charged reflects the discounted total. Phase 2 of the [promotions RFC](docs/rfcs/0001-promotions-and-subscriptions.md).

## Architecture
**Pure evaluation engine** ([`src/domains/promotions/evaluation.ts`](src/domains/promotions/evaluation.ts)) — DB-less function taking `(lines, promotions, code, now, shippingCost, buyerRedemptions)` and returning per-vendor winners. Enforces: no stacking (one winner per vendor, biggest absolute discount), date window, archived, minSubtotal, maxRedemptions, perUserLimit, scope ↔ line match, kind ↔ discount math. Covered by 22 unit tests.

**Loader + preview action** ([`src/domains/promotions/loader.ts`](src/domains/promotions/loader.ts), [`checkout.ts`](src/domains/promotions/checkout.ts)) — SQL-filtered candidate pool + read-only `previewPromotionsForCart` the checkout page calls on every cart/code/shipping change.

**Order integration** ([`src/domains/orders/actions.ts`](src/domains/orders/actions.ts)) — evaluates promotions BEFORE Stripe PaymentIntent creation so the charged amount is already discounted. Atomic redemption claim inside the same transaction that reserves stock, protecting `maxRedemptions` against races:

```sql
UPDATE "Promotion" SET "redemptionCount" = "redemptionCount" + 1
WHERE id = $1
  AND "archivedAt" IS NULL
  AND ("maxRedemptions" IS NULL OR "redemptionCount" < "maxRedemptions")
```

If `rowsAffected === 0`, the transaction rolls back and the buyer is never charged. Also reduces `taxAmount` proportionally to the discount so reporting stays honest (tax is included in unit prices here).

## UI
- Coupon input with apply / remove states in the checkout breakdown
- Live-updating preview — auto-promos show without any buyer input
- New "Descuento" line + applied promotion name inline
- New "Envío gratis aplicado" hint when `FREE_SHIPPING` is applied
- Invalid code surfaces the server error under the input

## Out of scope (explicit)
- **Stripe Coupon sync** — we pre-compute the discount and reduce the PaymentIntent `amount`. Stripe Coupons add complexity for no benefit in this model.
- **Per-vendor shipping split** — `FREE_SHIPPING` in multi-vendor carts is skipped rather than approximated. A future RFC can split shipping per vendor.
- **Promotion edit action** — archive + re-create remains the flow.
- **Admin dashboards** — phase 5.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — **611 / 611** passing (22 new unit tests for the engine)
- [x] `npm run test:integration` — **153 / 153** passing (12 new tests for checkout integration: auto-promo, code beats auto, unknown code rejection, expired, archived, maxRedemptions race, perUserLimit re-use, multi-vendor independent application, FREE_SHIPPING skipped in multi-vendor cart, preview happy + error)
- [ ] Manual: create an auto 10% vendor-wide promo, add 50€ of that vendor's products to the cart, go to checkout → see "Descuento −5,00 €" in the breakdown, Stripe total should be 45 € + shipping
- [ ] Manual: create a `SUMMER20` coupon code, enter it on checkout → see it replace the auto-promo if it's bigger
- [ ] Manual: enter `TYPO` → see the error "El código 'TYPO' no es válido…"
- [ ] Manual: set maxRedemptions=1, place the first order successfully, then place a second order from another buyer — the second order goes through without the discount

🤖 Generated with [Claude Code](https://claude.com/claude-code)