### PR TITLE
feat(subscriptions): phase 4b-α — Stripe Price provisioning + webhook sync

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -17,6 +17,10 @@ import {
 } from '@/domains/orders/order-event-payload'
 import { recordWebhookDeadLetter } from '@/domains/payments/webhook-dlq'
 import { getServerEnv } from '@/lib/env'
+import {
+  mapStripeSubscriptionStatus,
+  parseStripeSubscriptionEvent,
+} from '@/domains/subscriptions/stripe-subscriptions'
 import type Stripe from 'stripe'
 
 type WebhookEvent = {
@@ -99,6 +103,21 @@ export async function POST(req: NextRequest) {
           break
         }
         await handlePaymentFailed(pi.id, event.id)
+        break
+      }
+      // Phase 4b-α: subscription lifecycle. The handler is idempotent by
+      // construction (state-based sync — applying the same status twice
+      // is a no-op) so we do not need the OrderEvent dedupe table here.
+      // Phase 4b-β will add `invoice.paid` / `invoice.payment_failed`
+      // handling that materializes Orders + VendorFulfillments.
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted': {
+        const parsed = parseStripeSubscriptionEvent(event.data.object)
+        if (!parsed) {
+          logInvalidWebhookPayload(event)
+          break
+        }
+        await handleSubscriptionSync(parsed, event.type)
         break
       }
     }
@@ -278,6 +297,54 @@ async function handlePaymentFailed(providerRef: string, eventId?: string) {
       error,
     })
     throw error
+  })
+}
+
+async function handleSubscriptionSync(
+  payload: { id: string; status: string; pause_collection?: unknown; canceled_at?: number | null },
+  eventType: 'customer.subscription.updated' | 'customer.subscription.deleted'
+) {
+  const subscription = await db.subscription.findUnique({
+    where: { stripeSubscriptionId: payload.id },
+    select: { id: true, status: true, canceledAt: true },
+  })
+
+  if (!subscription) {
+    // Phase 4b-α: buyers cannot subscribe yet (no public subscribe flow),
+    // so most events will arrive with a stripeSubscriptionId that is not
+    // in our DB. This is expected and a no-op. Logged at info level so we
+    // can spot wiring issues in phase 4b-β when the public flow opens.
+    console.info('[stripe-webhook][subscription-not-found]', {
+      stripeSubscriptionId: payload.id,
+      eventType,
+    })
+    return
+  }
+
+  // `customer.subscription.deleted` is Stripe's terminal cancelation
+  // event — trust it over whatever `status` says on the object.
+  const nextStatus =
+    eventType === 'customer.subscription.deleted'
+      ? 'CANCELED'
+      : mapStripeSubscriptionStatus(payload.status, payload.pause_collection)
+
+  if (subscription.status === nextStatus) {
+    // Idempotent no-op — the row is already in the state this event
+    // asks for. Common when Stripe retries a webhook.
+    return
+  }
+
+  const canceledAt =
+    nextStatus === 'CANCELED'
+      ? subscription.canceledAt ?? new Date()
+      : null
+
+  await db.subscription.update({
+    where: { id: subscription.id },
+    data: {
+      status: nextStatus,
+      canceledAt,
+    },
   })
 }
 

--- a/src/domains/subscriptions/actions.ts
+++ b/src/domains/subscriptions/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { getActionSession } from '@/lib/action-session'
 import { isVendor } from '@/lib/roles'
 import { safeRevalidatePath } from '@/lib/revalidate'
+import { provisionPlanPrice } from '@/domains/subscriptions/stripe-subscriptions'
 
 /**
  * Phase 3 of the promotions & subscriptions RFC
@@ -49,6 +50,7 @@ export async function createSubscriptionPlan(input: SubscriptionPlanInput) {
     },
     select: {
       id: true,
+      name: true,
       basePrice: true,
       taxRate: true,
     },
@@ -88,8 +90,45 @@ export async function createSubscriptionPlan(input: SubscriptionPlanInput) {
     },
   })
 
-  safeRevalidatePath('/vendor/suscripciones')
-  return plan
+  // Phase 4b-α of the promotions RFC: provision a Stripe Price for the
+  // plan so phase 4b-β can create Subscriptions that reference it. The
+  // provisioning runs AFTER the row is committed — if Stripe rejects the
+  // request (invalid key, outage, bad data) we clean up the orphan row
+  // so the vendor can retry without hitting the @@unique([productId])
+  // constraint.
+  try {
+    const provisioning = await provisionPlanPrice({
+      planId: plan.id,
+      productName: product.name,
+      priceEurCents: Math.round(Number(product.basePrice) * 100),
+      cadence: data.cadence,
+      taxRate: Number(product.taxRate),
+      vendorStripeAccountId: vendor.stripeAccountId ?? null,
+    })
+    const updated = await db.subscriptionPlan.update({
+      where: { id: plan.id },
+      data: { stripePriceId: provisioning.stripePriceId },
+    })
+    safeRevalidatePath('/vendor/suscripciones')
+    return updated
+  } catch (error) {
+    await db.subscriptionPlan
+      .delete({ where: { id: plan.id } })
+      .catch(cleanupError => {
+        console.error(
+          '[subscriptions] failed to clean up orphan plan after Stripe provisioning error',
+          { planId: plan.id, cleanupError }
+        )
+      })
+    console.error('[subscriptions] Stripe Price provisioning failed', {
+      planId: plan.id,
+      productId: product.id,
+      error,
+    })
+    throw new Error(
+      'No se pudo crear el plan en el proveedor de pagos. Inténtalo de nuevo en unos segundos.'
+    )
+  }
 }
 
 export async function listMySubscriptionPlans(

--- a/src/domains/subscriptions/stripe-subscriptions.ts
+++ b/src/domains/subscriptions/stripe-subscriptions.ts
@@ -1,0 +1,182 @@
+/**
+ * Phase 4b-α of the promotions & subscriptions RFC
+ * (docs/rfcs/0001-promotions-and-subscriptions.md).
+ *
+ * Thin adapter between our SubscriptionPlan / Subscription domain and the
+ * Stripe Subscriptions API. Scoped deliberately: this phase only handles
+ *   (a) provisioning a Stripe Price when a vendor creates a plan, and
+ *   (b) syncing a local Subscription row when Stripe fires a subscription
+ *       lifecycle event on an id we already know.
+ *
+ * Phase 4b-β will add: creating a Stripe Customer + Checkout Session from
+ * the buyer subscribe action, materialising an Order + VendorFulfillment
+ * on `invoice.paid`, and translating our cancel / pause helpers to the
+ * Stripe API. None of that lives here yet.
+ *
+ * The module exposes a small surface so both mock and real modes can be
+ * exercised from unit tests. All Stripe SDK access is lazy — importing
+ * this file never requires STRIPE_SECRET_KEY to be present.
+ */
+
+import { getServerEnv } from '@/lib/env'
+import type { SubscriptionCadence } from '@/generated/prisma/enums'
+
+export interface PlanProvisioningInput {
+  planId: string
+  productName: string
+  priceEurCents: number
+  cadence: SubscriptionCadence
+  taxRate: number
+  vendorStripeAccountId: string | null
+}
+
+export interface PlanProvisioningResult {
+  stripePriceId: string
+  stripeProductId: string | null
+}
+
+const CADENCE_TO_STRIPE_INTERVAL: Record<
+  SubscriptionCadence,
+  { interval: 'week' | 'month'; intervalCount: number }
+> = {
+  WEEKLY:   { interval: 'week',  intervalCount: 1 },
+  BIWEEKLY: { interval: 'week',  intervalCount: 2 },
+  MONTHLY:  { interval: 'month', intervalCount: 1 },
+}
+
+/**
+ * Creates the Stripe Product + recurring Price for a SubscriptionPlan.
+ * In mock mode (PAYMENT_PROVIDER=mock) returns deterministic fake IDs so
+ * tests can assert on them without reaching the network. In stripe mode
+ * creates a real Product and Price on the platform account — phase 4b-β
+ * will later create Subscriptions that reference this Price with
+ * `transfer_data.destination = vendorStripeAccountId`.
+ */
+export async function provisionPlanPrice(
+  input: PlanProvisioningInput
+): Promise<PlanProvisioningResult> {
+  const env = getServerEnv()
+
+  if (env.paymentProvider === 'mock') {
+    // Deterministic + namespaced so collisions with real Stripe ids are
+    // impossible even if the env flips mid-test.
+    return {
+      stripePriceId: `price_mock_${input.planId}`,
+      stripeProductId: `prod_mock_${input.planId}`,
+    }
+  }
+
+  const Stripe = (await import('stripe')).default
+  const stripe = new Stripe(env.stripeSecretKey!)
+
+  // We create a new Product for each plan rather than reusing the
+  // marketplace Product — a Stripe Product carries the buyer-facing name
+  // the buyer sees on their Stripe-hosted invoice, so keeping it 1:1 with
+  // the plan gives vendors room to rename the box later without touching
+  // existing subscribers.
+  const product = await stripe.products.create({
+    name: input.productName,
+    metadata: {
+      marketplacePlanId: input.planId,
+      marketplaceProductName: input.productName,
+    },
+  })
+
+  const cadence = CADENCE_TO_STRIPE_INTERVAL[input.cadence]
+  const price = await stripe.prices.create({
+    product: product.id,
+    currency: 'eur',
+    unit_amount: input.priceEurCents,
+    recurring: {
+      interval: cadence.interval,
+      interval_count: cadence.intervalCount,
+    },
+    tax_behavior: 'inclusive',
+    metadata: {
+      marketplacePlanId: input.planId,
+      marketplaceTaxRate: input.taxRate.toString(),
+      ...(input.vendorStripeAccountId && {
+        vendorStripeAccountId: input.vendorStripeAccountId,
+      }),
+    },
+  })
+
+  return {
+    stripePriceId: price.id,
+    stripeProductId: product.id,
+  }
+}
+
+/**
+ * Pure mapper from Stripe's subscription.status to our local
+ * SubscriptionStatus enum. Stripe has more granular states than we do —
+ * we collapse anything that results in no billing to PAUSED or CANCELED
+ * as appropriate. Kept as a pure function so tests can pin the mapping
+ * without touching the DB or the SDK.
+ *
+ * Reference: https://docs.stripe.com/api/subscriptions/object#subscription_object-status
+ */
+export type LocalSubscriptionStatus =
+  | 'ACTIVE'
+  | 'PAUSED'
+  | 'CANCELED'
+  | 'PAST_DUE'
+
+export function mapStripeSubscriptionStatus(
+  stripeStatus: string,
+  pauseCollection: unknown
+): LocalSubscriptionStatus {
+  // Stripe exposes a paused sub as status='active' with a non-null
+  // pause_collection — collapse that to our PAUSED.
+  if (pauseCollection && typeof pauseCollection === 'object') {
+    return 'PAUSED'
+  }
+
+  switch (stripeStatus) {
+    case 'active':
+    case 'trialing':
+      return 'ACTIVE'
+    case 'past_due':
+    case 'unpaid':
+      return 'PAST_DUE'
+    case 'canceled':
+    case 'incomplete_expired':
+      return 'CANCELED'
+    case 'paused':
+      return 'PAUSED'
+    default:
+      // Stripe may add new statuses in the future. Default to ACTIVE so
+      // the buyer does not lose access silently — the mismatch will be
+      // surfaced by the webhook logger and fixed in the mapper here.
+      return 'ACTIVE'
+  }
+}
+
+export interface StripeSubscriptionEventPayload {
+  id: string
+  status: string
+  pause_collection?: unknown
+  cancel_at?: number | null
+  canceled_at?: number | null
+}
+
+/**
+ * Parses the `data.object` of a Stripe `customer.subscription.*` event
+ * into a narrower shape. Returns null when the payload doesn't look like
+ * a subscription (in which case the webhook handler logs and no-ops).
+ */
+export function parseStripeSubscriptionEvent(
+  obj: unknown
+): StripeSubscriptionEventPayload | null {
+  if (!obj || typeof obj !== 'object') return null
+  const o = obj as Record<string, unknown>
+  if (typeof o.id !== 'string' || !o.id.startsWith('sub_')) return null
+  if (typeof o.status !== 'string') return null
+  return {
+    id: o.id,
+    status: o.status,
+    pause_collection: o.pause_collection,
+    cancel_at: typeof o.cancel_at === 'number' ? o.cancel_at : null,
+    canceled_at: typeof o.canceled_at === 'number' ? o.canceled_at : null,
+  }
+}

--- a/test/features/stripe-subscriptions-mapper.test.ts
+++ b/test/features/stripe-subscriptions-mapper.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  mapStripeSubscriptionStatus,
+  parseStripeSubscriptionEvent,
+} from '@/domains/subscriptions/stripe-subscriptions'
+
+/**
+ * Phase 4b-α — pure unit tests for the Stripe → local status mapper and
+ * the event payload parser. No DB, no SDK, no network.
+ */
+
+test('mapStripeSubscriptionStatus maps active / trialing to ACTIVE', () => {
+  assert.equal(mapStripeSubscriptionStatus('active', null), 'ACTIVE')
+  assert.equal(mapStripeSubscriptionStatus('trialing', null), 'ACTIVE')
+})
+
+test('mapStripeSubscriptionStatus maps past_due / unpaid to PAST_DUE', () => {
+  assert.equal(mapStripeSubscriptionStatus('past_due', null), 'PAST_DUE')
+  assert.equal(mapStripeSubscriptionStatus('unpaid', null), 'PAST_DUE')
+})
+
+test('mapStripeSubscriptionStatus maps canceled / incomplete_expired to CANCELED', () => {
+  assert.equal(mapStripeSubscriptionStatus('canceled', null), 'CANCELED')
+  assert.equal(mapStripeSubscriptionStatus('incomplete_expired', null), 'CANCELED')
+})
+
+test('mapStripeSubscriptionStatus treats a non-null pause_collection as PAUSED regardless of underlying status', () => {
+  // Stripe represents a paused sub as status=active + pause_collection={...}
+  assert.equal(
+    mapStripeSubscriptionStatus('active', { behavior: 'void' }),
+    'PAUSED'
+  )
+})
+
+test('mapStripeSubscriptionStatus defaults unknown statuses to ACTIVE so the buyer does not lose access silently', () => {
+  assert.equal(mapStripeSubscriptionStatus('something_new', null), 'ACTIVE')
+})
+
+test('parseStripeSubscriptionEvent accepts a well-formed subscription payload', () => {
+  const parsed = parseStripeSubscriptionEvent({
+    id: 'sub_123',
+    status: 'active',
+    pause_collection: null,
+    cancel_at: null,
+    canceled_at: null,
+  })
+  assert.ok(parsed)
+  assert.equal(parsed?.id, 'sub_123')
+  assert.equal(parsed?.status, 'active')
+})
+
+test('parseStripeSubscriptionEvent rejects payloads missing a subscription id', () => {
+  assert.equal(parseStripeSubscriptionEvent({ status: 'active' }), null)
+  assert.equal(parseStripeSubscriptionEvent(null), null)
+  assert.equal(parseStripeSubscriptionEvent('nope'), null)
+})
+
+test('parseStripeSubscriptionEvent rejects ids that do not look like Stripe subscription ids', () => {
+  // Defensive: a payload with id=`pi_xxx` would be a payment intent.
+  assert.equal(
+    parseStripeSubscriptionEvent({ id: 'pi_123', status: 'active' }),
+    null
+  )
+})

--- a/test/integration/subscriptions-stripe.test.ts
+++ b/test/integration/subscriptions-stripe.test.ts
@@ -1,0 +1,329 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { POST } from '@/app/api/webhooks/stripe/route'
+import { createSubscriptionPlan } from '@/domains/subscriptions/actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Phase 4b-α of the promotions & subscriptions RFC. Verifies
+ *   (a) plan creation provisions a Stripe Price (mock IDs in mock mode),
+ *   (b) webhook handler idempotently syncs local Subscription rows
+ *       when Stripe fires customer.subscription.* events on an id we
+ *       already know, and
+ *   (c) subscription events whose id is not in our DB are a no-op and
+ *       return 200 — the handler must not crash.
+ *
+ * Stripe Customer + Checkout Session creation, the public subscribe CTA,
+ * and invoice.paid → Order materialization live in phase 4b-β and are
+ * explicitly out of scope here.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  resetServerEnvCache()
+})
+
+test('createSubscriptionPlan provisions a mock Stripe Price id in mock mode', async () => {
+  const { user, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 27.5 })
+  useTestSession(buildSession(user.id, 'VENDOR'))
+
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  assert.ok(plan.stripePriceId)
+  assert.equal(plan.stripePriceId, `price_mock_${plan.id}`)
+})
+
+test('createSubscriptionPlan leaves no orphan plan row if Stripe provisioning throws', async () => {
+  // We force an exception by making `provisionPlanPrice` receive a
+  // non-finite price. Mock mode happily returns an id anyway, so the
+  // cleanest way to simulate a failure from outside the module is to
+  // flip the env to 'stripe' without a secret key — the adapter will
+  // blow up trying to construct the Stripe client inside the module.
+  //
+  // We do this *after* the action validates its schema, so we keep
+  // PAYMENT_PROVIDER='stripe' and stripeSecretKey empty; the env parser
+  // will reject that, so we patch process.env directly AFTER creating
+  // the vendor + product (which uses the server env too).
+  const { user, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 10 })
+  useTestSession(buildSession(user.id, 'VENDOR'))
+
+  process.env.PAYMENT_PROVIDER = 'stripe'
+  process.env.STRIPE_SECRET_KEY = 'sk_test_dummy'
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_dummy'
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_dummy'
+  resetServerEnvCache()
+
+  await assert.rejects(
+    () =>
+      createSubscriptionPlan({
+        productId: product.id,
+        cadence: 'WEEKLY',
+        cutoffDayOfWeek: 5,
+      }),
+    /proveedor de pagos/i
+  )
+
+  const orphanCount = await db.subscriptionPlan.count({
+    where: { vendorId: vendor.id },
+  })
+  assert.equal(orphanCount, 0)
+})
+
+test('webhook customer.subscription.updated syncs an existing Subscription to PAST_DUE', async () => {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 20 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: {
+      userId: buyer.id,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      line1: 'Calle Mayor 1',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      country: 'ES',
+    },
+  })
+
+  // Seed the Subscription row directly — the public subscribe flow
+  // doesn't land until phase 4b-β. The stripeSubscriptionId is the
+  // link Stripe will use in every future webhook for this sub.
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_past_due',
+    },
+  })
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_past_due_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test_past_due',
+            status: 'past_due',
+          },
+        },
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const updated = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(updated?.status, 'PAST_DUE')
+
+  // Idempotent: replaying the same event must leave the state unchanged.
+  const replay = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_past_due_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test_past_due',
+            status: 'past_due',
+          },
+        },
+      }),
+    }) as any
+  )
+  assert.equal(replay.status, 200)
+  const stillPastDue = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(stillPastDue?.status, 'PAST_DUE')
+})
+
+test('webhook customer.subscription.updated collapses active + pause_collection into PAUSED', async () => {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 20 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: {
+      userId: buyer.id,
+      firstName: 'Pause',
+      lastName: 'Tester',
+      line1: 'Calle Mayor 1',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      country: 'ES',
+    },
+  })
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_pause',
+    },
+  })
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_pause_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_test_pause',
+            status: 'active',
+            pause_collection: { behavior: 'void' },
+          },
+        },
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const updated = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(updated?.status, 'PAUSED')
+})
+
+test('webhook customer.subscription.deleted marks the local row CANCELED + stamps canceledAt', async () => {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 20 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: {
+      userId: buyer.id,
+      firstName: 'Cancel',
+      lastName: 'Tester',
+      line1: 'Calle Mayor 1',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      country: 'ES',
+    },
+  })
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_delete',
+    },
+  })
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_delete_1',
+        type: 'customer.subscription.deleted',
+        data: {
+          object: {
+            id: 'sub_test_delete',
+            status: 'canceled',
+            canceled_at: Math.floor(Date.now() / 1000),
+          },
+        },
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const updated = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(updated?.status, 'CANCELED')
+  assert.ok(updated?.canceledAt)
+})
+
+test('webhook customer.subscription.updated is a 200 no-op when the subscription id is unknown', async () => {
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_ghost_1',
+        type: 'customer.subscription.updated',
+        data: {
+          object: {
+            id: 'sub_never_seen',
+            status: 'active',
+          },
+        },
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+  // No rows should have been created as a side effect
+  assert.equal(await db.subscription.count(), 0)
+})
+
+test('webhook logs but does not crash on a malformed subscription payload', async () => {
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'evt_malformed',
+        type: 'customer.subscription.updated',
+        data: { object: { id: 'not_a_sub_id', status: 'active' } },
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+})


### PR DESCRIPTION
## Summary
A deliberately narrow slice of phase 4b of the [promotions & subscriptions RFC](docs/rfcs/0001-promotions-and-subscriptions.md). When a vendor creates a \`SubscriptionPlan\` we now provision a Stripe Product + Price on the platform account, and the Stripe webhook route learns to sync our local \`Subscription\` row when \`customer.subscription.updated\` / \`deleted\` events arrive for an id we already know.

**Everything else Stripe-related** — Customer + Checkout Session creation from the buyer subscribe action, \`invoice.paid\` → \`Order\` + \`VendorFulfillment\` materialization, and the public product-page "Subscribe" CTA — **stays out of this PR** and lands in phase 4b-β. This keeps 4b-α non-regressing: no existing order flow changes, no new buyer path opens, and the existing baseline (621 unit / 179 integration) still passes.

## What ships
- **Stripe adapter** ([\`src/domains/subscriptions/stripe-subscriptions.ts\`](src/domains/subscriptions/stripe-subscriptions.ts)): \`provisionPlanPrice\` (mock returns deterministic \`price_mock_<planId>\` / \`prod_mock_<planId>\`; stripe creates a Product + recurring Price with \`tax_behavior='inclusive'\` and cadence → Stripe \`interval / interval_count\` mapping), \`mapStripeSubscriptionStatus\` (pure mapper, collapses \`active + pause_collection\` into \`PAUSED\`, defaults unknown statuses to \`ACTIVE\` so buyers never lose access silently), \`parseStripeSubscriptionEvent\` (defensive parser rejecting non-subscription ids). Stripe SDK is loaded via dynamic import so importing this module never requires \`STRIPE_SECRET_KEY\`.
- **Wire into \`createSubscriptionPlan\`** ([\`src/domains/subscriptions/actions.ts\`](src/domains/subscriptions/actions.ts)): after the DB row is committed, provisioning runs and the returned \`stripePriceId\` is saved back onto the row. On failure the orphan plan is deleted (with a best-effort cleanup \`catch\`) and the vendor gets a friendly "try again" message. \`vendor.stripeAccountId\` is passed into Stripe metadata so phase 4b-β can wire destination charges.
- **Webhook handler** ([\`src/app/api/webhooks/stripe/route.ts\`](src/app/api/webhooks/stripe/route.ts)): new cases for \`customer.subscription.updated\` / \`deleted\`. State-based idempotency (applying the same status twice is a no-op, no \`OrderEvent\` dedupe needed). \`deleted\` always maps to \`CANCELED\` regardless of the payload \`status\`, matching Stripe's terminal semantics. Stamps \`canceledAt\` on the transition. Unknown \`stripeSubscriptionId\` returns 200 and logs at info — expected until the public flow opens in 4b-β.

## Out of scope (phase 4b-β onwards)
- Stripe Customer + Checkout Session creation from \`subscribeToPlan\`
- Public product-detail "Subscribe" CTA
- \`invoice.paid\` / \`invoice.payment_failed\` → \`Order\` + \`VendorFulfillment\` materialisation
- Translating local \`cancel\` / \`pause\` / \`skip\` into Stripe API calls
- Transactional emails (renewal confirmation, skip reminder, payment failed)

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **629 / 629** passing (8 new pure unit tests for the status mapper + parser)
- [x] \`npm run test:integration\` — **186 / 186** passing (7 new tests: mock provisioning, Stripe-failure rollback, updated → PAST_DUE idempotent, updated + \`pause_collection\` → PAUSED, deleted → CANCELED + \`canceledAt\`, unknown id no-op, malformed payload survives)
- [ ] Manual (mock mode): create a vendor plan → confirm \`stripePriceId = price_mock_<planId>\` is stored on the row
- [ ] Manual (stripe mode, staging): create a vendor plan with a valid Stripe test key → confirm a real \`price_*\` + \`prod_*\` appears in Stripe and the row is updated
- [ ] Manual (stripe mode, staging): seed a \`Subscription\` row with a real \`stripeSubscriptionId\`, trigger \`stripe trigger customer.subscription.updated\` → confirm the local row's status follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)