### PR TITLE
feat(subscriptions): phase 4b-β — Stripe Checkout Session + invoice.paid Order materialization

### DIFF
--- a/prisma/migrations/20260415140000_user_stripe_customer_id/migration.sql
+++ b/prisma/migrations/20260415140000_user_stripe_customer_id/migration.sql
@@ -1,0 +1,11 @@
+-- Phase 4b-β of the promotions & subscriptions RFC. Persists the Stripe
+-- Customer id the first time a buyer starts a subscription Checkout
+-- Session so every subsequent checkout + every renewal invoice reuses
+-- the same customer record. Nullable because most existing buyers will
+-- never need it.
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "stripeCustomerId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_stripeCustomerId_key" ON "User"("stripeCustomerId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,10 @@ model User {
   consentAcceptedAt    DateTime?
   passwordResetToken   String?   @unique
   passwordResetExpires DateTime?
+  // Phase 4b-β: created lazily on the first subscription checkout so we
+  // can attach the same Stripe Customer to every future Checkout Session
+  // and every renewal invoice.
+  stripeCustomerId     String?   @unique
   createdAt            DateTime  @default(now())
   updatedAt            DateTime  @updatedAt
 

--- a/src/app/(public)/productos/[slug]/page.tsx
+++ b/src/app/(public)/productos/[slug]/page.tsx
@@ -20,6 +20,9 @@ import { absoluteUrl, buildPageMetadata } from '@/lib/seo'
 import { getCatalogCopy, getLocalizedCertificationCopy, getLocalizedProductCopy } from '@/i18n/catalog-copy'
 import { getServerLocale } from '@/i18n/server'
 import { translateCategoryLabel } from '@/lib/portals'
+import { getServerEnv } from '@/lib/env'
+import { getActionSession } from '@/lib/action-session'
+import { SubscribeToBoxButton } from '@/components/catalog/SubscribeToBoxButton'
 
 export const revalidate = 300
 
@@ -89,6 +92,27 @@ export default async function ProductDetailPage({ params }: Props) {
     limit: 4,
   }).then(r => r.products.filter(p => p.id !== product.id).slice(0, 4))
   const reviewSummary = await getProductReviews(product.id)
+
+  // Phase 4b-β: compute whether to show the "Subscribe" CTA. Hidden
+  // unless the buyer beta flag is on, the vendor has published an
+  // active plan AND it has been successfully provisioned in Stripe.
+  const subscribeFlagOn = getServerEnv().subscriptionsBuyerBeta
+  const sessionForSubscribe = subscribeFlagOn ? await getActionSession() : null
+  const showSubscribeCta = Boolean(
+    subscribeFlagOn &&
+    product.subscriptionPlan &&
+    !product.subscriptionPlan.archivedAt &&
+    product.subscriptionPlan.stripePriceId
+  )
+  let defaultAddressIdForSubscribe: string | null = null
+  if (showSubscribeCta && sessionForSubscribe) {
+    const defaultAddress = await db.address.findFirst({
+      where: { userId: sessionForSubscribe.user.id },
+      orderBy: [{ isDefault: 'desc' }, { updatedAt: 'desc' }],
+      select: { id: true },
+    })
+    defaultAddressIdForSubscribe = defaultAddress?.id ?? null
+  }
   const breadcrumbData = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
@@ -266,6 +290,16 @@ export default async function ProductDetailPage({ params }: Props) {
               isActive: variant.isActive,
             }))}
           />
+
+          {showSubscribeCta && product.subscriptionPlan && (
+            <SubscribeToBoxButton
+              planId={product.subscriptionPlan.id}
+              cadence={product.subscriptionPlan.cadence}
+              priceEur={Number(product.subscriptionPlan.priceSnapshot)}
+              unit={localizedProduct.unit}
+              defaultAddressId={defaultAddressIdForSubscribe}
+            />
+          )}
 
           {/* Trust strip */}
           <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs text-[var(--muted)]">

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -19,8 +19,15 @@ import { recordWebhookDeadLetter } from '@/domains/payments/webhook-dlq'
 import { getServerEnv } from '@/lib/env'
 import {
   mapStripeSubscriptionStatus,
+  parseStripeInvoiceEvent,
   parseStripeSubscriptionEvent,
+  type StripeSubscriptionEventPayload,
 } from '@/domains/subscriptions/stripe-subscriptions'
+import { materializeSubscriptionRenewal } from '@/domains/subscriptions/renewal'
+import {
+  computeFirstDeliveryAt,
+  computeCurrentPeriodEnd,
+} from '@/domains/subscriptions/cadence'
 import type Stripe from 'stripe'
 
 type WebhookEvent = {
@@ -110,6 +117,15 @@ export async function POST(req: NextRequest) {
       // is a no-op) so we do not need the OrderEvent dedupe table here.
       // Phase 4b-β will add `invoice.paid` / `invoice.payment_failed`
       // handling that materializes Orders + VendorFulfillments.
+      case 'customer.subscription.created': {
+        const parsed = parseStripeSubscriptionEvent(event.data.object)
+        if (!parsed) {
+          logInvalidWebhookPayload(event)
+          break
+        }
+        await handleSubscriptionCreated(parsed)
+        break
+      }
       case 'customer.subscription.updated':
       case 'customer.subscription.deleted': {
         const parsed = parseStripeSubscriptionEvent(event.data.object)
@@ -118,6 +134,28 @@ export async function POST(req: NextRequest) {
           break
         }
         await handleSubscriptionSync(parsed, event.type)
+        break
+      }
+      // Phase 4b-β: when Stripe charges a renewal invoice, materialize
+      // an Order + OrderLine + VendorFulfillment so the vendor sees a
+      // pending fulfillment in their dashboard just like a one-off
+      // purchase. Idempotent via Payment.providerRef = invoice.id.
+      case 'invoice.paid': {
+        const invoice = parseStripeInvoiceEvent(event.data.object)
+        if (!invoice || !invoice.subscription) {
+          logInvalidWebhookPayload(event)
+          break
+        }
+        await handleInvoicePaid(invoice)
+        break
+      }
+      case 'invoice.payment_failed': {
+        const invoice = parseStripeInvoiceEvent(event.data.object)
+        if (!invoice || !invoice.subscription) {
+          logInvalidWebhookPayload(event)
+          break
+        }
+        await handleInvoicePaymentFailed(invoice)
         break
       }
     }
@@ -297,6 +335,139 @@ async function handlePaymentFailed(providerRef: string, eventId?: string) {
       error,
     })
     throw error
+  })
+}
+
+async function handleSubscriptionCreated(
+  payload: StripeSubscriptionEventPayload
+) {
+  // Idempotent: if we already have a local row tied to this Stripe
+  // subscription id, this is a replay and we skip straight to the sync
+  // path below.
+  const existing = await db.subscription.findUnique({
+    where: { stripeSubscriptionId: payload.id },
+    select: { id: true },
+  })
+  if (existing) {
+    await handleSubscriptionSync(payload, 'customer.subscription.updated')
+    return
+  }
+
+  // The buyer action put the planId, buyerId and shippingAddressId into
+  // the Checkout Session metadata, which Stripe copies onto the
+  // resulting Subscription. Without these we cannot create a local row
+  // — log at error level and bail so Stripe retries.
+  const meta = payload.metadata ?? {}
+  const planId = meta.marketplacePlanId
+  const buyerId = meta.marketplaceBuyerId
+  const shippingAddressId = meta.marketplaceShippingAddressId
+  if (!planId || !buyerId || !shippingAddressId) {
+    console.error('[stripe-webhook][subscription-created][missing-metadata]', {
+      stripeSubscriptionId: payload.id,
+      metadata: meta,
+    })
+    return
+  }
+
+  const plan = await db.subscriptionPlan.findUnique({
+    where: { id: planId },
+    select: { id: true, cadence: true, archivedAt: true },
+  })
+  if (!plan || plan.archivedAt) {
+    console.error('[stripe-webhook][subscription-created][plan-missing]', {
+      planId,
+      stripeSubscriptionId: payload.id,
+    })
+    return
+  }
+
+  const address = await db.address.findFirst({
+    where: { id: shippingAddressId, userId: buyerId },
+    select: { id: true },
+  })
+  if (!address) {
+    console.error('[stripe-webhook][subscription-created][address-missing]', {
+      buyerId,
+      shippingAddressId,
+      stripeSubscriptionId: payload.id,
+    })
+    return
+  }
+
+  const now = new Date()
+  const nextDeliveryAt = computeFirstDeliveryAt(now, plan.cadence)
+  const currentPeriodEnd = computeCurrentPeriodEnd(nextDeliveryAt, plan.cadence)
+
+  await db.subscription.upsert({
+    where: {
+      buyerId_planId: { buyerId, planId: plan.id },
+    },
+    create: {
+      buyerId,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: mapStripeSubscriptionStatus(payload.status, payload.pause_collection),
+      nextDeliveryAt,
+      currentPeriodEnd,
+      stripeSubscriptionId: payload.id,
+    },
+    update: {
+      // The buyer had a prior CANCELED sub for the same plan (we block
+      // this in subscribeToPlan but Stripe retries may resurface it).
+      // Overwrite the row in place so there is only ever one.
+      status: mapStripeSubscriptionStatus(payload.status, payload.pause_collection),
+      shippingAddressId: address.id,
+      nextDeliveryAt,
+      currentPeriodEnd,
+      stripeSubscriptionId: payload.id,
+      canceledAt: null,
+    },
+  })
+}
+
+async function handleInvoicePaid(invoice: {
+  id: string
+  subscription: string | null
+  amount_paid: number
+}) {
+  if (!invoice.subscription) return
+  const subscription = await db.subscription.findUnique({
+    where: { stripeSubscriptionId: invoice.subscription },
+    select: { id: true },
+  })
+  if (!subscription) {
+    // Likely: the `customer.subscription.created` event has not arrived
+    // yet (Stripe does not guarantee delivery order). Log at info and
+    // rely on Stripe's retry to deliver this event again after the
+    // created event has been processed.
+    console.info('[stripe-webhook][invoice-paid][subscription-not-found]', {
+      stripeSubscriptionId: invoice.subscription,
+      invoiceId: invoice.id,
+    })
+    return
+  }
+  await materializeSubscriptionRenewal({
+    invoiceId: invoice.id,
+    subscriptionId: subscription.id,
+    amountPaidCents: invoice.amount_paid,
+  })
+}
+
+async function handleInvoicePaymentFailed(invoice: {
+  id: string
+  subscription: string | null
+}) {
+  if (!invoice.subscription) return
+  const subscription = await db.subscription.findUnique({
+    where: { stripeSubscriptionId: invoice.subscription },
+    select: { id: true, status: true },
+  })
+  if (!subscription) return
+  if (subscription.status === 'PAST_DUE' || subscription.status === 'CANCELED') return
+
+  await db.subscription.update({
+    where: { id: subscription.id },
+    data: { status: 'PAST_DUE' },
   })
 }
 

--- a/src/components/catalog/SubscribeToBoxButton.tsx
+++ b/src/components/catalog/SubscribeToBoxButton.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { ArrowPathIcon } from '@heroicons/react/24/outline'
+import { startSubscriptionCheckout } from '@/domains/subscriptions/buyer-actions'
+import { formatPrice } from '@/lib/utils'
+import { useT } from '@/i18n'
+import type { TranslationKeys } from '@/i18n/locales'
+
+interface Props {
+  planId: string
+  cadence: 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY'
+  priceEur: number
+  unit: string
+  defaultAddressId: string | null
+}
+
+export function SubscribeToBoxButton({
+  planId,
+  cadence,
+  priceEur,
+  unit,
+  defaultAddressId,
+}: Props) {
+  const t = useT()
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const cadenceKey: TranslationKeys =
+    cadence === 'WEEKLY'   ? 'account.subscriptions.cadenceWeekly'   :
+    cadence === 'BIWEEKLY' ? 'account.subscriptions.cadenceBiweekly' :
+    'account.subscriptions.cadenceMonthly'
+
+  function handleClick() {
+    if (pending) return
+    if (!defaultAddressId) {
+      setError(t('catalog.subscribe.needsAddress'))
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result = await startSubscriptionCheckout({
+          planId,
+          shippingAddressId: defaultAddressId,
+        })
+        window.location.assign(result.url)
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : t('catalog.subscribe.errorGeneric')
+        )
+      }
+    })
+  }
+
+  return (
+    <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900/50 dark:bg-emerald-950/20">
+      <div className="flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+        <ArrowPathIcon className="h-4 w-4" />
+        {t('catalog.subscribe.title')}
+      </div>
+      <p className="mt-1 text-xs text-emerald-800 dark:text-emerald-300">
+        {t('catalog.subscribe.body')
+          .replace('{price}', formatPrice(priceEur))
+          .replace('{unit}', unit)
+          .replace('{cadence}', t(cadenceKey).toLowerCase())}
+      </p>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={pending}
+        className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400"
+      >
+        {pending ? t('catalog.subscribe.loading') : t('catalog.subscribe.cta')}
+      </button>
+      {error && (
+        <p className="mt-2 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/domains/catalog/queries.ts
+++ b/src/domains/catalog/queries.ts
@@ -182,6 +182,19 @@ async function getProductBySlugUncached(slug: string) {
       },
       category: { select: { name: true, slug: true } },
       variants: { where: { isActive: true } },
+      // Phase 4b-β: surface the subscription plan so the product detail
+      // page can render a "Subscribe" CTA when the vendor has published
+      // one. `archivedAt` is checked on the client — we still pass the
+      // row through so an archive is visible in previews.
+      subscriptionPlan: {
+        select: {
+          id: true,
+          cadence: true,
+          priceSnapshot: true,
+          archivedAt: true,
+          stripePriceId: true,
+        },
+      },
     },
   })
 

--- a/src/domains/subscriptions/buyer-actions.ts
+++ b/src/domains/subscriptions/buyer-actions.ts
@@ -12,6 +12,10 @@ import {
   computeFirstDeliveryAt,
   isBeforeCutoff,
 } from '@/domains/subscriptions/cadence'
+import {
+  createSubscriptionCheckoutSession,
+  ensureStripeCustomerId,
+} from '@/domains/subscriptions/stripe-subscriptions'
 
 /**
  * Phase 4a of the promotions & subscriptions RFC. Buyer-facing subscription
@@ -106,6 +110,78 @@ export async function subscribeToPlan(input: SubscribeInput) {
 
   safeRevalidatePath('/cuenta/suscripciones')
   return subscription
+}
+
+/**
+ * Phase 4b-β: kicks off a Stripe Checkout Session for a subscription
+ * plan. The local Subscription row is NOT created here — the webhook
+ * handler for `customer.subscription.created` creates it after Stripe
+ * confirms the buyer entered a valid payment method. This avoids
+ * orphan "subscribed but not charged" rows from abandoned checkouts.
+ *
+ * Returns the Checkout Session URL so the client can redirect the
+ * buyer to Stripe's hosted page. Gated by SUBSCRIPTIONS_BUYER_BETA.
+ */
+export async function startSubscriptionCheckout(
+  input: SubscribeInput
+): Promise<{ url: string }> {
+  const { buyerId, session } = await requireBuyer()
+  assertBetaEnabled()
+  const data = subscribeSchema.parse(input)
+
+  const plan = await db.subscriptionPlan.findFirst({
+    where: { id: data.planId, archivedAt: null },
+    include: {
+      product: { select: { id: true, status: true, deletedAt: true } },
+    },
+  })
+  if (!plan) throw new Error('Plan de suscripción no encontrado')
+  if (plan.product.status !== 'ACTIVE' || plan.product.deletedAt !== null) {
+    throw new Error('Este producto ya no está disponible para suscripción')
+  }
+  if (!plan.stripePriceId) {
+    throw new Error(
+      'Este plan todavía no está sincronizado con el proveedor de pagos. Inténtalo de nuevo en unos minutos.'
+    )
+  }
+
+  const address = await db.address.findFirst({
+    where: { id: data.shippingAddressId, userId: buyerId },
+    select: { id: true },
+  })
+  if (!address) throw new Error('Dirección de envío no encontrada')
+
+  // Block re-subscribe when an ACTIVE / PAUSED / PAST_DUE row already
+  // exists. A CANCELED row does NOT block — Stripe will create a new
+  // subscription id and the webhook handler upserts the local row.
+  const existing = await db.subscription.findUnique({
+    where: { buyerId_planId: { buyerId, planId: plan.id } },
+    select: { status: true },
+  })
+  if (existing && existing.status !== 'CANCELED') {
+    throw new Error('Ya estás suscrito a este plan')
+  }
+
+  const customerId = await ensureStripeCustomerId({
+    userId: buyerId,
+    email: session.user.email ?? '',
+    name: session.user.name ?? '',
+  })
+
+  const appUrl = getServerEnv().appUrl
+  const checkout = await createSubscriptionCheckoutSession({
+    customerId,
+    stripePriceId: plan.stripePriceId,
+    successUrl: `${appUrl}/cuenta/suscripciones?checkout=success`,
+    cancelUrl: `${appUrl}/productos?checkout=cancel`,
+    metadata: {
+      marketplacePlanId: plan.id,
+      marketplaceBuyerId: buyerId,
+      marketplaceShippingAddressId: address.id,
+    },
+  })
+
+  return { url: checkout.url }
 }
 
 export async function listMySubscriptions(

--- a/src/domains/subscriptions/renewal.ts
+++ b/src/domains/subscriptions/renewal.ts
@@ -1,0 +1,175 @@
+import { db } from '@/lib/db'
+import { generateOrderNumber } from '@/lib/utils'
+import { getShippingCost } from '@/domains/shipping/calculator'
+import { orderLineSnapshotSchema, orderAddressSnapshotSchema } from '@/types/order'
+import {
+  advanceByCadence,
+  computeCurrentPeriodEnd,
+} from '@/domains/subscriptions/cadence'
+
+/**
+ * Phase 4b-β: materializes an Order + OrderLine + VendorFulfillment +
+ * Payment for a subscription billing cycle that Stripe has just
+ * charged. Triggered from the `invoice.paid` webhook.
+ *
+ * The renewal skips all the checkout-time validation (promotion
+ * evaluation, variant selection, cart deduplication) because those
+ * decisions were already frozen into the `SubscriptionPlan` and
+ * `Subscription` rows at subscribe time. Stock is NOT decremented — a
+ * subscription box is assumed to be produced on demand by the vendor;
+ * if this turns out to be wrong for some vendors we can add an opt-in
+ * flag to the plan in a later phase.
+ *
+ * Idempotent via `Payment.providerRef === invoice.id` — a replay of the
+ * webhook finds the existing Payment row and bails out early.
+ */
+export interface RenewalInput {
+  invoiceId: string
+  subscriptionId: string
+  amountPaidCents: number
+}
+
+export async function materializeSubscriptionRenewal(
+  input: RenewalInput
+): Promise<{ orderId: string | null; skipped: 'duplicate' | null }> {
+  // Idempotency check: if we already booked an Order against this
+  // invoice id, return early. Keeps the webhook handler safe to replay.
+  const existingPayment = await db.payment.findUnique({
+    where: { providerRef: input.invoiceId },
+    select: { orderId: true },
+  })
+  if (existingPayment) {
+    return { orderId: existingPayment.orderId, skipped: 'duplicate' }
+  }
+
+  const subscription = await db.subscription.findUnique({
+    where: { id: input.subscriptionId },
+    include: {
+      plan: {
+        include: {
+          product: true,
+          vendor: { select: { id: true, slug: true, displayName: true } },
+        },
+      },
+      shippingAddress: true,
+    },
+  })
+  if (!subscription) {
+    throw new Error(`Subscription ${input.subscriptionId} no encontrada`)
+  }
+
+  const plan = subscription.plan
+  const product = plan.product
+  const vendor = plan.vendor
+  const address = subscription.shippingAddress
+
+  const unitPrice = Number(plan.priceSnapshot)
+  const taxRate = Number(plan.taxRateSnapshot)
+  const subtotal = unitPrice
+  const shippingCost = await getShippingCost(address.postalCode, subtotal)
+  // Tax is included in unit prices across the rest of the marketplace.
+  // Compute the tax-only slice for reporting parity with createOrder().
+  const taxAmount =
+    Math.round(((unitPrice * taxRate) / (1 + taxRate)) * 100) / 100
+  const grandTotal = Math.round((subtotal + shippingCost) * 100) / 100
+
+  const shippingSnapshot = orderAddressSnapshotSchema.parse({
+    firstName: address.firstName,
+    lastName: address.lastName,
+    line1: address.line1,
+    line2: address.line2 ?? null,
+    city: address.city,
+    province: address.province,
+    postalCode: address.postalCode,
+    phone: address.phone ?? null,
+  })
+
+  const productSnapshot = orderLineSnapshotSchema.parse({
+    id: product.id,
+    name: product.name,
+    slug: product.slug,
+    images: product.images,
+    unit: product.unit,
+    vendorName: vendor.displayName,
+    variantName: null,
+  })
+
+  const order = await db.$transaction(async tx => {
+    const created = await tx.order.create({
+      data: {
+        orderNumber: generateOrderNumber(),
+        customerId: subscription.buyerId,
+        addressId: null,
+        shippingAddressSnapshot: shippingSnapshot,
+        subtotal,
+        discountTotal: 0,
+        shippingCost,
+        taxAmount,
+        grandTotal,
+        // Stripe already told us the invoice was paid, so we can skip the
+        // PLACED → PAYMENT_CONFIRMED transition and mark it directly.
+        status: 'PAYMENT_CONFIRMED',
+        paymentStatus: 'SUCCEEDED',
+        lines: {
+          create: [
+            {
+              productId: product.id,
+              vendorId: vendor.id,
+              variantId: null,
+              quantity: 1,
+              unitPrice,
+              taxRate,
+              productSnapshot,
+            },
+          ],
+        },
+        payments: {
+          create: {
+            provider: 'stripe',
+            providerRef: input.invoiceId,
+            amount: grandTotal,
+            currency: 'EUR',
+            status: 'SUCCEEDED',
+          },
+        },
+        fulfillments: {
+          create: [
+            {
+              vendorId: vendor.id,
+              status: 'PENDING',
+            },
+          ],
+        },
+        events: {
+          create: {
+            type: 'SUBSCRIPTION_RENEWAL_CHARGED',
+            payload: {
+              subscriptionId: subscription.id,
+              invoiceId: input.invoiceId,
+              amountPaidCents: input.amountPaidCents,
+            },
+          },
+        },
+      },
+      select: { id: true },
+    })
+
+    // Advance the subscription's delivery window one cadence forward so
+    // the UI reflects the new next delivery and the next skip/cancel
+    // action applies to the correct cycle.
+    const nextDeliveryAt = advanceByCadence(subscription.nextDeliveryAt, plan.cadence)
+    const currentPeriodEnd = computeCurrentPeriodEnd(nextDeliveryAt, plan.cadence)
+    await tx.subscription.update({
+      where: { id: subscription.id },
+      data: {
+        nextDeliveryAt,
+        currentPeriodEnd,
+        status: 'ACTIVE',
+      },
+    })
+
+    return created
+  })
+
+  return { orderId: order.id, skipped: null }
+}

--- a/src/domains/subscriptions/stripe-subscriptions.ts
+++ b/src/domains/subscriptions/stripe-subscriptions.ts
@@ -152,12 +152,164 @@ export function mapStripeSubscriptionStatus(
   }
 }
 
+// ─── Phase 4b-β: Customer + Checkout Session helpers ─────────────────────────
+
+export interface StripeCustomerInput {
+  userId: string
+  email: string
+  name: string
+}
+
+/**
+ * Returns a Stripe Customer id for the given user, creating one on the
+ * fly if the User row does not already have a `stripeCustomerId`. In mock
+ * mode, returns a deterministic `cus_mock_<userId>` without touching the
+ * DB or the network. In stripe mode, the persisted id is indexed so the
+ * second call is a simple column read.
+ */
+export async function ensureStripeCustomerId(
+  input: StripeCustomerInput
+): Promise<string> {
+  // Lazy-load `@/lib/db` so merely importing this file does not trigger
+  // env validation — the pure mapper unit tests import the status mapper
+  // without any environment variables set.
+  const { db } = await import('@/lib/db')
+  const env = getServerEnv()
+
+  if (env.paymentProvider === 'mock') {
+    const mockId = `cus_mock_${input.userId}`
+    // Persist it so the buyer subscriptions rows (and later webhook
+    // lookups) can join against a single id.
+    await db.user.update({
+      where: { id: input.userId },
+      data: { stripeCustomerId: mockId },
+    }).catch(() => {
+      // Ignore races — another concurrent subscribe may have set it.
+    })
+    return mockId
+  }
+
+  const existing = await db.user.findUnique({
+    where: { id: input.userId },
+    select: { stripeCustomerId: true },
+  })
+  if (existing?.stripeCustomerId) return existing.stripeCustomerId
+
+  const Stripe = (await import('stripe')).default
+  const stripe = new Stripe(env.stripeSecretKey!)
+  const customer = await stripe.customers.create({
+    email: input.email,
+    name: input.name,
+    metadata: { marketplaceUserId: input.userId },
+  })
+
+  await db.user.update({
+    where: { id: input.userId },
+    data: { stripeCustomerId: customer.id },
+  })
+  return customer.id
+}
+
+export interface SubscriptionCheckoutInput {
+  customerId: string
+  stripePriceId: string
+  successUrl: string
+  cancelUrl: string
+  metadata: {
+    marketplacePlanId: string
+    marketplaceBuyerId: string
+    marketplaceShippingAddressId: string
+  }
+}
+
+export interface SubscriptionCheckoutSession {
+  id: string
+  url: string
+}
+
+/**
+ * Creates a Stripe Checkout Session in subscription mode for a single
+ * recurring line item. Mock mode returns a synthetic session + a local
+ * URL the client can redirect to for a simulated success — tests read
+ * the metadata back from that URL to assert the flow. Stripe mode
+ * delegates to `stripe.checkout.sessions.create`.
+ */
+export async function createSubscriptionCheckoutSession(
+  input: SubscriptionCheckoutInput
+): Promise<SubscriptionCheckoutSession> {
+  const env = getServerEnv()
+
+  if (env.paymentProvider === 'mock') {
+    const id = `cs_mock_${Date.now()}_${input.metadata.marketplacePlanId}`
+    // Mock checkout success URL — the buyer flow redirects here in dev
+    // mode, and a dedicated mock-confirmation route (phase 4b-β follow-up)
+    // can pick up the metadata. For phase 4b-β the URL is informational.
+    const url = `${input.successUrl}?mock_session=${id}&planId=${input.metadata.marketplacePlanId}`
+    return { id, url }
+  }
+
+  const Stripe = (await import('stripe')).default
+  const stripe = new Stripe(env.stripeSecretKey!)
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    customer: input.customerId,
+    line_items: [{ price: input.stripePriceId, quantity: 1 }],
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    subscription_data: {
+      metadata: input.metadata,
+    },
+    metadata: input.metadata,
+  })
+
+  if (!session.url) {
+    throw new Error('Stripe devolvió una sesión de checkout sin URL')
+  }
+  return { id: session.id, url: session.url }
+}
+
+// ─── Webhook event shapes ─────────────────────────────────────────────────────
+
 export interface StripeSubscriptionEventPayload {
   id: string
   status: string
   pause_collection?: unknown
   cancel_at?: number | null
   canceled_at?: number | null
+  customer?: string | null
+  metadata?: Record<string, string> | null
+  items?: { data: Array<{ price: { id: string } }> }
+}
+
+export interface StripeInvoiceEventPayload {
+  id: string
+  subscription: string | null
+  amount_paid: number
+  currency: string
+  lines?: { data: Array<{ price?: { id: string } | null }> }
+}
+
+/**
+ * Parses the `data.object` of a Stripe `invoice.*` event into a narrower
+ * shape so the webhook handler can materialize an Order without trusting
+ * the raw payload.
+ */
+export function parseStripeInvoiceEvent(
+  obj: unknown
+): StripeInvoiceEventPayload | null {
+  if (!obj || typeof obj !== 'object') return null
+  const o = obj as Record<string, unknown>
+  if (typeof o.id !== 'string' || !o.id.startsWith('in_')) return null
+  const subscription =
+    typeof o.subscription === 'string' ? o.subscription : null
+  const amount = typeof o.amount_paid === 'number' ? o.amount_paid : 0
+  const currency = typeof o.currency === 'string' ? o.currency : 'eur'
+  return {
+    id: o.id,
+    subscription,
+    amount_paid: amount,
+    currency,
+  }
 }
 
 /**
@@ -172,11 +324,19 @@ export function parseStripeSubscriptionEvent(
   const o = obj as Record<string, unknown>
   if (typeof o.id !== 'string' || !o.id.startsWith('sub_')) return null
   if (typeof o.status !== 'string') return null
+  const metadata =
+    o.metadata && typeof o.metadata === 'object'
+      ? (o.metadata as Record<string, string>)
+      : null
+  const customer =
+    typeof o.customer === 'string' ? o.customer : null
   return {
     id: o.id,
     status: o.status,
     pause_collection: o.pause_collection,
     cancel_at: typeof o.cancel_at === 'number' ? o.cancel_at : null,
     canceled_at: typeof o.canceled_at === 'number' ? o.canceled_at : null,
+    customer,
+    metadata,
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -815,6 +815,14 @@ const en: Record<TranslationKeys, string> = {
   'account.subscriptions.resume': 'Resume',
   'account.subscriptions.cancel': 'Cancel',
   'account.subscriptions.errorGeneric': 'The operation could not be completed',
+
+  // Catalog – subscribe CTA (phase 4b-β)
+  'catalog.subscribe.title': 'Receive it on a recurring basis',
+  'catalog.subscribe.body': 'Subscribe to this product and get a {cadence} delivery at {price} / {unit}. You can skip, pause or cancel any time.',
+  'catalog.subscribe.cta': 'Subscribe to the box',
+  'catalog.subscribe.loading': 'Redirecting to checkout…',
+  'catalog.subscribe.needsAddress': 'Add a shipping address to your account before subscribing.',
+  'catalog.subscribe.errorGeneric': 'Could not start the subscription. Please try again in a few seconds.',
   'account.comingSoon': 'Coming soon',
   'account.gdpr.title': 'Privacy and Data',
   'account.gdpr.desc': 'In accordance with GDPR, you have the right to access, export or delete your personal data.',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -813,6 +813,14 @@ const es = {
   'account.subscriptions.resume': 'Reanudar',
   'account.subscriptions.cancel': 'Cancelar',
   'account.subscriptions.errorGeneric': 'No se ha podido completar la operación',
+
+  // Catalog – subscribe CTA (phase 4b-β)
+  'catalog.subscribe.title': 'Recíbelo de forma recurrente',
+  'catalog.subscribe.body': 'Suscríbete a este producto y recibe una entrega {cadence} a {price} / {unit}. Puedes saltarte entregas, pausar o cancelar cuando quieras.',
+  'catalog.subscribe.cta': 'Suscribirme a la caja',
+  'catalog.subscribe.loading': 'Redirigiendo al pago…',
+  'catalog.subscribe.needsAddress': 'Añade una dirección de envío en tu cuenta antes de suscribirte.',
+  'catalog.subscribe.errorGeneric': 'No se ha podido iniciar la suscripción. Inténtalo de nuevo en unos segundos.',
   'account.comingSoon': 'Próximamente',
   'account.gdpr.title': 'Privacidad y Datos',
   'account.gdpr.desc': 'De conformidad con el RGPD, tienes derecho a acceder, exportar o eliminar tus datos personales.',

--- a/test/integration/subscriptions-checkout-flow.test.ts
+++ b/test/integration/subscriptions-checkout-flow.test.ts
@@ -1,0 +1,317 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { POST } from '@/app/api/webhooks/stripe/route'
+import { createSubscriptionPlan } from '@/domains/subscriptions/actions'
+import { startSubscriptionCheckout } from '@/domains/subscriptions/buyer-actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Phase 4b-β end-to-end (mock-mode) coverage of the subscribe flow:
+ *   1. buyer starts a Stripe Checkout Session (mock returns a deterministic URL),
+ *   2. Stripe fires customer.subscription.created → local Subscription row is upserted,
+ *   3. Stripe fires invoice.paid → Order + OrderLine + VendorFulfillment + Payment
+ *      are materialized and the subscription's next delivery advances.
+ *
+ * Real Stripe calls are never made — the adapter detects PAYMENT_PROVIDER=mock
+ * and returns synthetic IDs, so the tests can exercise every branch of the
+ * webhook handler without mocking out the SDK.
+ */
+
+const ADDRESS_INPUT = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  line1: 'Calle Mayor 1',
+  city: 'Madrid',
+  province: 'Madrid',
+  postalCode: '28001',
+  country: 'ES',
+}
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  process.env.SUBSCRIPTIONS_BUYER_BETA = 'true'
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  delete process.env.SUBSCRIPTIONS_BUYER_BETA
+  resetServerEnvCache()
+})
+
+async function setupPlanAndBuyer() {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 24, taxRate: 0.1 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: { userId: buyer.id, ...ADDRESS_INPUT },
+  })
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  return { plan, vendor, product, buyer, address }
+}
+
+function subscriptionEventBody(id: string, sub: {
+  id: string
+  status: string
+  planId: string
+  buyerId: string
+  shippingAddressId: string
+}) {
+  return JSON.stringify({
+    id,
+    type: 'customer.subscription.created',
+    data: {
+      object: {
+        id: sub.id,
+        status: sub.status,
+        customer: `cus_mock_${sub.buyerId}`,
+        metadata: {
+          marketplacePlanId: sub.planId,
+          marketplaceBuyerId: sub.buyerId,
+          marketplaceShippingAddressId: sub.shippingAddressId,
+        },
+      },
+    },
+  })
+}
+
+function invoiceEventBody(
+  id: string,
+  type: 'invoice.paid' | 'invoice.payment_failed',
+  invoice: { id: string; subscription: string; amount_paid: number }
+) {
+  return JSON.stringify({
+    id,
+    type,
+    data: {
+      object: {
+        id: invoice.id,
+        subscription: invoice.subscription,
+        amount_paid: invoice.amount_paid,
+        currency: 'eur',
+      },
+    },
+  })
+}
+
+test('startSubscriptionCheckout returns a mock Checkout Session URL and persists the Stripe Customer id', async () => {
+  const { plan, address, buyer } = await setupPlanAndBuyer()
+
+  const result = await startSubscriptionCheckout({
+    planId: plan.id,
+    shippingAddressId: address.id,
+  })
+  assert.ok(result.url.includes('/cuenta/suscripciones'))
+  assert.ok(result.url.includes(plan.id))
+
+  const refreshed = await db.user.findUnique({ where: { id: buyer.id } })
+  assert.equal(refreshed?.stripeCustomerId, `cus_mock_${buyer.id}`)
+})
+
+test('startSubscriptionCheckout refuses when the beta flag is off', async () => {
+  process.env.SUBSCRIPTIONS_BUYER_BETA = 'false'
+  resetServerEnvCache()
+  const { plan, address } = await setupPlanAndBuyer()
+
+  await assert.rejects(
+    () =>
+      startSubscriptionCheckout({
+        planId: plan.id,
+        shippingAddressId: address.id,
+      }),
+    /no están disponibles/i
+  )
+})
+
+test('customer.subscription.created webhook creates the local Subscription row from the metadata', async () => {
+  const { plan, buyer, address } = await setupPlanAndBuyer()
+
+  // No Subscription exists yet
+  assert.equal(await db.subscription.count(), 0)
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: subscriptionEventBody('evt_sub_created_1', {
+        id: 'sub_test_created',
+        status: 'active',
+        planId: plan.id,
+        buyerId: buyer.id,
+        shippingAddressId: address.id,
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const created = await db.subscription.findFirst({
+    where: { buyerId: buyer.id, planId: plan.id },
+  })
+  assert.ok(created)
+  assert.equal(created?.stripeSubscriptionId, 'sub_test_created')
+  assert.equal(created?.status, 'ACTIVE')
+  assert.equal(created?.shippingAddressId, address.id)
+})
+
+test('customer.subscription.created is idempotent on replay', async () => {
+  const { plan, buyer, address } = await setupPlanAndBuyer()
+
+  for (const evtId of ['evt_sub_created_1', 'evt_sub_created_1']) {
+    const response = await POST(
+      new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: subscriptionEventBody(evtId, {
+          id: 'sub_test_idempotent',
+          status: 'active',
+          planId: plan.id,
+          buyerId: buyer.id,
+          shippingAddressId: address.id,
+        }),
+      }) as any
+    )
+    assert.equal(response.status, 200)
+  }
+  assert.equal(await db.subscription.count(), 1)
+})
+
+test('invoice.paid webhook materializes an Order + OrderLine + VendorFulfillment + Payment', async () => {
+  const { plan, vendor, buyer, address } = await setupPlanAndBuyer()
+
+  // Pre-create the local Subscription row (normally done by the
+  // customer.subscription.created handler, which we tested separately).
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_invoice_paid',
+    },
+  })
+
+  const originalNextDelivery = new Date(sub.nextDeliveryAt)
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: invoiceEventBody('evt_invoice_paid_1', 'invoice.paid', {
+        id: 'in_test_paid',
+        subscription: 'sub_test_invoice_paid',
+        amount_paid: 2400,
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const orders = await db.order.findMany({
+    where: { customerId: buyer.id },
+    include: { lines: true, fulfillments: true, payments: true, events: true },
+  })
+  assert.equal(orders.length, 1)
+  const order = orders[0]
+  assert.equal(order.status, 'PAYMENT_CONFIRMED')
+  assert.equal(order.paymentStatus, 'SUCCEEDED')
+  assert.equal(Number(order.subtotal), 24)
+  assert.equal(order.lines.length, 1)
+  assert.equal(order.lines[0].vendorId, vendor.id)
+  assert.equal(order.fulfillments.length, 1)
+  assert.equal(order.fulfillments[0].vendorId, vendor.id)
+  assert.equal(order.payments.length, 1)
+  assert.equal(order.payments[0].providerRef, 'in_test_paid')
+  assert.equal(order.payments[0].status, 'SUCCEEDED')
+  assert.ok(order.events.some(e => e.type === 'SUBSCRIPTION_RENEWAL_CHARGED'))
+
+  // Subscription advanced to the next cycle
+  const updatedSub = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.ok(
+    updatedSub!.nextDeliveryAt.getTime() >
+      originalNextDelivery.getTime()
+  )
+})
+
+test('invoice.paid replay does not create a second Order for the same invoice id', async () => {
+  const { plan, buyer, address } = await setupPlanAndBuyer()
+  await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_replay',
+    },
+  })
+
+  for (const evtId of ['evt_paid_1', 'evt_paid_2']) {
+    const response = await POST(
+      new Request('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: invoiceEventBody(evtId, 'invoice.paid', {
+          id: 'in_test_replay',
+          subscription: 'sub_test_replay',
+          amount_paid: 2400,
+        }),
+      }) as any
+    )
+    assert.equal(response.status, 200)
+  }
+
+  const orderCount = await db.order.count({ where: { customerId: buyer.id } })
+  assert.equal(orderCount, 1)
+})
+
+test('invoice.payment_failed webhook marks the subscription PAST_DUE', async () => {
+  const { plan, buyer, address } = await setupPlanAndBuyer()
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId: 'sub_test_failed',
+    },
+  })
+
+  const response = await POST(
+    new Request('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: invoiceEventBody('evt_paid_failed', 'invoice.payment_failed', {
+        id: 'in_test_failed',
+        subscription: 'sub_test_failed',
+        amount_paid: 0,
+      }),
+    }) as any
+  )
+  assert.equal(response.status, 200)
+
+  const updated = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(updated?.status, 'PAST_DUE')
+})


### PR DESCRIPTION
## Summary
Phase 4b-β of the [promotions & subscriptions RFC](docs/rfcs/0001-promotions-and-subscriptions.md). Opens the buyer subscribe flow end-to-end: product-page CTA → Stripe Checkout → \`customer.subscription.created\` webhook creates the local row → \`invoice.paid\` webhook materializes \`Order + OrderLine + VendorFulfillment + Payment\` on every cycle. Still gated behind \`SUBSCRIPTIONS_BUYER_BETA=false\` so prod is untouched.

## Flow
1. Product detail page shows a Subscribe CTA when the vendor published a plan AND phase 4b-α already provisioned a \`stripePriceId\` AND the flag is on.
2. \`startSubscriptionCheckout({ planId, shippingAddressId })\` lazily creates a Stripe Customer (id persisted on \`User.stripeCustomerId\`), builds a Checkout Session in \`mode='subscription'\` with our metadata in \`subscription_data.metadata\`, returns the hosted URL.
3. Webhook \`customer.subscription.created\` upserts the local \`Subscription\` row from the metadata. Idempotent on replay.
4. Webhook \`invoice.paid\` calls \`materializeSubscriptionRenewal\`: creates \`Order\` (status \`PAYMENT_CONFIRMED\`) + one \`OrderLine\` + one \`VendorFulfillment\` (status \`PENDING\`) + \`Payment\` (status \`SUCCEEDED\`) + \`OrderEvent\` of type \`SUBSCRIPTION_RENEWAL_CHARGED\`. Advances \`subscription.nextDeliveryAt\` one cadence. **Idempotent** via \`Payment.providerRef = invoice.id\`.
5. Webhook \`invoice.payment_failed\` → \`subscription.status = PAST_DUE\`.

## What ships
- **Schema**: \`User.stripeCustomerId\` (nullable, unique). Handwritten migration.
- **Adapter**: [\`stripe-subscriptions.ts\`](src/domains/subscriptions/stripe-subscriptions.ts) gains \`ensureStripeCustomerId\`, \`createSubscriptionCheckoutSession\`, \`parseStripeInvoiceEvent\`. Mock mode returns deterministic ids / URLs; Stripe mode delegates to the SDK. Fix: moved the \`db\` import to lazy \`await import\` so importing the module for the pure mapper unit tests no longer triggers env validation.
- **Renewal helper**: [\`renewal.ts\`](src/domains/subscriptions/renewal.ts) — single transaction, idempotent via \`providerRef\`, snapshots vendor/product so a later product edit never leaks into a booked renewal.
- **Buyer action**: [\`startSubscriptionCheckout\`](src/domains/subscriptions/buyer-actions.ts) — beta-gated, validates ownership, returns a redirect URL.
- **Webhook handler**: three new cases (\`customer.subscription.created\`, \`invoice.paid\`, \`invoice.payment_failed\`) alongside the \`updated/deleted\` ones from 4b-α.
- **UI**: [\`SubscribeToBoxButton\`](src/components/catalog/SubscribeToBoxButton.tsx) client component + conditional mount in the product detail page. Handles loading, error, and the "no saved address" edge case.
- **i18n**: 6 new \`catalog.subscribe.*\` keys in both locales.

## Out of scope (phase 4b-γ / δ / 5)
- Translating local cancel / pause / skip into Stripe API calls
- Transactional emails (renewal confirm, payment failed, skip reminder)
- Admin dashboards

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **629 / 629** passing
- [x] \`npm run test:integration\` — **193 / 193** passing (7 new tests: checkout happy path + flag refusal, subscription.created upsert + idempotent replay, invoice.paid materialization + dedupe, invoice.payment_failed → PAST_DUE)
- [ ] Manual staging: \`PAYMENT_PROVIDER=stripe\`, valid test keys, flip \`SUBSCRIPTIONS_BUYER_BETA=true\`, create a plan, visit product page, click Subscribe → hit Stripe Checkout, enter card \`4242...\`, redirect back → \`Mis suscripciones\` shows ACTIVE row and \`Mis pedidos\` shows the renewal Order
- [ ] Manual staging: trigger \`stripe trigger invoice.payment_failed\` → row flips to PAST_DUE

🤖 Generated with [Claude Code](https://claude.com/claude-code)