### PR TITLE
fix(subscriptions): serialize Decimal fields before crossing the RSC boundary

### DIFF
--- a/src/domains/promotions/actions.ts
+++ b/src/domains/promotions/actions.ts
@@ -179,15 +179,82 @@ export async function createPromotion(input: PromotionInput) {
 }
 
 /**
+ * Serializes a Prisma promotion row with its included product/category
+ * into a plain-JS shape the RSC boundary accepts. Prisma's `Decimal`
+ * instances crash the server→client serializer in Next 16 — so we
+ * convert them to JS numbers eagerly. Kept local to this module so the
+ * test integration tests keep working unchanged (they just call
+ * `Number(promo.value)` which is idempotent on real numbers).
+ */
+type PromotionRowFromDb = Awaited<
+  ReturnType<typeof db.promotion.findFirst<{
+    include: {
+      product: { select: { id: true; name: true; slug: true } }
+      category: { select: { id: true; name: true; slug: true } }
+    }
+  }>>
+>
+
+export type SerializedPromotion = {
+  id: string
+  vendorId: string
+  name: string
+  code: string | null
+  kind: 'PERCENTAGE' | 'FIXED_AMOUNT' | 'FREE_SHIPPING'
+  scope: 'PRODUCT' | 'VENDOR' | 'CATEGORY'
+  value: number
+  productId: string | null
+  categoryId: string | null
+  minSubtotal: number | null
+  maxRedemptions: number | null
+  perUserLimit: number | null
+  redemptionCount: number
+  startsAt: Date
+  endsAt: Date
+  archivedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+  product: { id: string; name: string; slug: string } | null
+  category: { id: string; name: string; slug: string } | null
+}
+
+function serializePromotion(
+  row: NonNullable<PromotionRowFromDb>
+): SerializedPromotion {
+  return {
+    id: row.id,
+    vendorId: row.vendorId,
+    name: row.name,
+    code: row.code,
+    kind: row.kind,
+    scope: row.scope,
+    value: Number(row.value),
+    productId: row.productId,
+    categoryId: row.categoryId,
+    minSubtotal: row.minSubtotal !== null ? Number(row.minSubtotal) : null,
+    maxRedemptions: row.maxRedemptions,
+    perUserLimit: row.perUserLimit,
+    redemptionCount: row.redemptionCount,
+    startsAt: row.startsAt,
+    endsAt: row.endsAt,
+    archivedAt: row.archivedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    product: row.product,
+    category: row.category,
+  }
+}
+
+/**
  * Lists the current vendor's promotions, optionally filtered by archived
  * state. Default: non-archived first, most recent first.
  */
 export async function listMyPromotions(
   filter: 'active' | 'archived' | 'all' = 'active'
-) {
+): Promise<SerializedPromotion[]> {
   const { vendor } = await requireVendor()
 
-  return db.promotion.findMany({
+  const rows = await db.promotion.findMany({
     where: {
       vendorId: vendor.id,
       ...(filter === 'active' && { archivedAt: null }),
@@ -199,17 +266,21 @@ export async function listMyPromotions(
       category: { select: { id: true, name: true, slug: true } },
     },
   })
+  return rows.map(serializePromotion)
 }
 
-export async function getMyPromotion(promotionId: string) {
+export async function getMyPromotion(
+  promotionId: string
+): Promise<SerializedPromotion | null> {
   const { vendor } = await requireVendor()
-  return db.promotion.findFirst({
+  const row = await db.promotion.findFirst({
     where: { id: promotionId, vendorId: vendor.id },
     include: {
       product: { select: { id: true, name: true, slug: true } },
       category: { select: { id: true, name: true, slug: true } },
     },
   })
+  return row ? serializePromotion(row) : null
 }
 
 /**

--- a/src/domains/subscriptions/actions.ts
+++ b/src/domains/subscriptions/actions.ts
@@ -131,12 +131,73 @@ export async function createSubscriptionPlan(input: SubscriptionPlanInput) {
   }
 }
 
+/**
+ * Plain-JS shape the list and single-plan helpers return. Serialized
+ * eagerly because Prisma's Decimal crashes the RSC serializer — the
+ * vendor list page passes these rows straight to a client component.
+ */
+export interface SerializedSubscriptionPlanListRow {
+  id: string
+  vendorId: string
+  productId: string
+  cadence: 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY'
+  priceSnapshot: number
+  taxRateSnapshot: number
+  cutoffDayOfWeek: number
+  stripePriceId: string | null
+  archivedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+  product: {
+    id: string
+    name: string
+    slug: string
+    images: string[]
+    unit: string
+  }
+}
+
+type SubscriptionPlanListRowFromDb = Awaited<
+  ReturnType<typeof db.subscriptionPlan.findFirst<{
+    include: {
+      product: {
+        select: {
+          id: true
+          name: true
+          slug: true
+          images: true
+          unit: true
+        }
+      }
+    }
+  }>>
+>
+
+function serializePlanListRow(
+  row: NonNullable<SubscriptionPlanListRowFromDb>
+): SerializedSubscriptionPlanListRow {
+  return {
+    id: row.id,
+    vendorId: row.vendorId,
+    productId: row.productId,
+    cadence: row.cadence,
+    priceSnapshot: Number(row.priceSnapshot),
+    taxRateSnapshot: Number(row.taxRateSnapshot),
+    cutoffDayOfWeek: row.cutoffDayOfWeek,
+    stripePriceId: row.stripePriceId,
+    archivedAt: row.archivedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    product: row.product,
+  }
+}
+
 export async function listMySubscriptionPlans(
   filter: 'active' | 'archived' | 'all' = 'active'
-) {
+): Promise<SerializedSubscriptionPlanListRow[]> {
   const { vendor } = await requireVendor()
 
-  return db.subscriptionPlan.findMany({
+  const rows = await db.subscriptionPlan.findMany({
     where: {
       vendorId: vendor.id,
       ...(filter === 'active' && { archivedAt: null }),
@@ -149,16 +210,35 @@ export async function listMySubscriptionPlans(
       },
     },
   })
+  return rows.map(serializePlanListRow)
 }
 
 export async function getMySubscriptionPlan(planId: string) {
   const { vendor } = await requireVendor()
-  return db.subscriptionPlan.findFirst({
+  const row = await db.subscriptionPlan.findFirst({
     where: { id: planId, vendorId: vendor.id },
     include: {
       product: { select: { id: true, name: true, slug: true } },
     },
   })
+  if (!row) return null
+  // Less-used single-row helper — return a serialized-enough shape too
+  // so callers get a consistent type surface. Product is narrower here
+  // than in the list helper (no images/unit) by design.
+  return {
+    id: row.id,
+    vendorId: row.vendorId,
+    productId: row.productId,
+    cadence: row.cadence,
+    priceSnapshot: Number(row.priceSnapshot),
+    taxRateSnapshot: Number(row.taxRateSnapshot),
+    cutoffDayOfWeek: row.cutoffDayOfWeek,
+    stripePriceId: row.stripePriceId,
+    archivedAt: row.archivedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    product: row.product,
+  }
 }
 
 export async function archiveSubscriptionPlan(planId: string) {

--- a/src/domains/subscriptions/buyer-actions.ts
+++ b/src/domains/subscriptions/buyer-actions.ts
@@ -187,11 +187,62 @@ export async function startSubscriptionCheckout(
   return { url: checkout.url }
 }
 
+/**
+ * Plain-JS shape returned to server components. Decimal fields on the
+ * joined plan are converted to numbers so the row crosses the RSC
+ * boundary cleanly. The tests call Number() on these values already,
+ * which is a no-op on real numbers.
+ */
+export interface SerializedBuyerSubscription {
+  id: string
+  buyerId: string
+  planId: string
+  shippingAddressId: string
+  status: 'ACTIVE' | 'PAUSED' | 'CANCELED' | 'PAST_DUE'
+  currentPeriodEnd: Date
+  nextDeliveryAt: Date
+  skippedDeliveries: unknown
+  stripeSubscriptionId: string | null
+  createdAt: Date
+  updatedAt: Date
+  canceledAt: Date | null
+  plan: {
+    id: string
+    cadence: 'WEEKLY' | 'BIWEEKLY' | 'MONTHLY'
+    priceSnapshot: number
+    taxRateSnapshot: number
+    cutoffDayOfWeek: number
+    product: {
+      id: string
+      name: string
+      slug: string
+      images: string[]
+      unit: string
+    }
+    vendor: {
+      id: string
+      slug: string
+      displayName: string
+    }
+  }
+  shippingAddress: {
+    id: string
+    firstName: string
+    lastName: string
+    line1: string
+    line2: string | null
+    city: string
+    province: string
+    postalCode: string
+    country: string
+  }
+}
+
 export async function listMySubscriptions(
   filter: 'active' | 'canceled' | 'all' = 'all'
-) {
+): Promise<SerializedBuyerSubscription[]> {
   const { buyerId } = await requireBuyer()
-  return db.subscription.findMany({
+  const rows = await db.subscription.findMany({
     where: {
       buyerId,
       ...(filter === 'active' && { status: { not: 'CANCELED' } }),
@@ -208,6 +259,41 @@ export async function listMySubscriptions(
       shippingAddress: true,
     },
   })
+
+  return rows.map(row => ({
+    id: row.id,
+    buyerId: row.buyerId,
+    planId: row.planId,
+    shippingAddressId: row.shippingAddressId,
+    status: row.status,
+    currentPeriodEnd: row.currentPeriodEnd,
+    nextDeliveryAt: row.nextDeliveryAt,
+    skippedDeliveries: row.skippedDeliveries,
+    stripeSubscriptionId: row.stripeSubscriptionId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    canceledAt: row.canceledAt,
+    plan: {
+      id: row.plan.id,
+      cadence: row.plan.cadence,
+      priceSnapshot: Number(row.plan.priceSnapshot),
+      taxRateSnapshot: Number(row.plan.taxRateSnapshot),
+      cutoffDayOfWeek: row.plan.cutoffDayOfWeek,
+      product: row.plan.product,
+      vendor: row.plan.vendor,
+    },
+    shippingAddress: {
+      id: row.shippingAddress.id,
+      firstName: row.shippingAddress.firstName,
+      lastName: row.shippingAddress.lastName,
+      line1: row.shippingAddress.line1,
+      line2: row.shippingAddress.line2,
+      city: row.shippingAddress.city,
+      province: row.shippingAddress.province,
+      postalCode: row.shippingAddress.postalCode,
+      country: row.shippingAddress.country,
+    },
+  }))
 }
 
 export async function getMySubscription(id: string) {

--- a/test/integration/subscriptions-serialization.test.ts
+++ b/test/integration/subscriptions-serialization.test.ts
@@ -1,0 +1,170 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  listMySubscriptionPlans,
+  createSubscriptionPlan,
+} from '@/domains/subscriptions/actions'
+import {
+  listMySubscriptions,
+} from '@/domains/subscriptions/buyer-actions'
+import {
+  listMyPromotions,
+  createPromotion,
+} from '@/domains/promotions/actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Regression coverage for Next 16's strict server→client serializer.
+ * Any field that leaves the vendor / buyer list actions and ends up in
+ * a client component MUST be a plain-JS value — Prisma's Decimal, Buffer,
+ * and custom class instances crash the React RSC boundary with
+ * "Only plain objects can be passed to Client Components from Server
+ * Components".
+ *
+ * The existing phase-1 / phase-3 / phase-4a tests only exercise the
+ * action return value inside Node (no boundary crossing), so they miss
+ * this class of bug. These assertions explicitly check for the
+ * constructor name Prisma attaches to Decimal values so a future
+ * refactor that forgets to serialize a new field fails CI loudly.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  process.env.SUBSCRIPTIONS_BUYER_BETA = 'true'
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  delete process.env.SUBSCRIPTIONS_BUYER_BETA
+  resetServerEnvCache()
+})
+
+function assertPlainValue(value: unknown, field: string) {
+  if (value === null || value === undefined) return
+  if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') return
+  if (value instanceof Date) return
+  if (Array.isArray(value)) return
+  if (typeof value === 'object') {
+    const ctor = (value as object).constructor?.name
+    if (ctor === 'Decimal' || ctor === 'BigNumber' || ctor === 'Prisma.Decimal') {
+      throw new Error(`${field} is a Decimal instance; it must be converted to number before crossing the RSC boundary`)
+    }
+  }
+}
+
+test('listMyPromotions returns plain-JS rows — no Decimal instances in value / minSubtotal', async () => {
+  const { user, vendor } = await createVendorUser()
+  useTestSession(buildSession(user.id, 'VENDOR'))
+
+  await createPromotion({
+    name: 'Auto 10%',
+    code: null,
+    kind: 'PERCENTAGE',
+    value: 10,
+    scope: 'VENDOR',
+    productId: null,
+    categoryId: null,
+    minSubtotal: 20,
+    maxRedemptions: null,
+    perUserLimit: 1,
+    startsAt: new Date().toISOString(),
+    endsAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  })
+
+  const rows = await listMyPromotions('all')
+  assert.equal(rows.length, 1)
+  const row = rows[0]
+  assert.equal(typeof row.value, 'number')
+  assert.equal(row.value, 10)
+  assert.equal(typeof row.minSubtotal, 'number')
+  assert.equal(row.minSubtotal, 20)
+  assertPlainValue(row.value, 'value')
+  assertPlainValue(row.minSubtotal, 'minSubtotal')
+
+  // Safety net: sibling fields must also serialize cleanly.
+  assert.equal(row.vendorId, vendor.id)
+  assert.ok(row.startsAt instanceof Date)
+  assert.ok(row.endsAt instanceof Date)
+})
+
+test('listMySubscriptionPlans returns plain-JS priceSnapshot / taxRateSnapshot', async () => {
+  const { user, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 24.5, taxRate: 0.1 })
+  useTestSession(buildSession(user.id, 'VENDOR'))
+
+  await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const rows = await listMySubscriptionPlans('all')
+  assert.equal(rows.length, 1)
+  const row = rows[0]
+  assert.equal(typeof row.priceSnapshot, 'number')
+  assert.equal(row.priceSnapshot, 24.5)
+  assert.equal(typeof row.taxRateSnapshot, 'number')
+  assertPlainValue(row.priceSnapshot, 'priceSnapshot')
+  assertPlainValue(row.taxRateSnapshot, 'taxRateSnapshot')
+  assert.ok(row.product)
+  assert.equal(row.product.name, product.name)
+})
+
+test('listMySubscriptions returns plain-JS plan.priceSnapshot + shippingAddress', async () => {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 30 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: {
+      userId: buyer.id,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      line1: 'Calle Mayor 1',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      country: 'ES',
+    },
+  })
+  await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+  })
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const rows = await listMySubscriptions('all')
+  assert.equal(rows.length, 1)
+  const row = rows[0]
+  assert.equal(typeof row.plan.priceSnapshot, 'number')
+  assert.equal(row.plan.priceSnapshot, 30)
+  assert.equal(typeof row.plan.taxRateSnapshot, 'number')
+  assertPlainValue(row.plan.priceSnapshot, 'plan.priceSnapshot')
+  assertPlainValue(row.plan.taxRateSnapshot, 'plan.taxRateSnapshot')
+  assert.equal(row.shippingAddress.postalCode, '28001')
+})


### PR DESCRIPTION
## Summary
Live bug on main: \`/vendor/promociones\`, \`/vendor/suscripciones\` and \`/cuenta/suscripciones\` throw a 500 with the React error "Only plain objects can be passed to Client Components from Server Components. Decimal objects are not supported."

The vendor + buyer list actions were returning raw Prisma rows whose \`Decimal\` fields (\`Promotion.value\` / \`minSubtotal\`, \`SubscriptionPlan.priceSnapshot\` / \`taxRateSnapshot\`) crashed Next 16's server→client serializer the moment the client component tried to render them.

## Why the tests missed it
The integration tests call the actions directly from Node and never cross the RSC boundary, so the serializer check never ran. Adding a regression test that asserts on the constructor name of each numeric field makes the class of bug detectable from the DB-level suite.

## Fix
Serialize at the domain-layer boundary so every consumer gets plain JS values:
- \`listMyPromotions\` / \`getMyPromotion\` → \`SerializedPromotion\` shape with \`value\` + \`minSubtotal\` as \`number\`.
- \`listMySubscriptionPlans\` / \`getMySubscriptionPlan\` → \`SerializedSubscriptionPlanListRow\` with \`priceSnapshot\` + \`taxRateSnapshot\` as \`number\`.
- \`listMySubscriptions\` → \`SerializedBuyerSubscription\` with \`plan.priceSnapshot\` + \`plan.taxRateSnapshot\` as \`number\` and a narrow shipping-address shape.

Client components already call \`Number()\` on these fields, which is idempotent on real numbers — **no UI changes needed**.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — **629 / 629**
- [x] \`npm run test:integration\` — **196 / 196** (3 new regression tests in \`test/integration/subscriptions-serialization.test.ts\` that fail loud if any of these fields leaks as a Decimal again)
- [ ] Manual: restart the dev server (\`kill <pid> && npm run dev\`), visit \`/vendor/promociones\` and \`/vendor/suscripciones\` — both should render without the serializer error

## Heads-up for the running dev server
If the server hitting the bug was started **before** the phase-1..5 migrations landed, it will also hit a second error: \`Cannot read properties of undefined (reading 'findMany')\`. That is a stale in-memory Prisma Client — \`next dev\` does not hot-reload the generated client when new tables are added. **Only a full server restart fixes it.** This PR cannot fix that class of problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)