### PR TITLE
fix(panels): align sidebar header to h-14 and center collapsed content

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -7,7 +7,7 @@ import {
   ScaleIcon, Cog6ToothIcon, ClipboardDocumentListIcon,
   CurrencyEuroIcon, ExclamationTriangleIcon, ChartBarIcon,
   ArrowTopRightOnSquareIcon, TagIcon, ArrowPathIcon,
-  ChevronDoubleLeftIcon, ChevronDoubleRightIcon, XMarkIcon,
+  ChevronDoubleLeftIcon, XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import { adminNavItems } from '@/lib/navigation'
@@ -29,42 +29,63 @@ const NAV_META = {
   '/admin/informes':      ChartBarIcon,
 } as const
 
+const SIDEBAR_EASE = 'cubic-bezier(0.25, 0.1, 0.25, 1)'
+const SIDEBAR_DURATION_MS = 320
+
 export function AdminSidebar() {
   const pathname = usePathname()
   const { collapsed, toggleCollapsed, mobileOpen, closeMobile } = useSidebar()
 
+  const labelCls = cn(
+    'overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin] ease-out',
+    collapsed ? 'md:max-w-0 md:opacity-0 md:ml-0' : 'md:max-w-[12rem] md:opacity-100',
+  )
+  const labelStyle = { transitionDuration: `${SIDEBAR_DURATION_MS}ms` }
+  const asideStyle = {
+    transitionDuration: `${SIDEBAR_DURATION_MS}ms`,
+    transitionTimingFunction: SIDEBAR_EASE,
+    transitionProperty: 'width, transform',
+  }
+
   return (
     <>
-      {mobileOpen && (
-        <div
-          className="fixed inset-0 z-30 bg-black/40 md:hidden"
-          onClick={closeMobile}
-          aria-hidden="true"
-        />
-      )}
+      <div
+        className={cn(
+          'fixed inset-0 z-30 bg-black/40 md:hidden transition-opacity duration-300 ease-out',
+          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+        onClick={closeMobile}
+        aria-hidden="true"
+      />
 
       <aside
+        style={asideStyle}
         className={cn(
-          'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--border)] bg-[var(--surface)] transition-all duration-200 ease-out',
+          'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--border)] bg-[var(--surface)] will-change-[width,transform]',
           'w-56 md:static md:z-auto md:translate-x-0',
           collapsed ? 'md:w-16' : 'md:w-56',
           mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0',
         )}
         aria-label="Panel Admin"
       >
-        <div
-          className={cn(
-            'flex items-center justify-between border-b border-[var(--border)] py-4',
-            collapsed ? 'md:px-2' : 'px-4',
-          )}
-        >
-          <div className={cn('min-w-0', collapsed && 'md:hidden')}>
-            <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--muted)]">Panel Admin</p>
-            <p className="mt-1 font-bold text-[var(--foreground)] truncate">Mercado Productor</p>
+        <div className="relative flex h-14 shrink-0 items-center justify-between border-b border-[var(--border)] px-4">
+          <div
+            className={cn(
+              'min-w-0 flex-1 transition-opacity duration-300 ease-out',
+              collapsed && 'md:invisible md:opacity-0',
+            )}
+          >
+            <p className="text-[9px] font-semibold uppercase leading-none tracking-widest text-[var(--muted)]">Panel Admin</p>
+            <p className="mt-1 text-sm font-bold leading-none text-[var(--foreground)] truncate">Mercado Productor</p>
           </div>
           {collapsed && (
-            <div className="hidden md:flex w-full justify-center" aria-hidden="true">
-              <span className="text-lg font-bold text-[var(--foreground)]">MP</span>
+            <div
+              className="pointer-events-none hidden md:flex md:absolute md:inset-0 md:items-center md:justify-center"
+              aria-hidden="true"
+            >
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-600 text-white shadow-sm ring-1 ring-emerald-500/30 dark:bg-emerald-500 dark:text-gray-950 dark:ring-emerald-300/30">
+                <span className="text-[11px] font-bold">MP</span>
+              </div>
             </div>
           )}
           <button
@@ -89,16 +110,17 @@ export function AdminSidebar() {
                   key={href}
                   className={cn(
                     'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-[var(--muted)]',
-                    collapsed && 'md:justify-center md:px-2',
+                    collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
                   )}
                   title={collapsed ? `${label} (próximamente)` : undefined}
                 >
                   <Icon className="h-4 w-4 shrink-0" />
-                  <span className={cn('flex-1', collapsed && 'md:hidden')}>{label}</span>
+                  <span className={cn('flex-1', labelCls)} style={labelStyle}>{label}</span>
                   <span
+                    style={labelStyle}
                     className={cn(
-                      'rounded-full bg-[var(--surface-raised)] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--muted)]',
-                      collapsed && 'md:hidden',
+                      'rounded-full bg-[var(--surface-raised)] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--muted)] transition-opacity ease-out',
+                      collapsed && 'md:opacity-0 md:w-0 md:p-0 md:overflow-hidden',
                     )}
                   >
                     Soon
@@ -113,16 +135,17 @@ export function AdminSidebar() {
                 href={href}
                 title={collapsed ? label : undefined}
                 aria-label={label}
+                style={labelStyle}
                 className={cn(
-                  'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
-                  collapsed && 'md:justify-center md:px-2',
+                  'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-[background-color,color,width,height,padding,margin] ease-out',
+                  collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
                   isActive
                     ? 'bg-emerald-600 text-white shadow-sm ring-1 ring-emerald-500/30 dark:bg-emerald-500 dark:text-gray-950 dark:ring-emerald-300/30'
                     : 'text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]'
                 )}
               >
                 <Icon className="h-4 w-4 shrink-0" />
-                <span className={cn(collapsed && 'md:hidden')}>{label}</span>
+                <span className={labelCls} style={labelStyle}>{label}</span>
               </Link>
             )
           })}
@@ -134,31 +157,36 @@ export function AdminSidebar() {
             target="_blank"
             title={collapsed ? 'Ver tienda' : undefined}
             aria-label="Ver tienda"
+            style={labelStyle}
             className={cn(
-              'flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
-              collapsed && 'md:justify-center md:px-2',
+              'flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] transition-[width,height,padding,margin] ease-out hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
+              collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
             )}
           >
-            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-            <span className={cn(collapsed && 'md:hidden')}>Ver tienda</span>
+            <ArrowTopRightOnSquareIcon className="h-4 w-4 shrink-0" />
+            <span className={labelCls} style={labelStyle}>Ver tienda</span>
           </Link>
           <button
             type="button"
             onClick={toggleCollapsed}
+            style={labelStyle}
             className={cn(
-              'hidden md:flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
-              collapsed && 'md:justify-center md:px-2',
+              'hidden md:flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] transition-[width,height,padding,margin] ease-out hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
+              collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
             )}
             aria-label={collapsed ? 'Expandir menú' : 'Contraer menú'}
             aria-pressed={collapsed}
             title={collapsed ? 'Expandir menú' : 'Contraer menú'}
           >
-            {collapsed ? (
-              <ChevronDoubleRightIcon className="h-4 w-4" />
-            ) : (
+            <span
+              className={cn(
+                'flex h-4 w-4 shrink-0 items-center justify-center transition-transform duration-300 ease-out',
+                collapsed && 'rotate-180',
+              )}
+            >
               <ChevronDoubleLeftIcon className="h-4 w-4" />
-            )}
-            <span className={cn(collapsed && 'md:hidden')}>Contraer</span>
+            </span>
+            <span className={labelCls} style={labelStyle}>Contraer</span>
           </button>
         </div>
       </aside>

--- a/src/components/vendor/VendorSidebar.tsx
+++ b/src/components/vendor/VendorSidebar.tsx
@@ -6,7 +6,7 @@ import {
   HomeIcon, ArchiveBoxIcon, ShoppingBagIcon,
   CurrencyEuroIcon, UserCircleIcon, ArrowTopRightOnSquareIcon,
   StarIcon, TagIcon, ArrowPathIcon,
-  ChevronDoubleLeftIcon, ChevronDoubleRightIcon, XMarkIcon,
+  ChevronDoubleLeftIcon, XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import { vendorNavItems } from '@/lib/navigation'
@@ -28,6 +28,9 @@ interface Props {
   vendor?: { displayName: string; status: string; slug: string } | null
 }
 
+const SIDEBAR_EASE = 'cubic-bezier(0.25, 0.1, 0.25, 1)'
+const SIDEBAR_DURATION_MS = 320
+
 export function VendorSidebar({ vendor }: Props) {
   const pathname = usePathname()
   const t = useT()
@@ -36,53 +39,77 @@ export function VendorSidebar({ vendor }: Props) {
   const collapseLabel = collapsed ? t('vendor.sidebar.expand') : t('vendor.sidebar.collapse')
   const closeMenuLabel = t('vendor.sidebar.closeMenu')
 
+  const labelCls = cn(
+    'overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin] ease-out',
+    collapsed ? 'md:max-w-0 md:opacity-0 md:ml-0' : 'md:max-w-[12rem] md:opacity-100',
+  )
+  const labelStyle = { transitionDuration: `${SIDEBAR_DURATION_MS}ms` }
+  const asideStyle = {
+    transitionDuration: `${SIDEBAR_DURATION_MS}ms`,
+    transitionTimingFunction: SIDEBAR_EASE,
+    transitionProperty: 'width, transform',
+  }
+
   return (
     <>
-      {mobileOpen && (
-        <div
-          className="fixed inset-0 z-30 bg-black/40 md:hidden"
-          onClick={closeMobile}
-          aria-hidden="true"
-        />
-      )}
+      <div
+        className={cn(
+          'fixed inset-0 z-30 bg-black/40 md:hidden transition-opacity duration-300 ease-out',
+          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        )}
+        onClick={closeMobile}
+        aria-hidden="true"
+      />
 
       <aside
+        style={asideStyle}
         className={cn(
-          'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--border)] bg-[var(--surface)] transition-all duration-200 ease-out',
+          'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--border)] bg-[var(--surface)] will-change-[width,transform]',
           'w-56 md:static md:z-auto md:translate-x-0',
           collapsed ? 'md:w-16' : 'md:w-56',
           mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0',
         )}
         aria-label={t('vendor.sidebar.portalTitle')}
       >
-        <div
-          className={cn(
-            'flex items-start justify-between border-b border-[var(--border)] py-4',
-            collapsed ? 'md:px-2' : 'px-4',
-          )}
-        >
-          <div className={cn('min-w-0 flex-1', collapsed && 'md:hidden')}>
-            <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--muted)]">{t('vendor.sidebar.portalTitle')}</p>
-            <p className="mt-1 font-semibold text-[var(--foreground)] truncate">{vendor?.displayName ?? '…'}</p>
-            <div className="mt-1.5 flex items-center gap-1.5">
-              <span className={cn(
-                'h-2 w-2 rounded-full',
-                vendor?.status === 'ACTIVE' ? 'bg-emerald-500' : 'bg-amber-400'
-              )} />
-              <span className="text-xs text-[var(--muted)]">
-                {vendor?.status === 'ACTIVE' ? t('vendor.sidebar.statusActive') : t('vendor.sidebar.statusPending')}
-              </span>
+        <div className="relative flex h-14 shrink-0 items-center justify-between border-b border-[var(--border)] px-4">
+          <div
+            className={cn(
+              'min-w-0 flex-1 transition-opacity duration-300 ease-out',
+              collapsed && 'md:invisible md:opacity-0',
+            )}
+          >
+            <p className="text-[9px] font-semibold uppercase leading-none tracking-widest text-[var(--muted)]">{t('vendor.sidebar.portalTitle')}</p>
+            <div className="mt-1 flex items-center gap-1.5">
+              <span
+                className={cn(
+                  'h-1.5 w-1.5 shrink-0 rounded-full',
+                  vendor?.status === 'ACTIVE' ? 'bg-emerald-500' : 'bg-amber-400'
+                )}
+                aria-label={vendor?.status === 'ACTIVE' ? t('vendor.sidebar.statusActive') : t('vendor.sidebar.statusPending')}
+                title={vendor?.status === 'ACTIVE' ? t('vendor.sidebar.statusActive') : t('vendor.sidebar.statusPending')}
+              />
+              <p className="text-sm font-semibold leading-none text-[var(--foreground)] truncate">{vendor?.displayName ?? '…'}</p>
             </div>
           </div>
           {collapsed && (
-            <div className="hidden md:flex w-full flex-col items-center gap-1" aria-hidden="true">
-              <span className={cn(
-                'h-2 w-2 rounded-full',
-                vendor?.status === 'ACTIVE' ? 'bg-emerald-500' : 'bg-amber-400'
-              )} />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-[var(--muted)]">
-                {vendor?.displayName?.slice(0, 2).toUpperCase() ?? '—'}
-              </span>
+            <div
+              className="pointer-events-none hidden md:flex md:absolute md:inset-0 md:items-center md:justify-center"
+              aria-hidden="true"
+            >
+              <div
+                className="relative flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-600 text-white shadow-sm ring-1 ring-emerald-500/30 dark:bg-emerald-500 dark:text-gray-950 dark:ring-emerald-300/30"
+                title={vendor?.displayName ?? undefined}
+              >
+                <span className="text-[11px] font-bold">
+                  {vendor?.displayName?.slice(0, 2).toUpperCase() ?? '—'}
+                </span>
+                <span
+                  className={cn(
+                    'absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full ring-2 ring-[var(--surface)]',
+                    vendor?.status === 'ACTIVE' ? 'bg-emerald-400' : 'bg-amber-400'
+                  )}
+                />
+              </div>
             </div>
           )}
           <button
@@ -108,16 +135,19 @@ export function VendorSidebar({ vendor }: Props) {
                   key={href}
                   className={cn(
                     'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-[var(--muted)]',
-                    collapsed && 'md:justify-center md:px-2',
+                    collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
                   )}
                   title={collapsed ? label : undefined}
                 >
                   <Icon className="h-4 w-4 shrink-0" />
-                  <span className={cn('flex-1', collapsed && 'md:hidden')}>{label}</span>
-                  <span className={cn(
-                    'rounded-full bg-[var(--surface-raised)] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--muted)]',
-                    collapsed && 'md:hidden',
-                  )}>
+                  <span className={cn('flex-1', labelCls)} style={labelStyle}>{label}</span>
+                  <span
+                    style={labelStyle}
+                    className={cn(
+                      'rounded-full bg-[var(--surface-raised)] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--muted)] transition-opacity ease-out',
+                      collapsed && 'md:opacity-0 md:w-0 md:p-0 md:overflow-hidden',
+                    )}
+                  >
                     {t('vendor.sidebar.soon')}
                   </span>
                 </div>
@@ -130,16 +160,17 @@ export function VendorSidebar({ vendor }: Props) {
                 href={href}
                 title={collapsed ? label : undefined}
                 aria-label={label}
+                style={labelStyle}
                 className={cn(
-                  'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all',
-                  collapsed && 'md:justify-center md:px-2',
+                  'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-[background-color,color,width,height,padding,margin] ease-out',
+                  collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
                   isActive
                     ? 'bg-emerald-600 text-white shadow-sm ring-1 ring-emerald-500/30 dark:bg-emerald-500 dark:text-gray-950 dark:ring-emerald-300/30'
                     : 'text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]'
                 )}
               >
                 <Icon className="h-4 w-4 shrink-0" />
-                <span className={cn(collapsed && 'md:hidden')}>{label}</span>
+                <span className={labelCls} style={labelStyle}>{label}</span>
               </Link>
             )
           })}
@@ -152,32 +183,37 @@ export function VendorSidebar({ vendor }: Props) {
               target="_blank"
               title={collapsed ? t('vendor.sidebar.viewStore') : undefined}
               aria-label={t('vendor.sidebar.viewStore')}
+              style={labelStyle}
               className={cn(
-                'flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
-                collapsed && 'md:justify-center md:px-2',
+                'flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] transition-[width,height,padding,margin] ease-out hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
+                collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
               )}
             >
-              <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-              <span className={cn(collapsed && 'md:hidden')}>{t('vendor.sidebar.viewStore')}</span>
+              <ArrowTopRightOnSquareIcon className="h-4 w-4 shrink-0" />
+              <span className={labelCls} style={labelStyle}>{t('vendor.sidebar.viewStore')}</span>
             </Link>
           )}
           <button
             type="button"
             onClick={toggleCollapsed}
+            style={labelStyle}
             className={cn(
-              'hidden md:flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
-              collapsed && 'md:justify-center md:px-2',
+              'hidden md:flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-[var(--muted)] transition-[width,height,padding,margin] ease-out hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
+              collapsed && 'md:h-10 md:justify-center md:gap-0 md:px-0 md:py-0',
             )}
             aria-label={collapseLabel}
             aria-pressed={collapsed}
             title={collapseLabel}
           >
-            {collapsed ? (
-              <ChevronDoubleRightIcon className="h-4 w-4" />
-            ) : (
+            <span
+              className={cn(
+                'flex h-4 w-4 shrink-0 items-center justify-center transition-transform duration-300 ease-out',
+                collapsed && 'rotate-180',
+              )}
+            >
               <ChevronDoubleLeftIcon className="h-4 w-4" />
-            )}
-            <span className={cn(collapsed && 'md:hidden')}>{collapseLabel}</span>
+            </span>
+            <span className={labelCls} style={labelStyle}>{collapseLabel}</span>
           </button>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- Sidebar header was taller than the adjacent main-panel header (~72px vs 56px), so the bottom borders didn't meet and nav items began at a different Y than the right panel's content.
- Compact both admin and vendor sidebar headers to \`h-14\` with \`leading-none\`, inline the vendor status dot with the producer name, and shrink the brand badge to 32×32.
- In collapsed mode, the expanded title block stays in the DOM as \`md:invisible\` so the header keeps its exact height; the badge is absolutely positioned over it via \`md:inset-0 md:items-center md:justify-center\` to land dead-center.

## Test plan
- [x] \`npm run typecheck:app\`
- [x] \`npm test\` — 635/635 including \`test/contracts/collapsible-sidebar.test.ts\`
- [ ] Manual smoke: toggle collapse on admin + vendor, verify nav icons start at the same Y as the main-panel header's bottom border in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)