### PR TITLE
fix(mobile): body scroll lock, safe-area insets, sticky CTAs, 44px tap targets

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -49,13 +49,14 @@ export default function RegisterPage() {
 
       <form onSubmit={handleSubmit} className="mt-6 space-y-4">
         <div className="grid grid-cols-2 gap-3">
-          <Input name="firstName" label="Nombre" placeholder="María" required />
-          <Input name="lastName" label="Apellidos" placeholder="García" required />
+          <Input name="firstName" autoComplete="given-name" label="Nombre" placeholder="María" required />
+          <Input name="lastName" autoComplete="family-name" label="Apellidos" placeholder="García" required />
         </div>
-        <Input name="email" type="email" label="Email" placeholder="tu@email.com" required />
+        <Input name="email" type="email" autoComplete="email" label="Email" placeholder="tu@email.com" required />
         <Input
           name="password"
           type="password"
+          autoComplete="new-password"
           label="Contraseña"
           placeholder="Mínimo 8 caracteres"
           minLength={8}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,14 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Safe-area insets for notch / home indicator on iOS (viewport-fit=cover). */
+@supports (padding: max(0px)) {
+  body {
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+}
+
 /* Subtle texture overlay in light mode */
 body::before {
   content: '';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,6 +55,7 @@ export const viewport: Viewport = {
     { media: '(prefers-color-scheme: dark)', color: THEME_COLORS.dark },
   ],
   colorScheme: 'light dark',
+  viewportFit: 'cover',
 }
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -22,7 +22,7 @@ export function AdminHeader({ user }: Props) {
         <button
           type="button"
           onClick={openMobile}
-          className="md:hidden rounded-lg p-1.5 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+          className="md:hidden inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2.5 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
           aria-label="Abrir menú"
           title="Abrir menú"
         >

--- a/src/components/admin/AdminProducersClient.tsx
+++ b/src/components/admin/AdminProducersClient.tsx
@@ -317,7 +317,7 @@ export function AdminProducersClient({ data }: Props) {
 
       {/* Table */}
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
           <table className="w-full min-w-[1100px] text-sm">
             <thead className="bg-[var(--background)] text-left text-xs font-medium uppercase tracking-wide text-[var(--muted-light)]">
               <tr>

--- a/src/components/admin/AdminPromotionsClient.tsx
+++ b/src/components/admin/AdminPromotionsClient.tsx
@@ -65,7 +65,7 @@ export function AdminPromotionsClient({ data }: Props) {
             {t('adminPromotions.empty')}
           </p>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
             <table className="min-w-full text-sm">
               <thead className="bg-[var(--surface-raised)] text-xs uppercase tracking-wider text-[var(--muted)]">
                 <tr>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -91,7 +91,7 @@ export function AdminSidebar() {
           <button
             type="button"
             onClick={closeMobile}
-            className="md:hidden rounded-lg p-1.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+            className="md:hidden inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
             aria-label="Cerrar menú"
             title="Cerrar menú"
           >

--- a/src/components/admin/AdminSubscriptionsClient.tsx
+++ b/src/components/admin/AdminSubscriptionsClient.tsx
@@ -79,7 +79,7 @@ export function AdminSubscriptionsClient({ data }: Props) {
             {t('adminSubscriptions.plansEmpty')}
           </p>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
             <table className="min-w-full text-sm">
               <thead className="bg-[var(--surface-raised)] text-xs uppercase tracking-wider text-[var(--muted)]">
                 <tr>
@@ -115,7 +115,7 @@ export function AdminSubscriptionsClient({ data }: Props) {
             {t('adminSubscriptions.subsEmpty')}
           </p>
         ) : (
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
             <table className="min-w-full text-sm">
               <thead className="bg-[var(--surface-raised)] text-xs uppercase tracking-wider text-[var(--muted)]">
                 <tr>

--- a/src/components/admin/analytics/OrdersTable.tsx
+++ b/src/components/admin/analytics/OrdersTable.tsx
@@ -120,7 +120,7 @@ export function OrdersTable({ rows }: Props) {
         </div>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
         <table className="w-full text-left text-sm">
           <thead className="text-xs uppercase tracking-wide text-[var(--muted-light)]">
             <tr className="border-b border-[var(--border)]">

--- a/src/components/buyer/CartPageClient.tsx
+++ b/src/components/buyer/CartPageClient.tsx
@@ -93,7 +93,7 @@ export function CartPageClient({ shippingSettings }: Props) {
   const total = sub + shipping
 
   return (
-    <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+    <div className="mx-auto max-w-5xl px-4 py-10 pb-28 sm:px-6 lg:px-8 lg:pb-10">
       <h1 className="mb-8 text-2xl font-bold text-[var(--foreground)]">{t('cart.title')} ({itemCount()})</h1>
 
       <div className="grid gap-8 lg:grid-cols-3">
@@ -298,6 +298,30 @@ export function CartPageClient({ shippingSettings }: Props) {
               {t('cart.continueShopping')}
             </Link>
           </div>
+        </div>
+      </div>
+
+      {/* Mobile sticky checkout bar — keeps the primary action one tap away
+          regardless of scroll position. Hidden on desktop where the summary
+          sidebar is already sticky. */}
+      <div
+        className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--border)] bg-[var(--surface)]/95 px-4 pt-3 shadow-[0_-8px_24px_-12px_rgba(0,0,0,0.25)] backdrop-blur lg:hidden"
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs text-[var(--muted)]">{t('cart.total')}</p>
+            <p className="truncate text-lg font-bold text-[var(--foreground)]">{formatPrice(total)}</p>
+          </div>
+          {hasBlockingIssues ? (
+            <Button size="md" disabled className="min-w-[10rem]">
+              {t('cart.toCheckout')}
+            </Button>
+          ) : (
+            <Link href="/checkout" className="shrink-0">
+              <Button size="md" className="min-w-[10rem]">{t('cart.toCheckout')}</Button>
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/buyer/CheckoutPageClient.tsx
+++ b/src/components/buyer/CheckoutPageClient.tsx
@@ -468,17 +468,18 @@ export function CheckoutPageClient({
                     </button>
                   )}
                   <div className="grid grid-cols-2 gap-3">
-                    <Input label={t('checkout.firstName')} error={errors.firstName?.message} {...register('firstName')} />
-                    <Input label={t('checkout.lastName')} error={errors.lastName?.message} {...register('lastName')} />
+                    <Input label={t('checkout.firstName')} autoComplete="given-name" error={errors.firstName?.message} {...register('firstName')} />
+                    <Input label={t('checkout.lastName')} autoComplete="family-name" error={errors.lastName?.message} {...register('lastName')} />
                   </div>
-                  <Input label={t('checkout.line1')} placeholder={t('checkout.line1Placeholder')} error={errors.line1?.message} {...register('line1')} />
-                  <Input label={t('checkout.line2')} {...register('line2')} />
+                  <Input label={t('checkout.line1')} autoComplete="address-line1" placeholder={t('checkout.line1Placeholder')} error={errors.line1?.message} {...register('line1')} />
+                  <Input label={t('checkout.line2')} autoComplete="address-line2" {...register('line2')} />
                   <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                     <div className="space-y-1.5 sm:col-span-3">
                       <label className="block text-sm font-medium text-[var(--foreground)]">
                         {t('checkout.province')}
                       </label>
                       <select
+                        autoComplete="address-level1"
                         className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
                         value={watchedProvince}
                         onChange={e =>
@@ -507,6 +508,7 @@ export function CheckoutPageClient({
                       label={t('checkout.postalCode')}
                       placeholder={t('checkout.postalCodePlaceholder')}
                       inputMode="numeric"
+                      autoComplete="postal-code"
                       maxLength={5}
                       error={errors.postalCode?.message}
                       {...register('postalCode', {
@@ -519,6 +521,7 @@ export function CheckoutPageClient({
                     <div className="sm:col-span-2">
                       <Input
                         label={t('checkout.city')}
+                        autoComplete="address-level2"
                         error={errors.city?.message}
                         {...register('city')}
                       />
@@ -528,6 +531,7 @@ export function CheckoutPageClient({
                     label={t('checkout.phone')}
                     type="tel"
                     inputMode="tel"
+                    autoComplete="tel"
                     placeholder="+34 600 000 000"
                     error={errors.phone?.message}
                     value={watchedPhone}

--- a/src/components/catalog/MobileFilters.tsx
+++ b/src/components/catalog/MobileFilters.tsx
@@ -25,7 +25,7 @@ function MobileFiltersInner({ categories }: Props) {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={`Abrir filtros${activeCount > 0 ? ` (${activeCount} activos)` : ''}`}
-        className="flex items-center gap-1.5 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-medium text-[var(--foreground-soft)] shadow-sm transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] lg:hidden"
+        className="inline-flex min-h-11 items-center gap-1.5 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-2.5 text-sm font-medium text-[var(--foreground-soft)] shadow-sm transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] lg:hidden"
       >
         <FunnelIcon className="h-4 w-4" />
         Filtros

--- a/src/components/catalog/ProductPurchasePanel.tsx
+++ b/src/components/catalog/ProductPurchasePanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocale } from '@/i18n'
 import { AddToCartButton } from '@/components/catalog/AddToCartButton'
 import {
@@ -51,6 +51,8 @@ export function ProductPurchasePanel({
   const { locale } = useLocale()
   const copy = getCatalogCopy(locale)
   const [quantity, setQuantity] = useState(1)
+  const inlineCtaRef = useRef<HTMLDivElement>(null)
+  const [showStickyCta, setShowStickyCta] = useState(false)
 
   const product = {
     basePrice,
@@ -93,6 +95,24 @@ export function ProductPurchasePanel({
       setSelectedVariantId(defaultVariant.id)
     }
   }, [defaultVariant, requiresVariantSelection, selectedVariant, selectedVariantId])
+
+  useEffect(() => {
+    const target = inlineCtaRef.current
+    if (!target || typeof IntersectionObserver === 'undefined') return
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0]
+        if (!entry) return
+        // Show the sticky CTA only once the inline button has scrolled out of
+        // view — avoids a duplicate action stacked on top of the canonical one.
+        setShowStickyCta(!entry.isIntersecting)
+      },
+      { rootMargin: '0px 0px -20% 0px', threshold: 0 },
+    )
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [])
 
   useEffect(() => {
     trackAnalyticsEvent('view_item', {
@@ -266,7 +286,7 @@ export function ProductPurchasePanel({
         </div>
       </div>
 
-      <div className="mt-6">
+      <div ref={inlineCtaRef} className="mt-6">
         <AddToCartButton
           productId={productId}
           variantId={selectedVariant?.id}
@@ -281,6 +301,61 @@ export function ProductPurchasePanel({
           vendorId={vendorId}
           vendorName={vendorName}
         />
+      </div>
+
+      {/* Mobile sticky CTA — revealed once the inline add-to-cart scrolls out
+          of view. Keeps the primary action always a thumb away on phones.
+          Hidden from desktop so the inline panel stays canonical there. */}
+      <MobileStickyCta
+        visible={showStickyCta}
+        price={displayPrice}
+        unit={localizedUnit}
+      >
+        <AddToCartButton
+          productId={productId}
+          variantId={selectedVariant?.id}
+          variantName={selectedVariant?.name}
+          disabled={!canAddToCart || isOutOfStock}
+          quantity={quantity}
+          productName={productName}
+          price={displayPrice}
+          slug={slug}
+          image={image}
+          unit={localizedUnit}
+          vendorId={vendorId}
+          vendorName={vendorName}
+          size="md"
+          className="min-w-[9rem]"
+        />
+      </MobileStickyCta>
+    </div>
+  )
+}
+
+interface MobileStickyCtaProps {
+  visible: boolean
+  price: number
+  unit: string
+  children: React.ReactNode
+}
+
+function MobileStickyCta({ visible, price, unit, children }: MobileStickyCtaProps) {
+  return (
+    <div
+      aria-hidden={!visible}
+      className={`fixed inset-x-0 bottom-0 z-40 border-t border-[var(--border)] bg-[var(--surface)]/95 px-4 pt-3 shadow-[0_-8px_24px_-12px_rgba(0,0,0,0.25)] backdrop-blur transition-transform duration-200 md:hidden ${
+        visible ? 'translate-y-0' : 'translate-y-full pointer-events-none'
+      }`}
+      style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-base font-bold text-[var(--foreground)]">
+            {formatPrice(price)}
+            <span className="ml-1 text-xs font-normal text-[var(--muted)]">/ {unit}</span>
+          </p>
+        </div>
+        {children}
       </div>
     </div>
   )

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -73,6 +73,16 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
     // flicker as the drawer drags along.
     if (mobileOpen) setHideMobileSearch(false)
   }, [mobileOpen])
+
+  useEffect(() => {
+    if (!mobileOpen) return
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+    return () => {
+      body.style.overflow = previousOverflow
+    }
+  }, [mobileOpen])
   useEffect(() => {
     function handleScroll() {
       if (mobileOpenRef.current) return
@@ -304,7 +314,7 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
               onClick={() => setMobileOpen(v => !v)}
               aria-expanded={mobileOpen}
               aria-label={mobileOpen ? t('close_menu') : t('open_menu')}
-              className="rounded-xl p-2 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] md:hidden"
+              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-xl p-2.5 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] md:hidden"
             >
               {mobileOpen ? <XMarkIcon className="h-5 w-5" /> : <Bars3Icon className="h-5 w-5" />}
             </button>

--- a/src/components/layout/SidebarProvider.tsx
+++ b/src/components/layout/SidebarProvider.tsx
@@ -34,6 +34,16 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
     setMobileOpen(false)
   }, [pathname])
 
+  useEffect(() => {
+    if (!mobileOpen) return
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+    return () => {
+      body.style.overflow = previousOverflow
+    }
+  }, [mobileOpen])
+
   const toggleCollapsed = useCallback(() => {
     setCollapsed(prev => {
       const next = !prev

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -22,6 +22,10 @@ export function Modal({ open, onClose, title, children, size = 'md', className }
   useEffect(() => {
     if (!open) return
 
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         onClose()
@@ -47,6 +51,7 @@ export function Modal({ open, onClose, title, children, size = 'md', className }
     return () => {
       document.removeEventListener('keydown', onKey)
       window.clearTimeout(frame)
+      body.style.overflow = previousOverflow
     }
   }, [open, onClose])
 
@@ -109,7 +114,7 @@ export function Modal({ open, onClose, title, children, size = 'md', className }
               type="button"
               onClick={onClose}
               aria-label="Cerrar modal"
-              className="rounded-lg p-1.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
             >
               <XMarkIcon className="h-5 w-5" />
             </button>

--- a/src/components/vendor/ProductForm.tsx
+++ b/src/components/vendor/ProductForm.tsx
@@ -244,8 +244,8 @@ export function ProductForm({ categories, initialData, stripeOnboarded }: Produc
           </label>
           <textarea
             id="description"
-            rows={5}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
+            rows={3}
+            className="w-full min-h-24 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 sm:min-h-40 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
             placeholder={t('vendor.descPlaceholder')}
             {...register('description')}
           />
@@ -281,6 +281,7 @@ export function ProductForm({ categories, initialData, stripeOnboarded }: Produc
         <Input
           label={t('vendor.basePrice')}
           type="number"
+          inputMode="decimal"
           min="0"
           step="0.01"
           error={errors.basePrice?.message}
@@ -290,6 +291,7 @@ export function ProductForm({ categories, initialData, stripeOnboarded }: Produc
         <Input
           label={t('vendor.compareAtPrice')}
           type="number"
+          inputMode="decimal"
           min="0"
           step="0.01"
           hint={t('vendor.compareAtHint')}
@@ -318,6 +320,7 @@ export function ProductForm({ categories, initialData, stripeOnboarded }: Produc
         <Input
           label={t('vendor.stock')}
           type="number"
+          inputMode="numeric"
           min="0"
           step="1"
           error={errors.stock?.message}
@@ -327,6 +330,7 @@ export function ProductForm({ categories, initialData, stripeOnboarded }: Produc
         <Input
           label={t('vendor.weightGrams')}
           type="number"
+          inputMode="numeric"
           min="1"
           step="1"
           placeholder="500"

--- a/src/components/vendor/VendorHeader.tsx
+++ b/src/components/vendor/VendorHeader.tsx
@@ -26,7 +26,7 @@ export function VendorHeader({ user, vendor }: Props) {
         <button
           type="button"
           onClick={openMobile}
-          className="md:hidden rounded-lg p-1.5 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+          className="md:hidden inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2.5 text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
           aria-label={openMenuLabel}
           title={openMenuLabel}
         >

--- a/src/components/vendor/VendorSidebar.tsx
+++ b/src/components/vendor/VendorSidebar.tsx
@@ -115,7 +115,7 @@ export function VendorSidebar({ vendor }: Props) {
           <button
             type="button"
             onClick={closeMobile}
-            className="md:hidden rounded-lg p-1.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+            className="md:hidden inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2.5 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
             aria-label={closeMenuLabel}
             title={closeMenuLabel}
           >

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Contract: the marketplace mobile UX invariants we just locked in.
+ *
+ *   1. The root viewport export opts into safe areas (viewport-fit=cover)
+ *      and the global stylesheet honours env(safe-area-inset-*) so iOS
+ *      notch devices don't clip content.
+ *   2. Body scroll is locked whenever the SidebarProvider mobile drawer,
+ *      the public Header mobile menu, or the shared Modal is open —
+ *      otherwise the background scrolls behind the overlay on touch.
+ *   3. Close / hamburger buttons across the panel shells meet the 44px
+ *      touch-target minimum via `min-h-11 min-w-11`.
+ *   4. Admin tables that rely on horizontal scroll contain it (no page
+ *      back-swipe) and expose a dedicated touch pan axis.
+ *   5. Vendor ProductForm numeric inputs use `inputMode` so the right
+ *      mobile keyboard opens.
+ *   6. The buyer checkout address form exposes `autoComplete` tokens so
+ *      mobile browsers can prefill contact + address fields.
+ *   7. The PDP purchase panel renders a mobile-only sticky add-to-cart
+ *      bar, and the cart page renders a mobile-only sticky checkout bar.
+ *
+ * These invariants are enforced statically so a refactor can't silently
+ * drop them — any change to the listed files must keep them intact or
+ * update this test in the same PR.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function read(relative: string): string {
+  return readFileSync(new URL(`../../${relative}`, import.meta.url).pathname, 'utf8')
+}
+
+test('root viewport opts into safe areas and body honours env insets', () => {
+  const layout = read('src/app/layout.tsx')
+  assert.match(layout, /viewportFit:\s*'cover'/, 'layout.tsx viewport must set viewportFit: cover')
+
+  const css = read('src/app/globals.css')
+  assert.match(css, /env\(safe-area-inset-left\)/, 'globals.css must use safe-area-inset-left')
+  assert.match(css, /env\(safe-area-inset-right\)/, 'globals.css must use safe-area-inset-right')
+})
+
+test('SidebarProvider locks body scroll while the mobile drawer is open', () => {
+  const source = read('src/components/layout/SidebarProvider.tsx')
+  assert.match(
+    source,
+    /body\.style\.overflow\s*=\s*'hidden'/,
+    'SidebarProvider must toggle body.style.overflow when mobileOpen flips',
+  )
+  assert.match(source, /\[mobileOpen\]/, 'scroll-lock effect must depend on mobileOpen')
+})
+
+test('public Header locks body scroll while the mobile menu is open', () => {
+  const source = read('src/components/layout/Header.tsx')
+  const matches = source.match(/body\.style\.overflow\s*=\s*'hidden'/g) ?? []
+  assert.ok(matches.length >= 1, 'Header must lock body scroll when mobileOpen is true')
+})
+
+test('Modal locks body scroll while it is open', () => {
+  const source = read('src/components/ui/modal.tsx')
+  assert.match(
+    source,
+    /body\.style\.overflow\s*=\s*'hidden'/,
+    'Modal must lock body scroll while open',
+  )
+  assert.match(
+    source,
+    /body\.style\.overflow\s*=\s*previousOverflow/,
+    'Modal must restore the previous overflow on cleanup',
+  )
+})
+
+test('panel close/hamburger buttons meet 44px tap-target minimum', () => {
+  const files = [
+    'src/components/ui/modal.tsx',
+    'src/components/admin/AdminSidebar.tsx',
+    'src/components/vendor/VendorSidebar.tsx',
+    'src/components/admin/AdminHeader.tsx',
+    'src/components/vendor/VendorHeader.tsx',
+    'src/components/layout/Header.tsx',
+  ]
+  for (const file of files) {
+    const source = read(file)
+    assert.match(
+      source,
+      /min-h-11 min-w-11/,
+      `${file} must contain a button with min-h-11 min-w-11 for the 44px tap target`,
+    )
+  }
+})
+
+test('admin tables contain horizontal overscroll and opt into touch-pan-x', () => {
+  const files = [
+    'src/components/admin/AdminPromotionsClient.tsx',
+    'src/components/admin/AdminProducersClient.tsx',
+    'src/components/admin/AdminSubscriptionsClient.tsx',
+    'src/components/admin/analytics/OrdersTable.tsx',
+  ]
+  for (const file of files) {
+    const source = read(file)
+    assert.match(
+      source,
+      /overflow-x-auto overscroll-x-contain touch-pan-x/,
+      `${file} must wrap its table with overscroll-x-contain + touch-pan-x`,
+    )
+  }
+})
+
+test('vendor ProductForm numeric inputs declare inputMode for mobile keyboards', () => {
+  const source = read('src/components/vendor/ProductForm.tsx')
+  // Price fields → decimal keypad; stock / weight → numeric keypad.
+  const decimalMatches = source.match(/inputMode="decimal"/g) ?? []
+  const numericMatches = source.match(/inputMode="numeric"/g) ?? []
+  assert.ok(
+    decimalMatches.length >= 2,
+    `ProductForm must keep inputMode="decimal" on the base and compareAt price inputs (found ${decimalMatches.length})`,
+  )
+  assert.ok(
+    numericMatches.length >= 2,
+    `ProductForm must keep inputMode="numeric" on stock/weight inputs (found ${numericMatches.length})`,
+  )
+})
+
+test('checkout address form exposes autoComplete tokens for mobile prefill', () => {
+  const source = read('src/components/buyer/CheckoutPageClient.tsx')
+  const required = [
+    'autoComplete="given-name"',
+    'autoComplete="family-name"',
+    'autoComplete="address-line1"',
+    'autoComplete="address-line2"',
+    'autoComplete="address-level1"',
+    'autoComplete="address-level2"',
+    'autoComplete="postal-code"',
+    'autoComplete="tel"',
+  ]
+  for (const token of required) {
+    assert.ok(
+      source.includes(token),
+      `CheckoutPageClient must declare ${token} so mobile browsers can prefill`,
+    )
+  }
+})
+
+test('PDP purchase panel renders a mobile-only sticky add-to-cart bar', () => {
+  const source = read('src/components/catalog/ProductPurchasePanel.tsx')
+  assert.match(source, /function MobileStickyCta/, 'ProductPurchasePanel must declare a MobileStickyCta helper')
+  assert.match(source, /md:hidden/, 'sticky CTA container must hide itself on desktop')
+  assert.match(source, /fixed inset-x-0 bottom-0/, 'sticky CTA container must be fixed to the viewport bottom')
+  assert.match(source, /env\(safe-area-inset-bottom\)/, 'sticky CTA must honour the home-indicator safe area')
+  assert.match(source, /IntersectionObserver/, 'sticky CTA must toggle via IntersectionObserver on the inline CTA')
+})
+
+test('cart page renders a mobile-only sticky checkout bar', () => {
+  const source = read('src/components/buyer/CartPageClient.tsx')
+  assert.match(source, /fixed inset-x-0 bottom-0[^"]*lg:hidden/, 'cart must render a mobile-only fixed checkout bar')
+  assert.match(source, /env\(safe-area-inset-bottom\)/, 'cart sticky bar must honour the home-indicator safe area')
+})


### PR DESCRIPTION
## Summary
- Lock body scroll while the Modal, admin/vendor mobile drawer, and public header mobile menu are open — iOS no longer scrolls the page behind the overlay.
- Opt into iOS safe areas (`viewportFit: 'cover'` + `env(safe-area-inset-*)`) so notch / home indicator no longer clip content.
- Raise close / hamburger buttons across the panel shells and public header to the 44×44px touch-target minimum (`min-h-11 min-w-11`).
- Admin tables (promociones, productores, suscripciones, analytics/orders) contain horizontal scroll with `overscroll-x-contain touch-pan-x` so swiping sideways no longer triggers the browser back gesture.
- `ProductForm`: add `inputMode=decimal|numeric` on price/stock/weight inputs and shrink the description textarea on mobile so it no longer dominates the form.
- Checkout + register forms expose the correct `autoComplete` tokens for mobile prefill (`given-name`, `family-name`, `address-line1/2`, `address-level1/2`, `postal-code`, `tel`, `new-password`).
- PDP: reveal a mobile-only sticky add-to-cart bar once the inline CTA scrolls out of view (IntersectionObserver driven, safe-area aware).
- Cart: render a mobile-only sticky checkout bar with the running total so the primary action is always a thumb away.

All invariants are covered statically in [`test/contracts/mobile-ux.test.ts`](test/contracts/mobile-ux.test.ts) so a refactor can't silently drop them.

## Not in scope (follow-ups)
- Converting admin tables to stacked mobile cards (bigger refactor than this PR wanted).
- Replacing the filter Modal with a true bottom-sheet component (current Modal already locks scroll and works well enough on mobile).
- Auditing remaining secondary flows (perfil buyer, direcciones, vendor dashboards).

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (645 tests, includes new `mobile-ux` contract)
- [x] `npm run build`
- [ ] Manual smoke on a real iOS device: PDP sticky CTA appears/disappears at the right scroll point, cart sticky checkout bar doesn't cover the last cart item, drawers no longer scroll the page behind them, no notch clipping in landscape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)