### PR TITLE
fix(mobile): round 2 — buyer account, gallery, vendor action tap targets

### DIFF
--- a/docs/admin-host.md
+++ b/docs/admin-host.md
@@ -1,0 +1,52 @@
+# Admin host isolation
+
+Ticket: [#348](https://github.com/juanmixto/marketplace/issues/348)
+
+## What this is
+
+The admin panel (`/admin/**`) can be served on a dedicated host (e.g.
+`admin.marketplace.example`) separate from the public storefront
+(`marketplace.example`). When enabled:
+
+- `/admin/**` requests on the public host get redirected to the admin host.
+- Non-admin paths on the admin host return 404 (no public pages, no product listings, no checkout).
+- The NextAuth session cookie is **host-only** (no `Domain` attribute), so the cookie set on `marketplace.example` is **not** sent to `admin.marketplace.example`, and vice versa. Compromising one host's session cookie does not grant access to the other.
+
+This is enforced in one place: [`src/proxy.ts`](../src/proxy.ts). The host comparison lives in [`src/lib/admin-host.ts`](../src/lib/admin-host.ts) and is unit-tested in [`test/features/proxy.test.ts`](../test/features/proxy.test.ts).
+
+## How to enable (ops checklist)
+
+1. **DNS**: create a `CNAME` or `A` record for `admin.<your-domain>` pointing at the same deployment as the public host.
+2. **TLS**: provision a certificate that covers `admin.<your-domain>`. On Vercel/Netlify this happens automatically once the domain is added to the project.
+3. **Environment**: set `ADMIN_HOST=admin.<your-domain>` in the deployment environment. No prefix (`https://`), no path, no port. Example: `ADMIN_HOST=admin.marketplace.example`.
+4. **Deploy**: once the env var is set, the next deploy will start enforcing host isolation.
+5. **Verify**:
+   - `curl -I https://<public-host>/admin/dashboard` → `307` redirect to `https://<admin-host>/admin/dashboard`
+   - `curl -I https://<admin-host>/productos` → `404`
+   - Log in at `https://<public-host>/login?callbackUrl=/admin/dashboard` as an admin — you should land on `https://<admin-host>/admin/dashboard` with a fresh admin session cookie.
+   - Open DevTools → Application → Cookies. The session cookie for `<admin-host>` should be a **different** cookie from the one on `<public-host>`.
+
+## How to disable
+
+Unset `ADMIN_HOST`. With no env var, the middleware behaves exactly as before (single-host mode). This is the default and is safe for local development.
+
+## Local development
+
+For local testing, map `admin.localhost` to `127.0.0.1` (your OS already does this for `*.localhost`), then set:
+
+```
+ADMIN_HOST=admin.localhost:3000
+```
+
+Visit the app via `http://admin.localhost:3000/admin/dashboard` and `http://localhost:3000` in parallel browser profiles to verify isolation.
+
+## What this does NOT do (yet)
+
+- **Cross-domain login handoff**: today, if an admin logs in on the public host and is redirected to the admin host, they will land on the admin host **without** a session and have to re-authenticate. A seamless handshake (signed one-time token exchanged for a session on the admin host) is out of scope for this ticket — see the [#348 description](https://github.com/juanmixto/marketplace/issues/348) for the design sketch. For now, document to admins that they should log in directly at `https://<admin-host>/login`.
+- **IP allowlist**: the `ADMIN_IP_ALLOWLIST` feature mentioned in the ticket is intentionally deferred.
+- **CSP hardening on the admin host specifically**: deferred. The same CSP is served for both hosts until a follow-up ticket.
+
+## Invariants this ticket depends on
+
+- The NextAuth session cookie must remain **host-only** (no explicit `Domain` attribute). This is the default in [`src/lib/auth-host.ts`](../src/lib/auth-host.ts) today. If a future change adds `Domain=<parent-domain>`, the isolation is silently defeated. Keep this in mind when modifying cookie config.
+- `ADMIN_HOST` must NOT overlap with the public host. The middleware will happily treat them as the same if they match, removing the protection.

--- a/src/app/(admin)/admin/productores/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/productores/[id]/edit/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { db } from '@/lib/db'
+import { requireSuperadmin } from '@/lib/auth-guard'
+import { AdminVendorEditForm } from '@/components/admin/AdminVendorEditForm'
+
+export const metadata: Metadata = { title: 'Editar productor | Admin' }
+export const dynamic = 'force-dynamic'
+
+interface Props { params: Promise<{ id: string }> }
+
+export default async function AdminVendorEditPage({ params }: Props) {
+  await requireSuperadmin()
+  const { id } = await params
+
+  const vendor = await db.vendor.findUnique({ where: { id } })
+  if (!vendor) notFound()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/admin/productores" className="text-sm text-emerald-700 hover:underline dark:text-emerald-400">
+          ← Volver al listado
+        </Link>
+        <p className="mt-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">Productores · Edición admin</p>
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">{vendor.displayName}</h1>
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          Sólo SUPERADMIN puede editar estos datos — afectan facturación y comisiones.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+        <AdminVendorEditForm
+          vendor={{
+            id: vendor.id,
+            displayName: vendor.displayName,
+            slug: vendor.slug,
+            description: vendor.description,
+            location: vendor.location,
+            status: vendor.status,
+            commissionRate: Number(vendor.commissionRate),
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/productos/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/productos/[id]/edit/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { db } from '@/lib/db'
+import { requireCatalogAdmin } from '@/lib/auth-guard'
+import { getCategories } from '@/domains/catalog/queries'
+import { AdminProductEditForm } from '@/components/admin/AdminProductEditForm'
+
+export const metadata: Metadata = { title: 'Editar producto | Admin' }
+export const dynamic = 'force-dynamic'
+
+interface Props { params: Promise<{ id: string }> }
+
+export default async function AdminProductEditPage({ params }: Props) {
+  await requireCatalogAdmin()
+  const { id } = await params
+
+  const [product, categories] = await Promise.all([
+    db.product.findUnique({
+      where: { id },
+      include: { vendor: { select: { id: true, displayName: true } } },
+    }),
+    getCategories(),
+  ])
+
+  if (!product) notFound()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/admin/productos" className="text-sm text-emerald-700 hover:underline dark:text-emerald-400">
+          ← Volver al listado
+        </Link>
+        <p className="mt-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">Catálogo · Edición admin</p>
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">{product.name}</h1>
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          Productor: <span className="font-medium text-[var(--foreground)]">{product.vendor.displayName}</span>
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+        <AdminProductEditForm
+          categories={categories.map(c => ({ id: c.id, name: c.name }))}
+          product={{
+            id: product.id,
+            name: product.name,
+            description: product.description,
+            categoryId: product.categoryId,
+            basePrice: Number(product.basePrice),
+            compareAtPrice: product.compareAtPrice == null ? null : Number(product.compareAtPrice),
+            taxRate: Number(product.taxRate),
+            unit: product.unit,
+            stock: product.stock,
+            trackStock: product.trackStock,
+            status: product.status,
+            originRegion: product.originRegion,
+            rejectionNote: product.rejectionNote,
+            expiresAt: product.expiresAt ? product.expiresAt.toISOString().slice(0, 10) : null,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/productos/page.tsx
+++ b/src/app/(admin)/admin/productos/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { db } from '@/lib/db'
 import { formatDate, formatPrice } from '@/lib/utils'
 import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge'
@@ -67,12 +68,18 @@ export default async function AdminProductsPage() {
               <div>
                 <AdminStatusBadge label={product.status} tone={getProductStatusTone(product.status)} />
               </div>
-              <div>
+              <div className="flex items-center gap-3">
                 <ProductModerationActions
                   productId={product.id}
                   productName={product.name}
                   status={product.status}
                 />
+                <Link
+                  href={`/admin/productos/${product.id}/edit`}
+                  className="text-xs font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+                >
+                  Editar
+                </Link>
               </div>
             </div>
           ))}

--- a/src/app/(admin)/admin/promociones/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/promociones/[id]/edit/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { db } from '@/lib/db'
+import { requireCatalogAdmin } from '@/lib/auth-guard'
+import { getCategories } from '@/domains/catalog/queries'
+import { AdminPromotionEditForm } from '@/components/admin/AdminPromotionEditForm'
+
+export const metadata: Metadata = { title: 'Editar promoción | Admin' }
+export const dynamic = 'force-dynamic'
+
+interface Props { params: Promise<{ id: string }> }
+
+export default async function AdminPromotionEditPage({ params }: Props) {
+  await requireCatalogAdmin()
+  const { id } = await params
+
+  const promotion = await db.promotion.findUnique({
+    where: { id },
+    include: { vendor: { select: { id: true, displayName: true } } },
+  })
+  if (!promotion) notFound()
+
+  const [vendorProducts, categories] = await Promise.all([
+    db.product.findMany({
+      where: { vendorId: promotion.vendorId, deletedAt: null },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+    }),
+    getCategories(),
+  ])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/admin/promociones" className="text-sm text-emerald-700 hover:underline dark:text-emerald-400">
+          ← Volver a promociones
+        </Link>
+        <p className="mt-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">Promociones · Edición admin</p>
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">{promotion.name}</h1>
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          Productor: <span className="font-medium text-[var(--foreground)]">{promotion.vendor.displayName}</span>
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+        <AdminPromotionEditForm
+          promotion={{
+            id: promotion.id,
+            name: promotion.name,
+            code: promotion.code,
+            kind: promotion.kind,
+            value: Number(promotion.value),
+            scope: promotion.scope,
+            productId: promotion.productId,
+            categoryId: promotion.categoryId,
+            minSubtotal: promotion.minSubtotal == null ? null : Number(promotion.minSubtotal),
+            maxRedemptions: promotion.maxRedemptions,
+            perUserLimit: promotion.perUserLimit,
+            startsAt: promotion.startsAt.toISOString(),
+            endsAt: promotion.endsAt.toISOString(),
+          }}
+          vendorProducts={vendorProducts.map(p => ({ id: p.id, label: p.name }))}
+          categories={categories.map(c => ({ id: c.id, label: c.name }))}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/suscripciones/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/suscripciones/[id]/edit/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { db } from '@/lib/db'
+import { requireSuperadmin } from '@/lib/auth-guard'
+import { AdminSubscriptionPlanEditForm } from '@/components/admin/AdminSubscriptionPlanEditForm'
+
+export const metadata: Metadata = { title: 'Editar plan | Admin' }
+export const dynamic = 'force-dynamic'
+
+interface Props { params: Promise<{ id: string }> }
+
+export default async function AdminPlanEditPage({ params }: Props) {
+  await requireSuperadmin()
+  const { id } = await params
+
+  const plan = await db.subscriptionPlan.findUnique({
+    where: { id },
+    include: {
+      vendor: { select: { displayName: true } },
+      product: { select: { name: true } },
+    },
+  })
+  if (!plan) notFound()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link href="/admin/suscripciones" className="text-sm text-emerald-700 hover:underline dark:text-emerald-400">
+          ← Volver a suscripciones
+        </Link>
+        <p className="mt-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">Suscripciones · Edición admin</p>
+        <h1 className="text-2xl font-bold text-[var(--foreground)]">{plan.product.name}</h1>
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          Productor: <span className="font-medium text-[var(--foreground)]">{plan.vendor.displayName}</span>
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+        <AdminSubscriptionPlanEditForm
+          plan={{
+            id: plan.id,
+            cadence: plan.cadence,
+            priceSnapshot: Number(plan.priceSnapshot),
+            taxRateSnapshot: Number(plan.taxRateSnapshot),
+            cutoffDayOfWeek: plan.cutoffDayOfWeek,
+            archived: plan.archivedAt != null,
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -2,16 +2,18 @@ import { AdminSidebar } from '@/components/admin/AdminSidebar'
 import { AdminHeader } from '@/components/admin/AdminHeader'
 import { SidebarProvider } from '@/components/layout/SidebarProvider'
 import { requireAdmin } from '@/lib/auth-guard'
+import { getAvailablePortals } from '@/lib/portals'
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAdmin()
+  const portals = getAvailablePortals(session.user.role)
 
   return (
     <SidebarProvider>
       <div className="flex h-screen bg-[var(--background)]">
         <AdminSidebar />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <AdminHeader user={session.user} />
+          <AdminHeader user={session.user} portals={portals} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,14 @@
 import { LoginForm } from '@/components/auth/LoginForm'
 import { auth } from '@/lib/auth'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { resolvePostLoginDestination } from '@/lib/portals'
+import {
+  resolvePostLoginDestination,
+  describeCallbackRejection,
+  isValidPortalMode,
+  LAST_PORTAL_COOKIE,
+} from '@/lib/portals'
+import { logger } from '@/lib/logger'
 
 interface Props {
   searchParams: Promise<{ callbackUrl?: string }>
@@ -11,8 +18,36 @@ export default async function LoginPage({ searchParams }: Props) {
   const params = await searchParams
   const session = await auth()
 
+  if (params.callbackUrl) {
+    const rejection = describeCallbackRejection(params.callbackUrl)
+    if (rejection && rejection !== 'empty') {
+      logger.warn('auth.callback.rejected', {
+        reason: rejection,
+        // Log only length, not the raw URL, to avoid capturing attacker payloads.
+        callbackLength: params.callbackUrl.length,
+      })
+    }
+  }
+
   if (session?.user) {
-    redirect(resolvePostLoginDestination(session.user.role, params.callbackUrl))
+    const cookieStore = await cookies()
+    const rawLastPortal = cookieStore.get(LAST_PORTAL_COOKIE)?.value
+    const lastPortal = isValidPortalMode(rawLastPortal) ? rawLastPortal : null
+
+    redirect(
+      resolvePostLoginDestination(session.user.role, params.callbackUrl, {
+        lastPortal,
+        onRoleMismatch: ({ callbackMode, roleMode }) => {
+          logger.warn('auth.callback.rejected', {
+            reason: 'role_mismatch',
+            userId: session.user?.id,
+            role: session.user?.role,
+            callbackMode,
+            roleMode,
+          })
+        },
+      })
+    )
   }
 
   return <LoginForm callbackUrl={params.callbackUrl ?? '/'} />

--- a/src/app/(auth)/recuperar-contrasena/RequestForm.tsx
+++ b/src/app/(auth)/recuperar-contrasena/RequestForm.tsx
@@ -79,8 +79,10 @@ export function RequestForm() {
           {...register('email')}
           type="email"
           id="email"
+          inputMode="email"
+          autoComplete="email"
           placeholder={t('auth.recoveryEmailPlaceholder')}
-          className="mt-2 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
+          className="mt-2 block min-h-11 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
         />
         {errors.email && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.email.message}</p>}
       </div>

--- a/src/app/(auth)/recuperar-contrasena/nueva/ResetForm.tsx
+++ b/src/app/(auth)/recuperar-contrasena/nueva/ResetForm.tsx
@@ -92,8 +92,9 @@ export function ResetForm({ token }: ResetFormProps) {
           {...register('password')}
           type="password"
           id="password"
+          autoComplete="new-password"
           placeholder="Mínimo 8 caracteres"
-          className="mt-2 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
+          className="mt-2 block min-h-11 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
         />
         {errors.password && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.password.message}</p>}
       </div>
@@ -107,8 +108,9 @@ export function ResetForm({ token }: ResetFormProps) {
           {...register('confirmPassword')}
           type="password"
           id="confirmPassword"
+          autoComplete="new-password"
           placeholder="Repite la contraseña"
-          className="mt-2 block w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
+          className="mt-2 block min-h-11 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 dark:border-[var(--border)] dark:bg-[var(--surface-raised)] dark:text-[var(--foreground)] dark:placeholder-[var(--muted-light)] dark:focus:ring-emerald-900/60"
         />
         {errors.confirmPassword && <p className="mt-1 text-sm text-red-600 dark:text-red-400">{errors.confirmPassword.message}</p>}
       </div>

--- a/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
@@ -243,6 +243,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.firstName')}</label>
                 <input
                   {...register('firstName')}
+                  autoComplete="given-name"
                   placeholder={t('account.firstNamePlaceholder')}
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -254,6 +255,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.lastName')}</label>
                 <input
                   {...register('lastName')}
+                  autoComplete="family-name"
                   placeholder={t('account.lastNamePlaceholder')}
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -265,6 +267,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.line1')}</label>
                 <input
                   {...register('line1')}
+                  autoComplete="address-line1"
                   placeholder={t('account.line1Placeholder')}
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -276,6 +279,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.line2Field')}</label>
                 <input
                   {...register('line2')}
+                  autoComplete="address-line2"
                   placeholder={t('account.line2Placeholder')}
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -287,6 +291,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.city')}</label>
                 <input
                   {...register('city')}
+                  autoComplete="address-level2"
                   placeholder={t('account.cityPlaceholder')}
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -298,6 +303,7 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.province')}</label>
                 <select
                   {...register('province')}
+                  autoComplete="address-level1"
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 >
                   <option value="">{t('account.selectProvince')}</option>
@@ -313,6 +319,9 @@ export function DireccionesClient({
                 <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.postalCode')}</label>
                 <input
                   {...register('postalCode')}
+                  inputMode="numeric"
+                  autoComplete="postal-code"
+                  maxLength={5}
                   placeholder="28001"
                   className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
                 />
@@ -386,10 +395,10 @@ export function DireccionesClient({
                 <p>{address.city}, {address.province} {address.postalCode}</p>
               </div>
 
-              <div className="flex gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <button
                   onClick={() => handleEdit(address)}
-                  className="inline-flex items-center gap-1 text-sm font-medium text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300"
+                  className="inline-flex min-h-11 items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50/60 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-800/70 dark:bg-emerald-950/30 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
                 >
                   <PencilIcon className="h-4 w-4" />
                   {t('account.edit')}
@@ -397,7 +406,7 @@ export function DireccionesClient({
                 {!address.isDefault && (
                   <button
                     onClick={() => handleSetDefault(address.id)}
-                    className="inline-flex items-center gap-1 text-sm font-medium text-[var(--muted)] hover:text-[var(--foreground)]"
+                    className="inline-flex min-h-11 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
                   >
                     {t('account.setAsDefault')}
                   </button>
@@ -405,7 +414,7 @@ export function DireccionesClient({
                 <button
                   onClick={() => handleDelete(address.id)}
                   disabled={deleting === address.id}
-                  className="ml-auto inline-flex items-center gap-1 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50"
+                  className="ml-auto inline-flex min-h-11 items-center gap-1.5 rounded-lg border border-red-200 bg-red-50/60 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-100 disabled:opacity-50 dark:border-red-800/70 dark:bg-red-950/30 dark:text-red-300 dark:hover:bg-red-900/40"
                 >
                   <TrashIcon className="h-4 w-4" />
                   {t('account.delete')}

--- a/src/app/(buyer)/cuenta/favoritos/FavoritosClient.tsx
+++ b/src/app/(buyer)/cuenta/favoritos/FavoritosClient.tsx
@@ -130,8 +130,9 @@ export function FavoritosClient({ initialFavorites }: { initialFavorites: Favori
                 <button
                   onClick={() => handleRemove(fav.product.id)}
                   disabled={removing === fav.product.id}
-                  className="absolute right-2 top-2 rounded-full bg-[var(--surface)] dark:bg-[var(--surface-raised)] p-2 shadow-md hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-50 transition"
+                  className="absolute right-2 top-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full bg-[var(--surface)] p-2.5 shadow-md transition hover:bg-red-50 disabled:opacity-50 dark:bg-[var(--surface-raised)] dark:hover:bg-red-950/30"
                   title={t('favorites.removeTitle')}
+                  aria-label={t('favorites.removeTitle')}
                 >
                   <HeartIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
                 </button>

--- a/src/app/(buyer)/cuenta/incidencias/nueva/OpenIncidentForm.tsx
+++ b/src/app/(buyer)/cuenta/incidencias/nueva/OpenIncidentForm.tsx
@@ -71,7 +71,7 @@ export function OpenIncidentForm({ orderId }: Props) {
           id="incident-type"
           value={type}
           onChange={event => setType(event.target.value as IncidentType)}
-          className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+          className="mt-1 block min-h-11 w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
           disabled={submitting}
         >
           {INCIDENT_TYPES.map(option => (
@@ -91,11 +91,11 @@ export function OpenIncidentForm({ orderId }: Props) {
         </label>
         <textarea
           id="incident-description"
-          rows={6}
+          rows={4}
           value={description}
           onChange={event => setDescription(event.target.value)}
           placeholder={t('incident.descriptionPlaceholder')}
-          className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+          className="mt-1 block max-h-[60vh] min-h-32 w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 sm:min-h-40"
           minLength={10}
           maxLength={5000}
           required

--- a/src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx
+++ b/src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx
@@ -176,7 +176,7 @@ export function OrderDetailClient({ order, nuevo, reviewEligibility }: Props) {
                           href={f.trackingUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="font-mono underline hover:text-[var(--foreground-soft)]"
+                          className="inline-flex min-h-8 items-center rounded font-mono underline underline-offset-2 hover:text-[var(--foreground-soft)]"
                         >
                           {f.trackingNumber}
                         </a>

--- a/src/app/(buyer)/cuenta/pedidos/page.tsx
+++ b/src/app/(buyer)/cuenta/pedidos/page.tsx
@@ -142,7 +142,7 @@ export default async function MisPedidosPage() {
               <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-[var(--border)] pt-3">
                 <Link
                   href={`/cuenta/pedidos/${order.id}`}
-                  className="text-sm font-medium text-emerald-700 underline-offset-4 hover:underline dark:text-emerald-400"
+                  className="inline-flex min-h-11 items-center rounded-lg border border-emerald-200 bg-emerald-50/60 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-800/70 dark:bg-emerald-950/30 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
                 >
                   {t('account.ordersViewDetail')}
                 </Link>

--- a/src/app/(public)/buscar/page.tsx
+++ b/src/app/(public)/buscar/page.tsx
@@ -145,7 +145,7 @@ export default async function BuscarPage({ searchParams }: Props) {
                   {hasPrev && (
                     <a
                       href={`?q=${encodeURIComponent(params.q || '')}${params.categoria ? `&categoria=${params.categoria}` : ''}${params.orden ? `&orden=${params.orden}` : ''}`}
-                      className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-surface-raised"
+                      className="inline-flex min-h-11 items-center rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-surface-raised"
                     >
                       ← {copy.page.previous}
                     </a>
@@ -153,7 +153,7 @@ export default async function BuscarPage({ searchParams }: Props) {
                   {hasNext && (
                     <a
                       href={`?q=${encodeURIComponent(params.q || '')}&cursor=${nextCursor}${params.categoria ? `&categoria=${params.categoria}` : ''}${params.orden ? `&orden=${params.orden}` : ''}`}
-                      className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+                      className="inline-flex min-h-11 items-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
                     >
                       {copy.page.next} →
                     </a>

--- a/src/app/(vendor)/layout.tsx
+++ b/src/app/(vendor)/layout.tsx
@@ -1,8 +1,12 @@
+import { cookies } from 'next/headers'
 import { VendorSidebar } from '@/components/vendor/VendorSidebar'
 import { VendorHeader } from '@/components/vendor/VendorHeader'
 import { SidebarProvider } from '@/components/layout/SidebarProvider'
+import { ImpersonationBanner } from '@/components/vendor/ImpersonationBanner'
 import { db } from '@/lib/db'
 import { requireVendor } from '@/lib/auth-guard'
+import { getAvailablePortals } from '@/lib/portals'
+import { IMPERSONATION_COOKIE, verifyImpersonationToken } from '@/lib/impersonation'
 
 export default async function VendorLayout({ children }: { children: React.ReactNode }) {
   const session = await requireVendor()
@@ -12,12 +16,29 @@ export default async function VendorLayout({ children }: { children: React.React
     select: { displayName: true, status: true, slug: true },
   })
 
+  const portals = getAvailablePortals(session.user.role)
+
+  const cookieStore = await cookies()
+  const impersonationCookie = cookieStore.get(IMPERSONATION_COOKIE)?.value
+  const impersonation = verifyImpersonationToken(impersonationCookie)
+  const impersonatingAdminEmail = impersonation
+    ? (await db.user.findUnique({ where: { id: impersonation.adminId }, select: { email: true } }))?.email ?? null
+    : null
+
   return (
     <SidebarProvider>
       <div className="flex h-screen bg-[var(--background)]">
         <VendorSidebar vendor={vendor} />
         <div className="flex flex-1 flex-col overflow-hidden">
-          <VendorHeader user={session.user} vendor={vendor} />
+          {impersonation && (
+            <ImpersonationBanner
+              adminEmail={impersonatingAdminEmail}
+              vendorLabel={vendor?.displayName ?? impersonation.vendorId}
+              remainingSeconds={impersonation.remainingSeconds}
+              readOnly={impersonation.readOnly}
+            />
+          )}
+          <VendorHeader user={session.user} vendor={vendor} portals={portals} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/app/(vendor)/vendor/dashboard/page.tsx
+++ b/src/app/(vendor)/vendor/dashboard/page.tsx
@@ -87,7 +87,7 @@ export default async function VendorDashboardPage() {
                 </span>
                 {!step.done && (
                   <Link href={`/vendor/${step.key === 'product' ? 'productos/nuevo' : 'perfil'}`}
-                    className="ml-auto rounded-sm text-xs text-amber-700 hover:underline dark:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/30">
+                    className="ml-auto inline-flex min-h-11 items-center rounded-md px-2 py-2 text-xs font-medium text-amber-700 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/30 dark:text-amber-400">
                     {t('vendor.dashboard.doItNow')}
                   </Link>
                 )}
@@ -115,7 +115,7 @@ export default async function VendorDashboardPage() {
                   </p>
                 </div>
                 <Link href="/vendor/pedidos"
-                  className="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  className="inline-flex min-h-11 items-center rounded-lg bg-red-600 px-3 py-2 text-xs font-semibold text-white shadow-sm hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] dark:bg-red-500 dark:hover:bg-red-400">
                   {t('vendor.dashboard.viewOrders')}
                 </Link>
               </div>

--- a/src/app/(vendor)/vendor/liquidaciones/page.tsx
+++ b/src/app/(vendor)/vendor/liquidaciones/page.tsx
@@ -401,7 +401,7 @@ export default async function Liquidaciones({ searchParams }: PageProps) {
           )}
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow dark:border-[var(--border)] dark:bg-[var(--surface)]">
+        <div className="overflow-x-auto overscroll-x-contain touch-pan-x rounded-lg border border-gray-200 bg-white shadow dark:border-[var(--border)] dark:bg-[var(--surface)]">
           <table className="min-w-full divide-y divide-gray-200 dark:divide-[var(--border)]">
             <thead className="bg-gray-50 dark:bg-[var(--surface-raised)]">
               <tr>

--- a/src/app/(vendor)/vendor/pedidos/page.tsx
+++ b/src/app/(vendor)/vendor/pedidos/page.tsx
@@ -85,20 +85,20 @@ function FulfillmentList({ fulfillments, t }: { fulfillments: FulfillmentWithDet
         const customer = f.order.customer
         const shippingAddress = parseOrderAddressSnapshot(f.order.shippingAddressSnapshot) ?? f.order.address
         return (
-          <div key={f.id} className="space-y-3 p-4 transition-colors hover:bg-[var(--surface-raised)]/70">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <div className="flex items-center gap-2">
+          <div key={f.id} className="space-y-3 p-4 transition-colors hover:bg-[var(--surface-raised)]/70 sm:p-5">
+            <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
                   <p className="font-medium text-[var(--foreground)]">
                     {t('vendor.orders.orderNumber').replace('{id}', f.orderId.slice(-6).toUpperCase())}
                   </p>
                   <Badge variant={statusVariant}>{statusLabel}</Badge>
                 </div>
-                <p className="text-sm text-[var(--muted)] mt-0.5">
+                <p className="mt-0.5 text-sm text-[var(--muted)]">
                   {customer.firstName} {customer.lastName} · {formatDate(f.createdAt)}
                 </p>
                 {shippingAddress && (
-                  <p className="text-xs text-[var(--muted-light)] mt-0.5">
+                  <p className="mt-0.5 text-xs leading-relaxed text-[var(--muted-light)]">
                     {shippingAddress.line1}, {shippingAddress.city} {shippingAddress.postalCode}
                   </p>
                 )}
@@ -114,9 +114,9 @@ function FulfillmentList({ fulfillments, t }: { fulfillments: FulfillmentWithDet
             <div className="space-y-2">
               {f.order.lines.map(line => (
                 <div key={line.id} className="flex items-center gap-3">
-                  <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-[var(--surface-raised)]">
+                  <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-[var(--surface-raised)] sm:h-10 sm:w-10">
                     {line.product.images?.[0]
-                      ? <Image src={line.product.images[0]} alt={line.product.name} fill className="object-cover" sizes="40px" />
+                      ? <Image src={line.product.images[0]} alt={line.product.name} fill className="object-cover" sizes="(max-width: 640px) 48px, 40px" />
                       : <div className="flex h-full items-center justify-center text-lg">🌿</div>}
                   </div>
                   <div className="flex-1 min-w-0">

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -7,12 +7,15 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { useSidebar } from '@/components/layout/SidebarProvider'
+import { PortalSwitcher } from '@/components/layout/PortalSwitcher'
+import type { AvailablePortal } from '@/lib/portals'
 
 interface Props {
   user: { name?: string | null; email?: string | null; role: string }
+  portals?: AvailablePortal[]
 }
 
-export function AdminHeader({ user }: Props) {
+export function AdminHeader({ user, portals = [] }: Props) {
   const [open, setOpen] = useState(false)
   const { openMobile } = useSidebar()
 
@@ -41,6 +44,7 @@ export function AdminHeader({ user }: Props) {
       </div>
 
       <div className="flex items-center gap-1">
+        <PortalSwitcher portals={portals} current="admin" />
         <ThemeToggle />
 
         <div className="relative">

--- a/src/components/admin/AdminProducersClient.tsx
+++ b/src/components/admin/AdminProducersClient.tsx
@@ -499,7 +499,13 @@ function ProducerRow({
       </td>
       <td className="px-4 py-3 text-xs text-[var(--muted)]">{fmtDate(p.createdAt, locale)}</td>
       <td className="px-4 py-3">
-        <div className="flex justify-end">
+        <div className="flex items-center justify-end gap-3">
+          <Link
+            href={`/admin/productores/${p.id}/edit`}
+            className="text-xs font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+          >
+            Editar
+          </Link>
           <VendorModerationActions vendorId={p.id} status={p.status} />
         </div>
       </td>

--- a/src/components/admin/AdminProductEditForm.tsx
+++ b/src/components/admin/AdminProductEditForm.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { adminUpdateProduct, type AdminProductInput } from '@/domains/admin/writes'
+
+const PRODUCT_STATUSES = ['DRAFT', 'PENDING_REVIEW', 'ACTIVE', 'SUSPENDED', 'REJECTED'] as const
+
+interface CategoryOption { id: string; name: string }
+
+interface InitialProduct {
+  id: string
+  name: string
+  description: string | null
+  categoryId: string | null
+  basePrice: number
+  compareAtPrice: number | null
+  taxRate: number
+  unit: string
+  stock: number
+  trackStock: boolean
+  status: string
+  originRegion: string | null
+  rejectionNote: string | null
+  expiresAt: string | null
+}
+
+interface Props {
+  product: InitialProduct
+  categories: CategoryOption[]
+}
+
+export function AdminProductEditForm({ product, categories }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSuccess(false)
+    const fd = new FormData(event.currentTarget)
+    const input: AdminProductInput = {
+      name: String(fd.get('name') ?? ''),
+      description: fd.get('description')?.toString() || null,
+      categoryId: fd.get('categoryId')?.toString() || null,
+      basePrice: Number(fd.get('basePrice')),
+      compareAtPrice: fd.get('compareAtPrice') ? Number(fd.get('compareAtPrice')) : null,
+      taxRate: Number(fd.get('taxRate')),
+      unit: String(fd.get('unit') ?? 'kg'),
+      stock: Number(fd.get('stock')),
+      trackStock: fd.get('trackStock') === 'on',
+      status: fd.get('status') as AdminProductInput['status'],
+      originRegion: fd.get('originRegion')?.toString() || null,
+      rejectionNote: fd.get('rejectionNote')?.toString() || null,
+      expiresAt: fd.get('expiresAt')?.toString() || null,
+    }
+
+    startTransition(async () => {
+      try {
+        await adminUpdateProduct(product.id, input)
+        setSuccess(true)
+        router.refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error desconocido')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <Field label="Nombre">
+        <input name="name" defaultValue={product.name} required minLength={3} maxLength={100} className={inputCls} />
+      </Field>
+
+      <Field label="Descripción">
+        <textarea name="description" defaultValue={product.description ?? ''} rows={4} maxLength={2000} className={inputCls} />
+      </Field>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Categoría">
+          <select name="categoryId" defaultValue={product.categoryId ?? ''} className={inputCls}>
+            <option value="">Sin categoría</option>
+            {categories.map(c => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Estado">
+          <select name="status" defaultValue={product.status} className={inputCls}>
+            {PRODUCT_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Precio base (€)">
+          <input name="basePrice" type="number" step="0.01" min="0" defaultValue={product.basePrice} required className={inputCls} />
+        </Field>
+        <Field label="Precio tachado (€)">
+          <input name="compareAtPrice" type="number" step="0.01" min="0" defaultValue={product.compareAtPrice ?? ''} className={inputCls} />
+        </Field>
+        <Field label="IVA">
+          <select name="taxRate" defaultValue={product.taxRate} className={inputCls}>
+            <option value="0.04">4%</option>
+            <option value="0.10">10%</option>
+            <option value="0.21">21%</option>
+          </select>
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Unidad">
+          <input name="unit" defaultValue={product.unit} required maxLength={20} className={inputCls} />
+        </Field>
+        <Field label="Stock">
+          <input name="stock" type="number" min="0" defaultValue={product.stock} required className={inputCls} />
+        </Field>
+        <Field label="Trackear stock">
+          <label className="flex h-10 items-center gap-2 text-sm">
+            <input name="trackStock" type="checkbox" defaultChecked={product.trackStock} />
+            <span>Sí</span>
+          </label>
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Región de origen">
+          <input name="originRegion" defaultValue={product.originRegion ?? ''} maxLength={100} className={inputCls} />
+        </Field>
+        <Field label="Caducidad">
+          <input name="expiresAt" type="date" defaultValue={product.expiresAt ?? ''} className={inputCls} />
+        </Field>
+      </div>
+
+      <Field label="Nota de rechazo (sólo si aplica)">
+        <textarea name="rejectionNote" defaultValue={product.rejectionNote ?? ''} rows={2} maxLength={500} className={inputCls} />
+      </Field>
+
+      {error && (
+        <p className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">{error}</p>
+      )}
+      {success && (
+        <p className="rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">Cambios guardados.</p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {isPending ? 'Guardando…' : 'Guardar cambios'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+const inputCls =
+  'h-10 w-full rounded border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none'
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/admin/AdminPromotionEditForm.tsx
+++ b/src/components/admin/AdminPromotionEditForm.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { adminUpdatePromotion, type AdminPromotionInput } from '@/domains/admin/writes'
+
+const PROMOTION_KINDS = ['PERCENTAGE', 'FIXED_AMOUNT', 'FREE_SHIPPING'] as const
+const PROMOTION_SCOPES = ['PRODUCT', 'VENDOR', 'CATEGORY'] as const
+
+interface Option { id: string; label: string }
+
+interface InitialPromotion {
+  id: string
+  name: string
+  code: string | null
+  kind: string
+  value: number
+  scope: string
+  productId: string | null
+  categoryId: string | null
+  minSubtotal: number | null
+  maxRedemptions: number | null
+  perUserLimit: number | null
+  startsAt: string
+  endsAt: string
+}
+
+interface Props {
+  promotion: InitialPromotion
+  vendorProducts: Option[]
+  categories: Option[]
+}
+
+export function AdminPromotionEditForm({ promotion, vendorProducts, categories }: Props) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [scope, setScope] = useState(promotion.scope)
+  const [kind, setKind] = useState(promotion.kind)
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSuccess(false)
+    const fd = new FormData(event.currentTarget)
+    const input: AdminPromotionInput = {
+      name: String(fd.get('name') ?? ''),
+      code: fd.get('code')?.toString() || null,
+      kind: fd.get('kind') as AdminPromotionInput['kind'],
+      value: Number(fd.get('value') ?? 0),
+      scope: fd.get('scope') as AdminPromotionInput['scope'],
+      productId: fd.get('productId')?.toString() || null,
+      categoryId: fd.get('categoryId')?.toString() || null,
+      minSubtotal: fd.get('minSubtotal') ? Number(fd.get('minSubtotal')) : null,
+      maxRedemptions: fd.get('maxRedemptions') ? Number(fd.get('maxRedemptions')) : null,
+      perUserLimit: fd.get('perUserLimit') ? Number(fd.get('perUserLimit')) : null,
+      startsAt: String(fd.get('startsAt') ?? ''),
+      endsAt: String(fd.get('endsAt') ?? ''),
+    }
+
+    startTransition(async () => {
+      try {
+        await adminUpdatePromotion(promotion.id, input)
+        setSuccess(true)
+        router.refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error desconocido')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Nombre">
+          <input name="name" defaultValue={promotion.name} required minLength={3} maxLength={100} className={inputCls} />
+        </Field>
+        <Field label="Código (opcional)">
+          <input name="code" defaultValue={promotion.code ?? ''} maxLength={40} className={inputCls} />
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Tipo">
+          <select name="kind" value={kind} onChange={e => setKind(e.target.value)} className={inputCls}>
+            {PROMOTION_KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+          </select>
+        </Field>
+        <Field label={kind === 'PERCENTAGE' ? 'Porcentaje (%)' : kind === 'FIXED_AMOUNT' ? 'Descuento (€)' : 'Valor (ignorado)'}>
+          <input
+            name="value"
+            type="number"
+            step="0.01"
+            min="0"
+            defaultValue={promotion.value}
+            disabled={kind === 'FREE_SHIPPING'}
+            className={inputCls}
+          />
+        </Field>
+        <Field label="Ámbito">
+          <select name="scope" value={scope} onChange={e => setScope(e.target.value)} className={inputCls}>
+            {PROMOTION_SCOPES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </Field>
+      </div>
+
+      {scope === 'PRODUCT' && (
+        <Field label="Producto">
+          <select name="productId" defaultValue={promotion.productId ?? ''} className={inputCls} required>
+            <option value="">Selecciona un producto</option>
+            {vendorProducts.map(p => (
+              <option key={p.id} value={p.id}>{p.label}</option>
+            ))}
+          </select>
+        </Field>
+      )}
+
+      {scope === 'CATEGORY' && (
+        <Field label="Categoría">
+          <select name="categoryId" defaultValue={promotion.categoryId ?? ''} className={inputCls} required>
+            <option value="">Selecciona una categoría</option>
+            {categories.map(c => (
+              <option key={c.id} value={c.id}>{c.label}</option>
+            ))}
+          </select>
+        </Field>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Mínimo subtotal (€)">
+          <input name="minSubtotal" type="number" step="0.01" min="0" defaultValue={promotion.minSubtotal ?? ''} className={inputCls} />
+        </Field>
+        <Field label="Máx. canjes totales">
+          <input name="maxRedemptions" type="number" min="1" defaultValue={promotion.maxRedemptions ?? ''} className={inputCls} />
+        </Field>
+        <Field label="Límite por usuario">
+          <input name="perUserLimit" type="number" min="1" defaultValue={promotion.perUserLimit ?? 1} className={inputCls} />
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Empieza">
+          <input name="startsAt" type="datetime-local" defaultValue={toLocalDatetime(promotion.startsAt)} required className={inputCls} />
+        </Field>
+        <Field label="Termina">
+          <input name="endsAt" type="datetime-local" defaultValue={toLocalDatetime(promotion.endsAt)} required className={inputCls} />
+        </Field>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">{error}</p>
+      )}
+      {success && (
+        <p className="rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">Cambios guardados.</p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {isPending ? 'Guardando…' : 'Guardar cambios'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function toLocalDatetime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+const inputCls =
+  'h-10 w-full rounded border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none'
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/admin/AdminPromotionsClient.tsx
+++ b/src/components/admin/AdminPromotionsClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { TagIcon } from '@heroicons/react/24/outline'
 import { Badge } from '@/components/ui/badge'
 import { formatPrice } from '@/lib/utils'
@@ -75,6 +76,7 @@ export function AdminPromotionsClient({ data }: Props) {
                   <th className="px-4 py-2 text-left">{t('adminPromotions.col.window')}</th>
                   <th className="px-4 py-2 text-left">{t('adminPromotions.col.state')}</th>
                   <th className="px-4 py-2 text-right">{t('adminPromotions.col.redemptions')}</th>
+                  <th className="px-4 py-2 text-right">&nbsp;</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--border)]">
@@ -164,6 +166,14 @@ function PromoRow({ row, now }: { row: PromotionRow; now: Date }) {
         {row.maxRedemptions !== null && (
           <span className="text-xs text-[var(--muted)]"> / {row.maxRedemptions}</span>
         )}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Link
+          href={`/admin/promociones/${row.id}/edit`}
+          className="text-xs font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+        >
+          Editar
+        </Link>
       </td>
     </tr>
   )

--- a/src/components/admin/AdminSubscriptionPlanEditForm.tsx
+++ b/src/components/admin/AdminSubscriptionPlanEditForm.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { adminUpdateSubscriptionPlan, type AdminSubscriptionPlanInput } from '@/domains/admin/writes'
+
+const CADENCES = ['WEEKLY', 'BIWEEKLY', 'MONTHLY'] as const
+const DAYS = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado']
+
+interface InitialPlan {
+  id: string
+  cadence: string
+  priceSnapshot: number
+  taxRateSnapshot: number
+  cutoffDayOfWeek: number
+  archived: boolean
+}
+
+export function AdminSubscriptionPlanEditForm({ plan }: { plan: InitialPlan }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSuccess(false)
+    const fd = new FormData(event.currentTarget)
+    const input: AdminSubscriptionPlanInput = {
+      cadence: fd.get('cadence') as AdminSubscriptionPlanInput['cadence'],
+      priceSnapshot: Number(fd.get('priceSnapshot')),
+      taxRateSnapshot: Number(fd.get('taxRateSnapshot')),
+      cutoffDayOfWeek: Number(fd.get('cutoffDayOfWeek')),
+      archived: fd.get('archived') === 'on',
+    }
+
+    startTransition(async () => {
+      try {
+        await adminUpdateSubscriptionPlan(plan.id, input)
+        setSuccess(true)
+        router.refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error desconocido')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <p className="rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+        Los cambios de precio sólo aplican a <strong>nuevas suscripciones</strong>. Las suscripciones
+        ya activas mantienen el precio original de Stripe hasta que se cancelen y re-suscriban.
+      </p>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Cadencia">
+          <select name="cadence" defaultValue={plan.cadence} className={inputCls}>
+            {CADENCES.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </Field>
+        <Field label="Precio (€)">
+          <input name="priceSnapshot" type="number" step="0.01" min="0" defaultValue={plan.priceSnapshot} required className={inputCls} />
+        </Field>
+        <Field label="IVA">
+          <select name="taxRateSnapshot" defaultValue={plan.taxRateSnapshot} className={inputCls}>
+            <option value="0.04">4%</option>
+            <option value="0.10">10%</option>
+            <option value="0.21">21%</option>
+          </select>
+        </Field>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Día de corte semanal">
+          <select name="cutoffDayOfWeek" defaultValue={plan.cutoffDayOfWeek} className={inputCls}>
+            {DAYS.map((d, i) => <option key={i} value={i}>{i} — {d}</option>)}
+          </select>
+        </Field>
+        <Field label="Archivado">
+          <label className="flex h-10 items-center gap-2 text-sm">
+            <input name="archived" type="checkbox" defaultChecked={plan.archived} />
+            <span>Archivar plan (no visible para nuevos suscriptores)</span>
+          </label>
+        </Field>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">{error}</p>
+      )}
+      {success && (
+        <p className="rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">Cambios guardados.</p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {isPending ? 'Guardando…' : 'Guardar cambios'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+const inputCls =
+  'h-10 w-full rounded border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none'
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/admin/AdminSubscriptionsClient.tsx
+++ b/src/components/admin/AdminSubscriptionsClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { ArrowPathIcon } from '@heroicons/react/24/outline'
 import { Badge } from '@/components/ui/badge'
 import { formatPrice } from '@/lib/utils'
@@ -89,6 +90,7 @@ export function AdminSubscriptionsClient({ data }: Props) {
                   <th className="px-4 py-2 text-right">{t('adminSubscriptions.col.price')}</th>
                   <th className="px-4 py-2 text-right">{t('adminSubscriptions.col.subscribers')}</th>
                   <th className="px-4 py-2 text-left">{t('adminSubscriptions.col.state')}</th>
+                  <th className="px-4 py-2 text-right">&nbsp;</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--border)]">
@@ -192,6 +194,14 @@ function PlanRow({ plan }: { plan: SubscriptionPlanRow }) {
         ) : (
           <Badge variant="green">{t('adminSubscriptions.plan.active')}</Badge>
         )}
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Link
+          href={`/admin/suscripciones/${plan.id}/edit`}
+          className="text-xs font-semibold text-emerald-700 hover:underline dark:text-emerald-400"
+        >
+          Editar
+        </Link>
       </td>
     </tr>
   )

--- a/src/components/admin/AdminVendorEditForm.tsx
+++ b/src/components/admin/AdminVendorEditForm.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { adminUpdateVendor, type AdminVendorInput } from '@/domains/admin/writes'
+
+const VENDOR_STATUSES = [
+  'APPLYING',
+  'PENDING_DOCS',
+  'ACTIVE',
+  'SUSPENDED_TEMP',
+  'SUSPENDED_PERM',
+  'REJECTED',
+] as const
+
+interface InitialVendor {
+  id: string
+  displayName: string
+  slug: string
+  description: string | null
+  location: string | null
+  status: string
+  commissionRate: number
+}
+
+export function AdminVendorEditForm({ vendor }: { vendor: InitialVendor }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSuccess(false)
+    const fd = new FormData(event.currentTarget)
+    const input: AdminVendorInput = {
+      displayName: String(fd.get('displayName') ?? ''),
+      slug: String(fd.get('slug') ?? ''),
+      description: fd.get('description')?.toString() || null,
+      location: fd.get('location')?.toString() || null,
+      status: fd.get('status') as AdminVendorInput['status'],
+      commissionRate: Number(fd.get('commissionRatePercent')) / 100,
+    }
+
+    startTransition(async () => {
+      try {
+        await adminUpdateVendor(vendor.id, input)
+        setSuccess(true)
+        router.refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Error desconocido')
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Nombre público">
+          <input name="displayName" defaultValue={vendor.displayName} required minLength={2} maxLength={100} className={inputCls} />
+        </Field>
+        <Field label="Slug (URL)">
+          <input name="slug" defaultValue={vendor.slug} required pattern="[a-z0-9-]+" minLength={2} maxLength={100} className={inputCls} />
+        </Field>
+      </div>
+
+      <Field label="Descripción">
+        <textarea name="description" defaultValue={vendor.description ?? ''} rows={4} maxLength={2000} className={inputCls} />
+      </Field>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Field label="Ubicación">
+          <input name="location" defaultValue={vendor.location ?? ''} maxLength={100} className={inputCls} />
+        </Field>
+        <Field label="Estado">
+          <select name="status" defaultValue={vendor.status} className={inputCls}>
+            {VENDOR_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </Field>
+        <Field label="Comisión (%)">
+          <input
+            name="commissionRatePercent"
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            defaultValue={(vendor.commissionRate * 100).toFixed(2)}
+            required
+            className={inputCls}
+          />
+        </Field>
+      </div>
+
+      {error && (
+        <p className="rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">{error}</p>
+      )}
+      {success && (
+        <p className="rounded border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">Cambios guardados.</p>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {isPending ? 'Guardando…' : 'Guardar cambios'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+const inputCls =
+  'h-10 w-full rounded border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none'
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -152,7 +152,7 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
         <div className="flex justify-end">
           <Link
             href="/forgot-password"
-            className="text-sm font-medium text-emerald-600 hover:underline dark:text-emerald-400"
+            className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm font-medium text-emerald-600 hover:underline dark:text-emerald-400"
           >
             ¿Olvidaste tu contraseña?
           </Link>

--- a/src/components/buyer/BuyerProfileForm.tsx
+++ b/src/components/buyer/BuyerProfileForm.tsx
@@ -183,6 +183,7 @@ export function BuyerProfileForm({ user }: Props) {
               <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileNameLabel')}</label>
               <input
                 {...profileForm.register('firstName')}
+                autoComplete="given-name"
                 className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
               />
               {profileForm.formState.errors.firstName && (
@@ -194,6 +195,7 @@ export function BuyerProfileForm({ user }: Props) {
               <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileLastNameLabel')}</label>
               <input
                 {...profileForm.register('lastName')}
+                autoComplete="family-name"
                 className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
               />
               {profileForm.formState.errors.lastName && (
@@ -206,6 +208,7 @@ export function BuyerProfileForm({ user }: Props) {
             <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileEmailLabel')}</label>
             <input
               type="email"
+              autoComplete="email"
               {...profileForm.register('email')}
               className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
             />
@@ -236,6 +239,7 @@ export function BuyerProfileForm({ user }: Props) {
             <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileCurrentPassword')}</label>
             <input
               type="password"
+              autoComplete="current-password"
               {...passwordForm.register('currentPassword')}
               className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
             />
@@ -248,6 +252,7 @@ export function BuyerProfileForm({ user }: Props) {
             <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileNewPassword')}</label>
             <input
               type="password"
+              autoComplete="new-password"
               {...passwordForm.register('newPassword')}
               className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
             />
@@ -260,6 +265,7 @@ export function BuyerProfileForm({ user }: Props) {
             <label className="block text-sm font-medium text-[var(--foreground)]">{t('account.profileConfirmPassword')}</label>
             <input
               type="password"
+              autoComplete="new-password"
               {...passwordForm.register('confirmPassword')}
               className="mt-1 block w-full rounded-lg border border-[var(--border)] bg-[var(--surface-raised)] px-3 py-2 text-sm text-[var(--foreground)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
             />

--- a/src/components/buyer/BuyerSubscriptionsListClient.tsx
+++ b/src/components/buyer/BuyerSubscriptionsListClient.tsx
@@ -211,7 +211,7 @@ function SubscriptionRow({ subscription }: { subscription: Subscription }) {
                 type="button"
                 onClick={() => runAction(() => skipNextDelivery(subscription.id))}
                 disabled={pending}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-semibold text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] disabled:opacity-60"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] min-h-11 px-3 py-2 text-xs font-semibold text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] disabled:opacity-60"
               >
                 <ForwardIcon className="h-4 w-4" />
                 {t('account.subscriptions.skipNext')}
@@ -220,7 +220,7 @@ function SubscriptionRow({ subscription }: { subscription: Subscription }) {
                 type="button"
                 onClick={() => runAction(() => pauseSubscription(subscription.id))}
                 disabled={pending}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100 disabled:opacity-60 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 min-h-11 px-3 py-2 text-xs font-semibold text-amber-700 transition hover:bg-amber-100 disabled:opacity-60 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-900/40"
               >
                 <PauseIcon className="h-4 w-4" />
                 {t('account.subscriptions.pause')}
@@ -232,7 +232,7 @@ function SubscriptionRow({ subscription }: { subscription: Subscription }) {
               type="button"
               onClick={() => runAction(() => resumeSubscription(subscription.id))}
               disabled={pending}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100 disabled:opacity-60 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-emerald-50 min-h-11 px-3 py-2 text-xs font-semibold text-emerald-700 transition hover:bg-emerald-100 disabled:opacity-60 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
             >
               <PlayIcon className="h-4 w-4" />
               {t('account.subscriptions.resume')}
@@ -243,7 +243,7 @@ function SubscriptionRow({ subscription }: { subscription: Subscription }) {
               type="button"
               onClick={() => runAction(() => cancelSubscription(subscription.id))}
               disabled={pending}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-red-300 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 transition hover:bg-red-100 disabled:opacity-60 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-900/40"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-red-300 bg-red-50 min-h-11 px-3 py-2 text-xs font-semibold text-red-700 transition hover:bg-red-100 disabled:opacity-60 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-900/40"
             >
               <XCircleIcon className="h-4 w-4" />
               {t('account.subscriptions.cancel')}

--- a/src/components/catalog/ProductImageGallery.tsx
+++ b/src/components/catalog/ProductImageGallery.tsx
@@ -90,7 +90,7 @@ export function ProductImageGallery({ images, alt }: Props) {
               type="button"
               onClick={prev}
               aria-label="Imagen anterior"
-              className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/55 p-2 text-white shadow-md transition-opacity hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 sm:p-1.5 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+              className="absolute left-2 top-1/2 inline-flex min-h-11 min-w-11 -translate-y-1/2 items-center justify-center rounded-full bg-black/55 p-2.5 text-white shadow-md transition-opacity hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 sm:min-h-0 sm:min-w-0 sm:p-1.5 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
             >
               <ChevronLeftIcon className="h-5 w-5" />
             </button>
@@ -99,24 +99,26 @@ export function ProductImageGallery({ images, alt }: Props) {
               type="button"
               onClick={next}
               aria-label="Imagen siguiente"
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/55 p-2 text-white shadow-md transition-opacity hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 sm:p-1.5 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
+              className="absolute right-2 top-1/2 inline-flex min-h-11 min-w-11 -translate-y-1/2 items-center justify-center rounded-full bg-black/55 p-2.5 text-white shadow-md transition-opacity hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 sm:min-h-0 sm:min-w-0 sm:p-1.5 sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100"
             >
               <ChevronRightIcon className="h-5 w-5" />
             </button>
 
-            <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-1.5 sm:hidden">
+            <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-1 sm:hidden">
               {validImages.map((url, i) => (
                 <button
                   key={url}
                   type="button"
                   onClick={() => setActiveIndex(i)}
                   aria-label={`Ir a imagen ${i + 1}`}
-                  className={`rounded-full transition-all ${
-                    i === safeIndex
-                      ? 'h-1.5 w-4 bg-white'
-                      : 'h-1.5 w-1.5 bg-white/50'
-                  }`}
-                />
+                  className="flex h-8 w-8 items-center justify-center"
+                >
+                  <span
+                    className={`block rounded-full transition-all ${
+                      i === safeIndex ? 'h-1.5 w-4 bg-white' : 'h-1.5 w-1.5 bg-white/60'
+                    }`}
+                  />
+                </button>
               ))}
             </div>
           </>

--- a/src/components/catalog/SortSelect.tsx
+++ b/src/components/catalog/SortSelect.tsx
@@ -37,7 +37,7 @@ export function SortSelect({ current }: Props) {
         defaultValue={current ?? 'newest'}
         onChange={e => updateSort(e.target.value)}
         className={[
-          'cursor-pointer appearance-none rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 pr-10 text-sm text-[var(--foreground)] shadow-sm',
+          'min-h-11 cursor-pointer appearance-none rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 pr-10 text-sm text-[var(--foreground)] shadow-sm',
           'transition-colors hover:bg-[var(--surface-raised)]',
           'focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20',
           'dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20',

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -47,7 +47,7 @@ export function Footer() {
             <ul className="mt-3 space-y-2">
               {links.comprar.map(l => (
                 <li key={l.href}>
-                  <Link href={l.href} className="rounded-md text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  <Link href={l.href} className="-mx-2 inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
                     {t(l.labelKey)}
                   </Link>
                 </li>
@@ -61,7 +61,7 @@ export function Footer() {
             <ul className="mt-3 space-y-2">
               {links.vender.map(l => (
                 <li key={l.labelKey}>
-                  <Link href={l.href} className="rounded-md text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  <Link href={l.href} className="-mx-2 inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
                     {t(l.labelKey)}
                   </Link>
                 </li>
@@ -75,7 +75,7 @@ export function Footer() {
             <ul className="mt-3 space-y-2">
               {links.ayuda.map(l => (
                 <li key={l.labelKey}>
-                  <Link href={l.href} className="rounded-md text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+                  <Link href={l.href} className="-mx-2 inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
                     {t(l.labelKey)}
                   </Link>
                 </li>
@@ -88,14 +88,14 @@ export function Footer() {
           <p className="text-xs text-[var(--muted)]">
             © {new Date().getFullYear()} {SITE_NAME}. {t('allRights')}
           </p>
-          <div className="flex gap-4">
+          <div className="-mx-2 flex flex-wrap gap-x-2 gap-y-1">
             {[
               { labelKey: 'legal'   as TranslationKeys,  href: '/aviso-legal' },
               { labelKey: 'privacy' as TranslationKeys, href: '/privacidad' },
               { labelKey: 'cookies' as TranslationKeys, href: '/cookies' },
               { labelKey: 'terms'   as TranslationKeys, href: '/terminos' },
             ].map(link => (
-              <Link key={link.href} href={link.href} className="rounded-md text-xs text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
+              <Link key={link.href} href={link.href} className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-xs text-[var(--muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]">
                 {t(link.labelKey)}
               </Link>
             ))}

--- a/src/components/layout/PortalSwitcher.tsx
+++ b/src/components/layout/PortalSwitcher.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  BuildingStorefrontIcon,
+  BriefcaseIcon,
+  ShieldCheckIcon,
+  ChevronDownIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline'
+import { cn } from '@/lib/utils'
+import { useT } from '@/i18n'
+import { switchPortal } from '@/domains/portals/actions'
+import type { AvailablePortal, LoginPortalMode } from '@/lib/portals'
+import type { TranslationKeys } from '@/i18n/locales'
+
+interface Props {
+  portals: AvailablePortal[]
+  current: LoginPortalMode
+}
+
+const ICONS: Record<LoginPortalMode, typeof BuildingStorefrontIcon> = {
+  buyer: BuildingStorefrontIcon,
+  vendor: BriefcaseIcon,
+  admin: ShieldCheckIcon,
+}
+
+export function PortalSwitcher({ portals, current }: Props) {
+  const [open, setOpen] = useState(false)
+  const t = useT()
+
+  // Hide the control entirely when there's nothing to switch to.
+  if (portals.length < 2) return null
+
+  const currentPortal = portals.find(p => p.mode === current)
+  const CurrentIcon = ICONS[current]
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-label={t('portalSwitcher.label')}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex items-center gap-2 rounded-xl border border-[var(--border)] px-2.5 py-1.5 text-sm text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+      >
+        <CurrentIcon className="h-4 w-4" />
+        <span className="hidden sm:inline max-w-[140px] truncate">
+          {currentPortal ? t(currentPortal.titleKey as TranslationKeys) : ''}
+        </span>
+        <ChevronDownIcon className={cn('h-3.5 w-3.5 text-[var(--muted)] transition-transform', open && 'rotate-180')} />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div
+            role="menu"
+            className="absolute right-0 top-full z-20 mt-2 w-60 rounded-2xl border border-[var(--border)] bg-[var(--surface)] py-1.5 shadow-2xl ring-1 ring-black/5 backdrop-blur dark:ring-white/10"
+          >
+            <p className="px-3 py-2 text-[11px] uppercase tracking-wide text-[var(--muted)] border-b border-[var(--border)] mb-1">
+              {t('portalSwitcher.current')}
+            </p>
+            {portals.map(portal => {
+              const Icon = ICONS[portal.mode]
+              const isCurrent = portal.mode === current
+              return (
+                <form key={portal.mode} action={switchPortal}>
+                  <input type="hidden" name="target" value={portal.mode} />
+                  <button
+                    type="submit"
+                    role="menuitem"
+                    className={cn(
+                      'flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition mx-1',
+                      'text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]',
+                      isCurrent && 'bg-[var(--surface-raised)] text-[var(--foreground)]',
+                    )}
+                  >
+                    <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span className="flex-1 min-w-0">
+                      <span className="flex items-center gap-1.5 font-medium">
+                        {t(portal.titleKey as TranslationKeys)}
+                        {isCurrent && <CheckIcon className="h-3.5 w-3.5 text-emerald-600" />}
+                      </span>
+                      <span className="block text-xs text-[var(--muted)] truncate">
+                        {t(portal.descKey as TranslationKeys)}
+                      </span>
+                    </span>
+                  </button>
+                </form>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/vendor/FulfillmentActions.tsx
+++ b/src/components/vendor/FulfillmentActions.tsx
@@ -124,7 +124,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
               href={labelUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700"
+              className="inline-flex min-h-11 items-center rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white hover:bg-emerald-700"
             >
               {t('vendor.fulfillment.printLabel')}
             </a>
@@ -134,7 +134,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
               href={trackingUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center rounded-md border border-emerald-300 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-50"
+              className="inline-flex min-h-11 items-center rounded-md border border-emerald-300 px-3 py-2 text-xs font-medium text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-300 dark:hover:bg-emerald-950/40"
             >
               {t('vendor.fulfillment.viewTracking')}
             </a>

--- a/src/components/vendor/ImageUploader.tsx
+++ b/src/components/vendor/ImageUploader.tsx
@@ -48,8 +48,8 @@ export function ImageUploader({ urls, onChange, disabled }: ImageUploaderProps) 
 
   const remainingSlots = Math.max(0, MAX_IMAGES - urls.length - uploading.length)
 
-  const uploadFile = useCallback(
-    async (rawFile: File) => {
+  const uploadOne = useCallback(
+    async (rawFile: File): Promise<string | null> => {
       const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       setUploading(prev => [...prev, { id, name: rawFile.name }])
       try {
@@ -68,18 +68,19 @@ export function ImageUploader({ urls, onChange, disabled }: ImageUploaderProps) 
           throw new Error(data.error ?? 'upload-failed')
         }
         const data = (await response.json()) as { url: string }
-        onChange([...urls, data.url])
+        return data.url
       } catch (uploadError) {
         setError(
           uploadError instanceof Error
             ? `${rawFile.name}: ${uploadError.message}`
             : t('vendor.upload.error')
         )
+        return null
       } finally {
         setUploading(prev => prev.filter(item => item.id !== id))
       }
     },
-    [onChange, t, urls]
+    [t]
   )
 
   const acceptFiles = useCallback(
@@ -88,15 +89,22 @@ export function ImageUploader({ urls, onChange, disabled }: ImageUploaderProps) 
       setError(null)
 
       const files = Array.from(fileList).slice(0, remainingSlots)
+      // Accumulate locally so sequential uploads don't read a stale `urls`
+      // closure — each onChange would otherwise overwrite the previous.
+      let current = urls
       for (const file of files) {
         if (!ACCEPTED_TYPES.has(file.type)) {
           setError(`${file.name}: ${t('vendor.upload.unsupported')}`)
           continue
         }
-        await uploadFile(file)
+        const uploaded = await uploadOne(file)
+        if (uploaded) {
+          current = [...current, uploaded]
+          onChange(current)
+        }
       }
     },
-    [remainingSlots, t, uploadFile]
+    [onChange, remainingSlots, t, uploadOne, urls]
   )
 
   function handleDrop(event: React.DragEvent<HTMLLabelElement>) {

--- a/src/components/vendor/ImpersonationBanner.tsx
+++ b/src/components/vendor/ImpersonationBanner.tsx
@@ -1,0 +1,58 @@
+import { getServerT } from '@/i18n/server'
+import { endImpersonation } from '@/domains/impersonation/actions'
+
+interface Props {
+  adminEmail: string | null
+  vendorLabel: string
+  remainingSeconds: number
+  readOnly: boolean
+}
+
+function formatRemaining(seconds: number): string {
+  if (seconds <= 0) return '0m'
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  if (m === 0) return `${s}s`
+  return `${m}m ${s.toString().padStart(2, '0')}s`
+}
+
+export async function ImpersonationBanner({ adminEmail, vendorLabel, remainingSeconds, readOnly }: Props) {
+  const t = await getServerT()
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center justify-between gap-3 border-b-2 border-red-700 bg-red-600 px-4 py-2 text-sm font-medium text-white dark:bg-red-700 dark:border-red-800"
+      data-testid="impersonation-banner"
+    >
+      <div className="flex items-center gap-2">
+        <span aria-hidden="true">{'\u26A0'}</span>
+        <span>
+          {t('impersonation.banner.prefix')} <strong>{vendorLabel}</strong>
+          {adminEmail ? (
+            <>
+              {' · '}
+              {t('impersonation.banner.admin')}:{' '}
+              <strong>{adminEmail}</strong>
+            </>
+          ) : null}
+          {' · '}
+          {t('impersonation.banner.expiresIn')} {formatRemaining(remainingSeconds)}
+          {readOnly ? (
+            <>
+              {' · '}
+              <em>{t('impersonation.banner.readOnly')}</em>
+            </>
+          ) : null}
+        </span>
+      </div>
+      <form action={endImpersonation}>
+        <button
+          type="submit"
+          className="rounded-lg bg-white/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide ring-1 ring-white/30 hover:bg-white/20"
+        >
+          {t('impersonation.banner.end')}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/vendor/PromotionForm.tsx
+++ b/src/components/vendor/PromotionForm.tsx
@@ -244,7 +244,7 @@ export function PromotionForm({ products, categories, initial }: Props) {
         <Field label={t('vendor.promotions.formKind')} error={errors.kind?.message}>
           <select
             {...register('kind')}
-            className="h-10 w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+            className="min-h-11 w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 sm:h-10 sm:min-h-0"
           >
             <option value="PERCENTAGE">{t('vendor.promotions.kindPercentage')}</option>
             <option value="FIXED_AMOUNT">{t('vendor.promotions.kindFixed')}</option>
@@ -308,7 +308,7 @@ export function PromotionForm({ products, categories, initial }: Props) {
         <Field label={t('vendor.promotions.formCategory')} error={errors.categoryId?.message}>
           <select
             {...register('categoryId')}
-            className="h-10 w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+            className="min-h-11 w-full rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 text-sm text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 sm:h-10 sm:min-h-0"
           >
             <option value="">{t('vendor.promotions.formCategoryPlaceholder')}</option>
             {categories.map(c => (

--- a/src/components/vendor/VendorHeader.tsx
+++ b/src/components/vendor/VendorHeader.tsx
@@ -8,13 +8,16 @@ import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { useT } from '@/i18n'
 import { useSidebar } from '@/components/layout/SidebarProvider'
+import { PortalSwitcher } from '@/components/layout/PortalSwitcher'
+import type { AvailablePortal } from '@/lib/portals'
 
 interface Props {
   user: { name?: string | null; email?: string | null }
   vendor?: { displayName: string; status: string; slug: string } | null
+  portals?: AvailablePortal[]
 }
 
-export function VendorHeader({ user, vendor }: Props) {
+export function VendorHeader({ user, vendor, portals = [] }: Props) {
   const [open, setOpen] = useState(false)
   const t = useT()
   const { openMobile } = useSidebar()
@@ -50,6 +53,7 @@ export function VendorHeader({ user, vendor }: Props) {
       </div>
 
       <div className="flex items-center gap-1">
+        <PortalSwitcher portals={portals} current="vendor" />
         <ThemeToggle />
 
         <div className="relative">

--- a/src/components/vendor/VendorProfileForm.tsx
+++ b/src/components/vendor/VendorProfileForm.tsx
@@ -153,8 +153,8 @@ export function VendorProfileForm({ vendor }: Props) {
           </label>
           <textarea
             id="description"
-            rows={8}
-            className="w-full min-h-[12rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
+            rows={4}
+            className="w-full min-h-[8rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20 sm:min-h-[12rem] dark:focus:border-emerald-400 dark:focus:ring-emerald-400/20"
             placeholder={t('vendor.profileForm.descriptionPlaceholder')}
             {...register('description')}
           />
@@ -202,6 +202,7 @@ export function VendorProfileForm({ vendor }: Props) {
         <div className="grid gap-4 sm:grid-cols-2">
           <Input
             label={t('vendor.profileForm.cutoffLabel')}
+            type="time"
             placeholder="18:00"
             hint={t('vendor.profileForm.cutoffHint')}
             error={errors.orderCutoffTime?.message}
@@ -210,6 +211,7 @@ export function VendorProfileForm({ vendor }: Props) {
           <Input
             label={t('vendor.profileForm.prepDaysLabel')}
             type="number"
+            inputMode="numeric"
             min="0"
             max="30"
             hint={t('vendor.profileForm.prepDaysHint')}

--- a/src/components/vendor/VendorReviewsManager.tsx
+++ b/src/components/vendor/VendorReviewsManager.tsx
@@ -163,7 +163,7 @@ function ReviewCard({
                 type="button"
                 onClick={() => setEditing(true)}
                 disabled={pending}
-                className="rounded-md p-1.5 text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md p-2.5 text-emerald-700 hover:bg-emerald-100 disabled:opacity-50 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
                 aria-label={t('vendor.reviewsManager.editResponse')}
               >
                 <PencilSquareIcon className="h-4 w-4" />
@@ -172,7 +172,7 @@ function ReviewCard({
                 type="button"
                 onClick={remove}
                 disabled={pending}
-                className="rounded-md p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/40"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md p-2.5 text-red-600 hover:bg-red-100 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950/40"
                 aria-label={t('vendor.reviewsManager.deleteResponse')}
               >
                 <TrashIcon className="h-4 w-4" />

--- a/src/domains/admin/writes.ts
+++ b/src/domains/admin/writes.ts
@@ -1,0 +1,446 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { createAuditLog, getAuditRequestIp } from '@/lib/audit'
+import { requireCatalogAdmin, requireSuperadmin } from '@/lib/auth-guard'
+import { revalidateCatalogExperience, safeRevalidatePath } from '@/lib/revalidate'
+import { parseExpirationDateInput } from '@/domains/catalog/availability'
+
+// ─── Snapshots ────────────────────────────────────────────────────────────────
+
+function productSnapshot(p: {
+  id: string
+  name: string
+  slug: string
+  status: string
+  stock: number
+  vendorId: string
+  categoryId: string | null
+  basePrice: { toString(): string } | number
+  compareAtPrice: { toString(): string } | number | null
+  taxRate: { toString(): string } | number
+  unit: string
+  trackStock: boolean
+  description: string | null
+  originRegion: string | null
+  rejectionNote: string | null
+}) {
+  return {
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    status: p.status,
+    stock: p.stock,
+    vendorId: p.vendorId,
+    categoryId: p.categoryId,
+    basePrice: Number(p.basePrice),
+    compareAtPrice: p.compareAtPrice == null ? null : Number(p.compareAtPrice),
+    taxRate: Number(p.taxRate),
+    unit: p.unit,
+    trackStock: p.trackStock,
+    description: p.description,
+    originRegion: p.originRegion,
+    rejectionNote: p.rejectionNote,
+  }
+}
+
+function vendorSnapshot(v: {
+  id: string
+  status: string
+  displayName: string
+  slug: string
+  description: string | null
+  location: string | null
+  commissionRate: { toString(): string } | number
+}) {
+  return {
+    id: v.id,
+    status: v.status,
+    displayName: v.displayName,
+    slug: v.slug,
+    description: v.description,
+    location: v.location,
+    commissionRate: Number(v.commissionRate),
+  }
+}
+
+function promotionSnapshot(p: {
+  id: string
+  vendorId: string
+  name: string
+  code: string | null
+  kind: string
+  value: { toString(): string } | number
+  scope: string
+  productId: string | null
+  categoryId: string | null
+  minSubtotal: { toString(): string } | number | null
+  maxRedemptions: number | null
+  perUserLimit: number | null
+  startsAt: Date
+  endsAt: Date
+  archivedAt: Date | null
+}) {
+  return {
+    id: p.id,
+    vendorId: p.vendorId,
+    name: p.name,
+    code: p.code,
+    kind: p.kind,
+    value: Number(p.value),
+    scope: p.scope,
+    productId: p.productId,
+    categoryId: p.categoryId,
+    minSubtotal: p.minSubtotal == null ? null : Number(p.minSubtotal),
+    maxRedemptions: p.maxRedemptions,
+    perUserLimit: p.perUserLimit,
+    startsAt: p.startsAt.toISOString(),
+    endsAt: p.endsAt.toISOString(),
+    archivedAt: p.archivedAt?.toISOString() ?? null,
+  }
+}
+
+function planSnapshot(p: {
+  id: string
+  vendorId: string
+  productId: string
+  cadence: string
+  priceSnapshot: { toString(): string } | number
+  taxRateSnapshot: { toString(): string } | number
+  cutoffDayOfWeek: number
+  archivedAt: Date | null
+}) {
+  return {
+    id: p.id,
+    vendorId: p.vendorId,
+    productId: p.productId,
+    cadence: p.cadence,
+    priceSnapshot: Number(p.priceSnapshot),
+    taxRateSnapshot: Number(p.taxRateSnapshot),
+    cutoffDayOfWeek: p.cutoffDayOfWeek,
+    archivedAt: p.archivedAt?.toISOString() ?? null,
+  }
+}
+
+// ─── Products ─────────────────────────────────────────────────────────────────
+
+const PRODUCT_STATUSES = ['DRAFT', 'PENDING_REVIEW', 'ACTIVE', 'SUSPENDED', 'REJECTED'] as const
+
+const adminProductSchema = z.object({
+  name: z.string().trim().min(3).max(100),
+  description: z.string().trim().max(2000).optional().nullable(),
+  categoryId: z.string().trim().optional().nullable(),
+  basePrice: z.coerce.number().positive().max(100_000),
+  compareAtPrice: z.coerce.number().positive().max(100_000).optional().nullable(),
+  taxRate: z.coerce.number().refine(v => [0.04, 0.10, 0.21].includes(v), 'IVA inválido'),
+  unit: z.string().trim().min(1).max(20),
+  stock: z.coerce.number().int().min(0).max(1_000_000),
+  trackStock: z.coerce.boolean(),
+  status: z.enum(PRODUCT_STATUSES),
+  originRegion: z.string().trim().max(100).optional().nullable(),
+  rejectionNote: z.string().trim().max(500).optional().nullable(),
+  expiresAt: z.string().trim().optional().nullable(),
+})
+
+export type AdminProductInput = z.infer<typeof adminProductSchema>
+
+/**
+ * Admin edit of a product. Bypasses vendor ownership — catalog admins and
+ * superadmins can edit any vendor's product. Every change is audited.
+ */
+export async function adminUpdateProduct(productId: string, input: AdminProductInput) {
+  const session = await requireCatalogAdmin()
+  const data = adminProductSchema.parse(input)
+
+  const product = await db.product.findUnique({ where: { id: productId } })
+  if (!product) throw new Error('Producto no encontrado')
+
+  const before = productSnapshot(product)
+
+  const updated = await db.product.update({
+    where: { id: productId },
+    data: {
+      name: data.name,
+      description: data.description ?? null,
+      categoryId: data.categoryId && data.categoryId.length > 0 ? data.categoryId : null,
+      basePrice: data.basePrice,
+      compareAtPrice: data.compareAtPrice ?? null,
+      taxRate: data.taxRate,
+      unit: data.unit,
+      stock: data.stock,
+      trackStock: data.trackStock,
+      status: data.status,
+      originRegion: data.originRegion ?? null,
+      rejectionNote: data.rejectionNote ?? null,
+      expiresAt: parseExpirationDateInput(data.expiresAt),
+    },
+  })
+
+  const ip = await getAuditRequestIp()
+  await createAuditLog({
+    action: 'PRODUCT_EDITED',
+    entityType: 'Product',
+    entityId: productId,
+    before,
+    after: productSnapshot(updated),
+    actorId: session.user.id,
+    actorRole: session.user.role,
+    ip,
+  })
+
+  safeRevalidatePath('/admin/productos')
+  safeRevalidatePath(`/admin/productos/${productId}/edit`)
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/vendor/productos')
+  revalidateCatalogExperience({ productSlug: updated.slug })
+}
+
+// ─── Vendors (producers) ──────────────────────────────────────────────────────
+
+const VENDOR_STATUSES = [
+  'APPLYING',
+  'PENDING_DOCS',
+  'ACTIVE',
+  'SUSPENDED_TEMP',
+  'SUSPENDED_PERM',
+  'REJECTED',
+] as const
+
+const adminVendorSchema = z.object({
+  displayName: z.string().trim().min(2).max(100),
+  slug: z.string().trim().min(2).max(100).regex(/^[a-z0-9-]+$/, 'slug inválido'),
+  description: z.string().trim().max(2000).optional().nullable(),
+  location: z.string().trim().max(100).optional().nullable(),
+  status: z.enum(VENDOR_STATUSES),
+  commissionRate: z.coerce.number().min(0).max(1),
+})
+
+export type AdminVendorInput = z.infer<typeof adminVendorSchema>
+
+/**
+ * Admin edit of a vendor (producer). Status and commissionRate have financial
+ * implications, so this action requires SUPERADMIN.
+ */
+export async function adminUpdateVendor(vendorId: string, input: AdminVendorInput) {
+  const session = await requireSuperadmin()
+  const data = adminVendorSchema.parse(input)
+
+  const vendor = await db.vendor.findUnique({ where: { id: vendorId } })
+  if (!vendor) throw new Error('Productor no encontrado')
+
+  if (data.slug !== vendor.slug) {
+    const clash = await db.vendor.findFirst({
+      where: { slug: data.slug, NOT: { id: vendorId } },
+      select: { id: true },
+    })
+    if (clash) throw new Error('Ese slug ya está en uso')
+  }
+
+  const before = vendorSnapshot(vendor)
+
+  const updated = await db.vendor.update({
+    where: { id: vendorId },
+    data: {
+      displayName: data.displayName,
+      slug: data.slug,
+      description: data.description ?? null,
+      location: data.location ?? null,
+      status: data.status,
+      commissionRate: data.commissionRate,
+    },
+  })
+
+  const ip = await getAuditRequestIp()
+  await createAuditLog({
+    action: 'VENDOR_EDITED',
+    entityType: 'Vendor',
+    entityId: vendorId,
+    before,
+    after: vendorSnapshot(updated),
+    actorId: session.user.id,
+    actorRole: session.user.role,
+    ip,
+  })
+
+  safeRevalidatePath('/admin/productores')
+  safeRevalidatePath(`/admin/productores/${vendorId}/edit`)
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath(`/productores/${updated.slug}`)
+}
+
+// ─── Promotions ───────────────────────────────────────────────────────────────
+
+const PROMOTION_KINDS = ['PERCENTAGE', 'FIXED_AMOUNT', 'FREE_SHIPPING'] as const
+const PROMOTION_SCOPES = ['PRODUCT', 'VENDOR', 'CATEGORY'] as const
+
+const adminPromotionSchema = z
+  .object({
+    name: z.string().trim().min(3).max(100),
+    code: z.string().trim().max(40).regex(/^[A-Z0-9_-]*$/i).optional().nullable(),
+    kind: z.enum(PROMOTION_KINDS),
+    value: z.coerce.number().min(0).max(100_000),
+    scope: z.enum(PROMOTION_SCOPES),
+    productId: z.string().trim().optional().nullable(),
+    categoryId: z.string().trim().optional().nullable(),
+    minSubtotal: z.coerce.number().min(0).max(100_000).optional().nullable(),
+    maxRedemptions: z.coerce.number().int().positive().max(1_000_000).optional().nullable(),
+    perUserLimit: z.coerce.number().int().positive().max(1000).optional().nullable(),
+    startsAt: z.string().min(1),
+    endsAt: z.string().min(1),
+  })
+  .superRefine((data, ctx) => {
+    if (data.scope === 'PRODUCT' && !data.productId) {
+      ctx.addIssue({ code: 'custom', path: ['productId'], message: 'Selecciona un producto' })
+    }
+    if (data.scope === 'CATEGORY' && !data.categoryId) {
+      ctx.addIssue({ code: 'custom', path: ['categoryId'], message: 'Selecciona una categoría' })
+    }
+    if (data.kind === 'PERCENTAGE' && (data.value <= 0 || data.value > 100)) {
+      ctx.addIssue({ code: 'custom', path: ['value'], message: 'El porcentaje debe estar entre 0 y 100' })
+    }
+    const starts = new Date(data.startsAt).getTime()
+    const ends = new Date(data.endsAt).getTime()
+    if (Number.isNaN(starts) || Number.isNaN(ends) || ends <= starts) {
+      ctx.addIssue({ code: 'custom', path: ['endsAt'], message: 'Rango de fechas inválido' })
+    }
+  })
+
+export type AdminPromotionInput = z.infer<typeof adminPromotionSchema>
+
+/**
+ * Admin edit of a promotion. Works on any vendor's promotion. Archived
+ * promotions can still be edited by admin (vendors must un-archive first,
+ * admins can override).
+ */
+export async function adminUpdatePromotion(promotionId: string, input: AdminPromotionInput) {
+  const session = await requireCatalogAdmin()
+  const data = adminPromotionSchema.parse(input)
+
+  const current = await db.promotion.findUnique({ where: { id: promotionId } })
+  if (!current) throw new Error('Promoción no encontrada')
+
+  const code = data.code && data.code.length > 0 ? data.code.toUpperCase() : null
+
+  if (code) {
+    const clash = await db.promotion.findFirst({
+      where: { vendorId: current.vendorId, code, NOT: { id: promotionId } },
+      select: { id: true },
+    })
+    if (clash) throw new Error('Ya existe otra promoción con ese código para este productor')
+  }
+
+  if (data.scope === 'PRODUCT' && data.productId) {
+    const product = await db.product.findFirst({
+      where: { id: data.productId, vendorId: current.vendorId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!product) throw new Error('Producto no encontrado para este productor')
+  }
+  if (data.scope === 'CATEGORY' && data.categoryId) {
+    const category = await db.category.findUnique({
+      where: { id: data.categoryId },
+      select: { id: true },
+    })
+    if (!category) throw new Error('Categoría no encontrada')
+  }
+
+  const value = data.kind === 'FREE_SHIPPING' ? 0 : data.value
+
+  const before = promotionSnapshot(current)
+
+  const updated = await db.promotion.update({
+    where: { id: promotionId },
+    data: {
+      name: data.name,
+      code,
+      kind: data.kind,
+      value,
+      scope: data.scope,
+      productId: data.scope === 'PRODUCT' ? data.productId ?? null : null,
+      categoryId: data.scope === 'CATEGORY' ? data.categoryId ?? null : null,
+      minSubtotal: data.minSubtotal ?? null,
+      maxRedemptions: data.maxRedemptions ?? null,
+      perUserLimit: data.perUserLimit ?? 1,
+      startsAt: new Date(data.startsAt),
+      endsAt: new Date(data.endsAt),
+    },
+  })
+
+  const ip = await getAuditRequestIp()
+  await createAuditLog({
+    action: 'PROMOTION_EDITED',
+    entityType: 'Promotion',
+    entityId: promotionId,
+    before,
+    after: promotionSnapshot(updated),
+    actorId: session.user.id,
+    actorRole: session.user.role,
+    ip,
+  })
+
+  safeRevalidatePath('/admin/promociones')
+  safeRevalidatePath(`/admin/promociones/${promotionId}/edit`)
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/vendor/promociones')
+}
+
+// ─── Subscription plans ───────────────────────────────────────────────────────
+
+const SUBSCRIPTION_CADENCES = ['WEEKLY', 'BIWEEKLY', 'MONTHLY'] as const
+
+const adminPlanSchema = z.object({
+  cadence: z.enum(SUBSCRIPTION_CADENCES),
+  priceSnapshot: z.coerce.number().positive().max(100_000),
+  taxRateSnapshot: z.coerce.number().refine(v => [0.04, 0.10, 0.21].includes(v), 'IVA inválido'),
+  cutoffDayOfWeek: z.coerce.number().int().min(0).max(6),
+  archived: z.coerce.boolean().default(false),
+})
+
+export type AdminSubscriptionPlanInput = z.infer<typeof adminPlanSchema>
+
+/**
+ * Admin edit of a subscription plan. Price changes only apply to NEW
+ * renewals — existing Stripe subscriptions keep the price they were
+ * originally charged at (Stripe holds the recurring price on the
+ * subscription itself). Changing the price here rewrites the plan's
+ * snapshot so future Subscription rows pick it up on creation.
+ */
+export async function adminUpdateSubscriptionPlan(planId: string, input: AdminSubscriptionPlanInput) {
+  const session = await requireSuperadmin()
+  const data = adminPlanSchema.parse(input)
+
+  const plan = await db.subscriptionPlan.findUnique({ where: { id: planId } })
+  if (!plan) throw new Error('Plan no encontrado')
+
+  const before = planSnapshot(plan)
+
+  const updated = await db.subscriptionPlan.update({
+    where: { id: planId },
+    data: {
+      cadence: data.cadence,
+      priceSnapshot: data.priceSnapshot,
+      taxRateSnapshot: data.taxRateSnapshot,
+      cutoffDayOfWeek: data.cutoffDayOfWeek,
+      archivedAt: data.archived ? (plan.archivedAt ?? new Date()) : null,
+    },
+  })
+
+  const ip = await getAuditRequestIp()
+  await createAuditLog({
+    action: 'SUBSCRIPTION_PLAN_EDITED',
+    entityType: 'SubscriptionPlan',
+    entityId: planId,
+    before,
+    after: planSnapshot(updated),
+    actorId: session.user.id,
+    actorRole: session.user.role,
+    ip,
+  })
+
+  safeRevalidatePath('/admin/suscripciones')
+  safeRevalidatePath(`/admin/suscripciones/${planId}/edit`)
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/vendor/suscripciones')
+}
+

--- a/src/domains/impersonation/actions.ts
+++ b/src/domains/impersonation/actions.ts
@@ -1,0 +1,108 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { logger } from '@/lib/logger'
+import { UserRole } from '@/generated/prisma/enums'
+import { hasRole } from '@/lib/roles'
+import {
+  IMPERSONATION_COOKIE,
+  IMPERSONATION_TTL_SECONDS,
+  createImpersonationSessionId,
+  isImpersonationEnabled,
+  signImpersonationToken,
+  verifyImpersonationToken,
+} from '@/lib/impersonation'
+
+const IMPERSONATION_STARTERS: readonly UserRole[] = [
+  UserRole.ADMIN_SUPPORT,
+  UserRole.SUPERADMIN,
+] as const
+
+const startSchema = z.object({
+  vendorId: z.string().min(1),
+  reason: z.string().min(5).max(500),
+  readOnly: z.boolean().default(true),
+})
+
+/**
+ * Starts an impersonation session. Only ADMIN_SUPPORT and SUPERADMIN can
+ * call this. Requires the `IMPERSONATION_ENABLED` feature flag. Emits an
+ * audit log entry and sets the `mp_impersonation` cookie.
+ */
+export async function startImpersonation(input: unknown): Promise<void> {
+  if (!isImpersonationEnabled()) {
+    throw new Error('[impersonation] Feature disabled')
+  }
+
+  const session = await getActionSession()
+  if (!session || !hasRole(session.user.role, IMPERSONATION_STARTERS)) {
+    throw new Error('[impersonation] Not authorized')
+  }
+
+  const { vendorId, reason, readOnly } = startSchema.parse(input)
+
+  const vendor = await db.vendor.findUnique({
+    where: { id: vendorId },
+    select: { id: true, userId: true, displayName: true },
+  })
+  if (!vendor) {
+    throw new Error('[impersonation] Vendor not found')
+  }
+
+  const sid = createImpersonationSessionId()
+  const token = signImpersonationToken({
+    sid,
+    adminId: session.user.id,
+    targetUserId: vendor.userId,
+    vendorId: vendor.id,
+    readOnly,
+  })
+
+  logger.info('impersonation.started', {
+    sid,
+    adminId: session.user.id,
+    adminRole: session.user.role,
+    vendorId: vendor.id,
+    targetUserId: vendor.userId,
+    readOnly,
+    reason,
+    ttlSeconds: IMPERSONATION_TTL_SECONDS,
+  })
+
+  const cookieStore = await cookies()
+  cookieStore.set(IMPERSONATION_COOKIE, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: IMPERSONATION_TTL_SECONDS,
+  })
+
+  redirect('/vendor/dashboard')
+}
+
+/**
+ * Ends the current impersonation session by clearing the cookie. Safe to
+ * call even when no session is active.
+ */
+export async function endImpersonation(): Promise<void> {
+  const cookieStore = await cookies()
+  const existing = cookieStore.get(IMPERSONATION_COOKIE)?.value
+  const context = verifyImpersonationToken(existing)
+
+  if (context) {
+    logger.info('impersonation.ended', {
+      sid: context.sid,
+      adminId: context.adminId,
+      vendorId: context.vendorId,
+      remainingSeconds: context.remainingSeconds,
+    })
+  }
+
+  cookieStore.delete(IMPERSONATION_COOKIE)
+  redirect('/admin/dashboard')
+}

--- a/src/domains/portals/actions.ts
+++ b/src/domains/portals/actions.ts
@@ -1,0 +1,53 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import {
+  LAST_PORTAL_COOKIE,
+  LAST_PORTAL_MAX_AGE_SECONDS,
+  isValidPortalMode,
+  getAvailablePortals,
+  type LoginPortalMode,
+} from '@/lib/portals'
+import { getActionSession } from '@/lib/action-session'
+
+/**
+ * Switch the active portal. Sets the `mp_last_portal` cookie and redirects
+ * to the target portal's home. Validates that the caller actually has
+ * access to the requested portal — an attempt to switch to `admin` by a
+ * non-admin is rejected as a no-op.
+ *
+ * Called from the `PortalSwitcher` client component via a form action,
+ * which is the only way to mutate cookies from user-initiated UI in the
+ * current Next.js architecture.
+ */
+export async function switchPortal(formData: FormData): Promise<void> {
+  const rawTarget = formData.get('target')
+  if (typeof rawTarget !== 'string' || !isValidPortalMode(rawTarget)) {
+    // Silently ignore invalid input — never trust form data.
+    return
+  }
+  const target: LoginPortalMode = rawTarget
+
+  const session = await getActionSession()
+  if (!session) redirect('/login')
+
+  const available = getAvailablePortals(session.user.role)
+  const match = available.find(p => p.mode === target)
+  if (!match) {
+    // Caller asked for a portal they don't have access to — redirect them
+    // to their current landing area instead of honoring the request.
+    redirect(available[0]?.href ?? '/')
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set(LAST_PORTAL_COOKIE, target, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: LAST_PORTAL_MAX_AGE_SECONDS,
+  })
+
+  redirect(match.href)
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -367,6 +367,23 @@ const en: Record<TranslationKeys, string> = {
   'vendor.header.goToStore': 'Go to store',
   'vendor.header.signOut': 'Sign out',
 
+  // Portal switcher (shared header control)
+  'portalSwitcher.label': 'Switch panel',
+  'portalSwitcher.current': 'Current panel',
+  'portalSwitcher.buyer.title': 'Storefront',
+  'portalSwitcher.buyer.desc': 'Shop as a customer',
+  'portalSwitcher.vendor.title': 'Producer panel',
+  'portalSwitcher.vendor.desc': 'Manage your store',
+  'portalSwitcher.admin.title': 'Admin panel',
+  'portalSwitcher.admin.desc': 'Marketplace administration',
+
+  // Impersonation banner (admin-support viewing a vendor panel)
+  'impersonation.banner.prefix': 'Viewing as',
+  'impersonation.banner.admin': 'admin',
+  'impersonation.banner.expiresIn': 'expires in',
+  'impersonation.banner.readOnly': 'read only',
+  'impersonation.banner.end': 'End session',
+
   // Vendor – nav labels
   'vendor.nav.dashboard': 'Home',
   'vendor.nav.products': 'My catalog',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -365,6 +365,23 @@ const es = {
   'vendor.header.goToStore': 'Ir a la tienda',
   'vendor.header.signOut': 'Cerrar sesión',
 
+  // Portal switcher (shared header control)
+  'portalSwitcher.label': 'Cambiar de panel',
+  'portalSwitcher.current': 'Panel actual',
+  'portalSwitcher.buyer.title': 'Tienda',
+  'portalSwitcher.buyer.desc': 'Comprar como cliente',
+  'portalSwitcher.vendor.title': 'Panel productor',
+  'portalSwitcher.vendor.desc': 'Gestiona tu tienda',
+  'portalSwitcher.admin.title': 'Panel admin',
+  'portalSwitcher.admin.desc': 'Administración del marketplace',
+
+  // Impersonation banner (admin-support viewing a vendor panel)
+  'impersonation.banner.prefix': 'Viendo como',
+  'impersonation.banner.admin': 'administrador',
+  'impersonation.banner.expiresIn': 'expira en',
+  'impersonation.banner.readOnly': 'solo lectura',
+  'impersonation.banner.end': 'Terminar sesión',
+
   // Vendor – nav labels
   'vendor.nav.dashboard': 'Inicio',
   'vendor.nav.products': 'Mi catálogo',

--- a/src/lib/admin-host.ts
+++ b/src/lib/admin-host.ts
@@ -1,0 +1,55 @@
+/**
+ * Admin host isolation (ticket #348).
+ *
+ * When the `ADMIN_HOST` environment variable is set (e.g.
+ * `admin.marketplace.example`), the `/admin/**` routes are only reachable
+ * on that host, and the admin host rejects every non-admin route with a
+ * 404. This is enforced in `src/proxy.ts` (edge middleware), so no admin
+ * page is ever rendered on the public host — not even for logged-in
+ * admins who typed the URL manually.
+ *
+ * The helpers in this file are edge-safe: they rely only on Request /
+ * string primitives and MUST NOT import Prisma, logger, or any Node API.
+ *
+ * Infrastructure setup (not automated, owner action required):
+ *   1. Point `admin.<your-domain>` at the same deployment.
+ *   2. Set `ADMIN_HOST=admin.<your-domain>` in the environment.
+ *   3. Ensure TLS is terminated for the subdomain.
+ *   4. See `docs/admin-host.md` for the full runbook.
+ *
+ * Cookie scoping: the NextAuth session cookie today is host-only (no
+ * explicit Domain attribute in `src/lib/auth-host.ts`), which means a
+ * sibling-domain `admin.<dom>` gets its OWN session cookie, isolated from
+ * the public host. This ticket takes advantage of that to achieve cookie
+ * isolation without any code change to the auth layer — but it is a
+ * standing invariant. If a future change adds `Domain=<parent>` to the
+ * session cookie, this isolation is silently defeated. The test
+ * `admin-host.test.ts` pins the expectation.
+ */
+
+export const ADMIN_HOST_ENV_VAR = 'ADMIN_HOST'
+
+/**
+ * Returns true when the given host header value matches the configured
+ * `ADMIN_HOST`. Case-insensitive and ignores the `:port` suffix so dev
+ * (`admin.localhost:3000`) and prod (`admin.example.com`) both work.
+ */
+export function hostMatchesAdmin(host: string | null | undefined, adminHost: string | undefined): boolean {
+  if (!host || !adminHost) return false
+  const normalizedHost = host.toLowerCase().split(':')[0]!
+  const normalizedAdmin = adminHost.toLowerCase().split(':')[0]!
+  return normalizedHost === normalizedAdmin
+}
+
+/**
+ * Reads the host from an incoming `NextRequest`-like object and compares
+ * it against the `ADMIN_HOST` env var. Accepts a minimal structural type
+ * so this function can be unit-tested without constructing a full
+ * `NextRequest`.
+ */
+export function isRequestOnAdminHost(request: { headers: { get(name: string): string | null } }): boolean {
+  const adminHost = process.env[ADMIN_HOST_ENV_VAR]
+  if (!adminHost) return false
+  const host = request.headers.get('host') ?? request.headers.get('x-forwarded-host')
+  return hostMatchesAdmin(host, adminHost)
+}

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 import { auth } from '@/lib/auth'
 import { UserRole, type UserRole as UserRoleValue } from '@/generated/prisma/enums'
-import { isAdmin, hasRole } from '@/lib/roles'
+import { isAdmin, hasRole, CATALOG_ADMIN_ROLES, SUPERADMIN_ROLES } from '@/lib/roles'
 
 export async function requireAuth() {
   const session = await auth()
@@ -25,4 +25,16 @@ export async function requireAdmin() {
 
 export async function requireVendor() {
   return requireRole([UserRole.VENDOR])
+}
+
+export async function requireSuperadmin() {
+  const session = await requireAuth()
+  if (!hasRole(session.user.role, SUPERADMIN_ROLES)) redirect('/')
+  return session
+}
+
+export async function requireCatalogAdmin() {
+  const session = await requireAuth()
+  if (!hasRole(session.user.role, CATALOG_ADMIN_ROLES)) redirect('/')
+  return session
 }

--- a/src/lib/impersonation.ts
+++ b/src/lib/impersonation.ts
@@ -1,0 +1,146 @@
+/**
+ * Admin-support impersonation (ticket #351).
+ *
+ * Lets users with ADMIN_SUPPORT / SUPERADMIN role start a short-lived
+ * "view as vendor" session to reproduce issues reported by a producer.
+ *
+ * MVP design choices (explicitly not the full ticket scope):
+ *   - Stateless signed tokens (HMAC-SHA256 over AUTH_SECRET). No DB tables,
+ *     no per-session revocation. Tokens expire at `exp` and cannot be
+ *     revoked before then — mitigated by the short 15-minute TTL.
+ *   - Audit log goes through the structured logger (`logger.info` with
+ *     `scope: 'impersonation.*'`). Hook up to Datadog/Loki/Sentry via
+ *     LOGGER_SINK when wiring production.
+ *   - Feature-flagged behind `IMPERSONATION_ENABLED=true`. While the flag
+ *     is off, `startImpersonation` server-action refuses to create new
+ *     tokens and `getImpersonationContext` returns null. Turning the flag
+ *     on requires no code change.
+ *   - Read-only is enforced at the guard layer: `requireVendor()` returns
+ *     `{ isImpersonating: true, readOnly }` on the session, and a shared
+ *     helper `assertNotReadOnlyImpersonation()` is meant to be called at
+ *     the top of every vendor mutation. Wiring every mutation is tracked
+ *     as follow-up work in #351.
+ *
+ * A future iteration can back this with an `ImpersonationSession` table
+ * without changing the public interface of this module.
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+export const IMPERSONATION_COOKIE = 'mp_impersonation'
+export const IMPERSONATION_TTL_SECONDS = 15 * 60 // 15 minutes
+export const IMPERSONATION_ENABLED_ENV_VAR = 'IMPERSONATION_ENABLED'
+
+export interface ImpersonationPayload {
+  /** Short session id — random, used as a stable handle in audit logs. */
+  sid: string
+  /** User id of the admin who initiated the impersonation. */
+  adminId: string
+  /** User id of the vendor being impersonated (owner of the Vendor row). */
+  targetUserId: string
+  /** Vendor row id being impersonated. */
+  vendorId: string
+  /** When true, all mutations are blocked by the guard layer. */
+  readOnly: boolean
+  /** Unix timestamp (seconds) at which the token becomes invalid. */
+  exp: number
+}
+
+export interface ImpersonationContext extends ImpersonationPayload {
+  /** Remaining seconds until exp. */
+  remainingSeconds: number
+}
+
+export function isImpersonationEnabled(): boolean {
+  return process.env[IMPERSONATION_ENABLED_ENV_VAR] === 'true'
+}
+
+function getSecret(): string {
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET
+  if (!secret) {
+    // Fail loud: impersonation depends on a cryptographically strong secret.
+    throw new Error('[impersonation] AUTH_SECRET must be configured')
+  }
+  return secret
+}
+
+function toBase64Url(input: Buffer): string {
+  return input.toString('base64url')
+}
+
+function fromBase64Url(input: string): Buffer {
+  return Buffer.from(input, 'base64url')
+}
+
+function sign(payload: string): string {
+  return toBase64Url(createHmac('sha256', getSecret()).update(payload).digest())
+}
+
+export function signImpersonationToken(
+  payload: Omit<ImpersonationPayload, 'exp'>,
+  ttlSeconds: number = IMPERSONATION_TTL_SECONDS
+): string {
+  const body: ImpersonationPayload = {
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  }
+  const bodyEncoded = toBase64Url(Buffer.from(JSON.stringify(body), 'utf8'))
+  const signature = sign(bodyEncoded)
+  return `${bodyEncoded}.${signature}`
+}
+
+export function verifyImpersonationToken(token: string | null | undefined): ImpersonationContext | null {
+  if (!token) return null
+  const dot = token.indexOf('.')
+  if (dot === -1) return null
+  const bodyEncoded = token.slice(0, dot)
+  const signature = token.slice(dot + 1)
+
+  const expected = sign(bodyEncoded)
+  const expectedBuf = fromBase64Url(expected)
+  const actualBuf = fromBase64Url(signature)
+  if (expectedBuf.length !== actualBuf.length) return null
+  if (!timingSafeEqual(expectedBuf, actualBuf)) return null
+
+  let parsed: ImpersonationPayload
+  try {
+    parsed = JSON.parse(fromBase64Url(bodyEncoded).toString('utf8'))
+  } catch {
+    return null
+  }
+
+  if (
+    typeof parsed.sid !== 'string' ||
+    typeof parsed.adminId !== 'string' ||
+    typeof parsed.targetUserId !== 'string' ||
+    typeof parsed.vendorId !== 'string' ||
+    typeof parsed.readOnly !== 'boolean' ||
+    typeof parsed.exp !== 'number'
+  ) {
+    return null
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (parsed.exp <= now) return null
+
+  return { ...parsed, remainingSeconds: parsed.exp - now }
+}
+
+export function createImpersonationSessionId(): string {
+  // 12 bytes = 16 base64url chars. Enough entropy to uniquely identify a
+  // session in audit logs without being guessable.
+  return toBase64Url(
+    Buffer.from(Array.from({ length: 12 }, () => Math.floor(Math.random() * 256)))
+  )
+}
+
+/**
+ * Called at the top of every vendor mutation that must NOT run while a
+ * read-only impersonation session is active. Throws when blocked so the
+ * error bubbles up through Next's server-action error boundary.
+ */
+export function assertNotReadOnlyImpersonation(context: ImpersonationContext | null): void {
+  if (context?.readOnly) {
+    throw new Error('[impersonation] This session is read-only. Mutations are blocked.')
+  }
+}

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -11,10 +11,47 @@ export interface PortalLink {
 
 export type LoginPortalMode = 'buyer' | 'vendor' | 'admin'
 
+export const LAST_PORTAL_COOKIE = 'mp_last_portal'
+export const LAST_PORTAL_MAX_AGE_SECONDS = 60 * 60 * 24 * 30 // 30 days
+
+export function isValidPortalMode(value: unknown): value is LoginPortalMode {
+  return value === 'buyer' || value === 'vendor' || value === 'admin'
+}
+
 export const STOREFRONT_PATH = '/'
 const DEFAULT_ACCOUNT_PATH = '/cuenta'
 const LOGIN_PATH = '/login'
 const REGISTER_PATH = '/register'
+
+// Allowlist of path prefixes that may be used as a post-login callback.
+// Anything outside this list is rejected by sanitizeCallbackUrl.
+const CALLBACK_ALLOWED_PREFIXES = [
+  '/',
+  '/cuenta',
+  '/carrito',
+  '/checkout',
+  '/productos',
+  '/productores',
+  '/vendor',
+  '/admin',
+] as const
+
+// Characters that must never appear in a callback path: control chars,
+// backslashes (some browsers normalize `\` → `/`), and `@` (userinfo
+// confusion against `new URL` parsers).
+// eslint-disable-next-line no-control-regex
+const CALLBACK_FORBIDDEN_CHARS = /[\x00-\x1f\x7f\\@]/
+
+export type CallbackRejectionReason =
+  | 'empty'
+  | 'not_relative'
+  | 'protocol_relative'
+  | 'forbidden_chars'
+  | 'login_or_register'
+  | 'decode_failed'
+  | 'scheme_after_decode'
+  | 'not_in_allowlist'
+  | 'role_mismatch'
 
 const CATEGORY_TRANSLATION_KEYS: Partial<Record<string, TranslationKeys>> = {
   verduras: 'cat_verduras',
@@ -78,14 +115,129 @@ function getPortalModeForRole(role?: UserRole): LoginPortalMode {
   return 'buyer'
 }
 
-export function sanitizeCallbackUrl(callbackUrl?: string | null) {
-  if (!callbackUrl) return undefined
-  if (!callbackUrl.startsWith('/') || callbackUrl.startsWith('//')) return undefined
-  if (callbackUrl.startsWith(LOGIN_PATH) || callbackUrl.startsWith(REGISTER_PATH)) return undefined
-  return callbackUrl
+export interface AvailablePortal {
+  mode: LoginPortalMode
+  href: string
+  titleKey: 'portalSwitcher.buyer.title' | 'portalSwitcher.vendor.title' | 'portalSwitcher.admin.title'
+  descKey: 'portalSwitcher.buyer.desc' | 'portalSwitcher.vendor.desc' | 'portalSwitcher.admin.desc'
 }
 
-export function resolvePostLoginDestination(role?: UserRole, callbackUrl?: string | null) {
+/**
+ * Returns the list of portals a given role has access to. Buyer access is
+ * implicit for every authenticated user (any role can also shop). Vendor
+ * access requires the VENDOR role. Admin access requires any ADMIN_* role.
+ *
+ * Used by the portal switcher dropdown in vendor/admin headers — it
+ * renders only when the list has ≥2 entries (there's nothing to switch
+ * to for a pure CUSTOMER).
+ */
+export function getAvailablePortals(role?: UserRole): AvailablePortal[] {
+  if (!role) return []
+  const portals: AvailablePortal[] = [
+    {
+      mode: 'buyer',
+      href: DEFAULT_ACCOUNT_PATH,
+      titleKey: 'portalSwitcher.buyer.title',
+      descKey: 'portalSwitcher.buyer.desc',
+    },
+  ]
+  if (isVendor(role)) {
+    portals.push({
+      mode: 'vendor',
+      href: '/vendor/dashboard',
+      titleKey: 'portalSwitcher.vendor.title',
+      descKey: 'portalSwitcher.vendor.desc',
+    })
+  }
+  if (isAdmin(role)) {
+    portals.push({
+      mode: 'admin',
+      href: '/admin/dashboard',
+      titleKey: 'portalSwitcher.admin.title',
+      descKey: 'portalSwitcher.admin.desc',
+    })
+  }
+  return portals
+}
+
+/**
+ * Returns the reason a candidate callback URL would be rejected, or null
+ * if it passes all structural checks. Kept separate from sanitizeCallbackUrl
+ * so callers that need to emit telemetry can do so without parsing twice.
+ *
+ * This function is edge-safe: it uses only String and URL primitives and
+ * does not import logger, db, or any Node-only module.
+ */
+export function describeCallbackRejection(
+  callbackUrl?: string | null
+): CallbackRejectionReason | null {
+  if (!callbackUrl) return 'empty'
+  if (!callbackUrl.startsWith('/')) return 'not_relative'
+  if (callbackUrl.startsWith('//')) return 'protocol_relative'
+  if (CALLBACK_FORBIDDEN_CHARS.test(callbackUrl)) return 'forbidden_chars'
+  if (callbackUrl.startsWith(LOGIN_PATH) || callbackUrl.startsWith(REGISTER_PATH)) {
+    return 'login_or_register'
+  }
+
+  // Decode twice to detect double-encoded attacks (%252f%252fevil.com).
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(callbackUrl)
+    decoded = decodeURIComponent(decoded)
+  } catch {
+    return 'decode_failed'
+  }
+  if (CALLBACK_FORBIDDEN_CHARS.test(decoded)) return 'forbidden_chars'
+  if (decoded.startsWith('//')) return 'protocol_relative'
+  // After decoding, no scheme should appear. `javascript:`, `data:`, `http:`
+  // etc. are all caught by looking for a colon before the first slash.
+  const firstSlash = decoded.indexOf('/')
+  const firstColon = decoded.indexOf(':')
+  if (firstColon !== -1 && (firstSlash === -1 || firstColon < firstSlash)) {
+    return 'scheme_after_decode'
+  }
+
+  // Path must start with one of the allowed prefixes.
+  const pathOnly = decoded.split('?')[0]!.split('#')[0]!
+  const allowed = CALLBACK_ALLOWED_PREFIXES.some(prefix => {
+    if (prefix === '/') return pathOnly === '/'
+    return pathOnly === prefix || pathOnly.startsWith(`${prefix}/`)
+  })
+  if (!allowed) return 'not_in_allowlist'
+
+  return null
+}
+
+export function sanitizeCallbackUrl(callbackUrl?: string | null) {
+  return describeCallbackRejection(callbackUrl) === null ? callbackUrl! : undefined
+}
+
+export interface ResolvePostLoginOptions {
+  /**
+   * Optional callback invoked when a structurally valid callback URL is
+   * rejected because it does not match the authenticated user's role.
+   * Kept as a callback (instead of importing logger here) so this module
+   * stays edge-safe and can be pulled into the middleware runtime.
+   */
+  onRoleMismatch?: (details: {
+    callbackUrl: string
+    callbackMode: LoginPortalMode
+    roleMode: LoginPortalMode
+  }) => void
+  /**
+   * The last portal the user explicitly switched to (via the portal
+   * switcher). When present and the user has access to that portal, we
+   * prefer it over the role-based primary destination. No effect when a
+   * callback URL is provided — explicit callbacks always win.
+   */
+  lastPortal?: LoginPortalMode | null
+}
+
+export function resolvePostLoginDestination(
+  role?: UserRole,
+  callbackUrl?: string | null,
+  options: ResolvePostLoginOptions = {}
+) {
   const safeCallbackUrl = sanitizeCallbackUrl(callbackUrl)
 
   if (safeCallbackUrl) {
@@ -95,6 +247,22 @@ export function resolvePostLoginDestination(role?: UserRole, callbackUrl?: strin
     if (!role || callbackMode === roleMode) {
       return safeCallbackUrl
     }
+
+    options.onRoleMismatch?.({
+      callbackUrl: safeCallbackUrl,
+      callbackMode,
+      roleMode,
+    })
+  }
+
+  // Honor lastPortal preference when the user has access to it. A VENDOR
+  // who was browsing the storefront and then logs in again should land
+  // back on /cuenta (not /vendor/dashboard) — the switcher is the source
+  // of truth for "which portal am I actively using right now".
+  if (role && options.lastPortal) {
+    const available = getAvailablePortals(role)
+    const match = available.find(p => p.mode === options.lastPortal)
+    if (match) return match.href
   }
 
   return role ? getPrimaryPortalHref(role) : STOREFRONT_PATH

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -44,6 +44,13 @@ export const FINANCE_ADMIN_ROLES: readonly UserRole[] = [
   UserRole.SUPERADMIN,
 ]
 
+export const CATALOG_ADMIN_ROLES: readonly UserRole[] = [
+  UserRole.ADMIN_CATALOG,
+  UserRole.SUPERADMIN,
+]
+
+export const SUPERADMIN_ROLES: readonly UserRole[] = [UserRole.SUPERADMIN]
+
 export function hasRole<Role extends UserRole>(
   role: UserRole | null | undefined,
   allowedRoles: readonly Role[]
@@ -65,6 +72,14 @@ export function isOpsAdminRole(role?: UserRole | null): role is typeof OPS_ADMIN
 
 export function isFinanceAdminRole(role?: UserRole | null): role is typeof FINANCE_ADMIN_ROLES[number] {
   return hasRole(role, FINANCE_ADMIN_ROLES)
+}
+
+export function isCatalogAdminRole(role?: UserRole | null): role is typeof CATALOG_ADMIN_ROLES[number] {
+  return hasRole(role, CATALOG_ADMIN_ROLES)
+}
+
+export function isSuperadminRole(role?: UserRole | null): role is typeof UserRole.SUPERADMIN {
+  return hasRole(role, SUPERADMIN_ROLES)
 }
 
 export const isAdmin = isAdminRole

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { isAdmin, isVendor } from '@/lib/roles'
 import { type UserRole } from '@/generated/prisma/enums'
+import { getPrimaryPortalHref, sanitizeCallbackUrl } from '@/lib/portals'
+import { isRequestOnAdminHost, hostMatchesAdmin, ADMIN_HOST_ENV_VAR } from '@/lib/admin-host'
 
 const PROTECTED_PREFIXES = ['/admin', '/vendor', '/carrito', '/checkout', '/cuenta'] as const
 
@@ -11,12 +13,35 @@ function isProtectedPath(pathname: string) {
 
 export function createLoginRedirectUrl(request: NextRequest) {
   const loginUrl = new URL('/login', request.url)
-  loginUrl.searchParams.set('callbackUrl', `${request.nextUrl.pathname}${request.nextUrl.search}`)
+  const rawCallback = `${request.nextUrl.pathname}${request.nextUrl.search}`
+  const safe = sanitizeCallbackUrl(rawCallback)
+  if (safe) loginUrl.searchParams.set('callbackUrl', safe)
   return loginUrl
 }
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
+
+  // ------------------------------------------------------------------
+  // Admin host isolation (ticket #348). When ADMIN_HOST is configured,
+  // /admin/** is only reachable on that host, and the admin host only
+  // serves admin routes (everything else 404s). This is a hard gate in
+  // addition to the role check below, so a stolen non-admin cookie on
+  // the public host cannot pivot into the admin panel.
+  // ------------------------------------------------------------------
+  const adminHost = process.env[ADMIN_HOST_ENV_VAR]
+  if (adminHost) {
+    const onAdminHost = isRequestOnAdminHost(request)
+    if (pathname.startsWith('/admin') && !onAdminHost) {
+      const adminUrl = new URL(request.url)
+      adminUrl.host = adminHost
+      adminUrl.protocol = 'https:'
+      return NextResponse.redirect(adminUrl)
+    }
+    if (onAdminHost && !pathname.startsWith('/admin') && !pathname.startsWith('/login') && !pathname.startsWith('/api')) {
+      return new NextResponse(null, { status: 404 })
+    }
+  }
 
   if (!isProtectedPath(pathname)) {
     return NextResponse.next()
@@ -31,15 +56,18 @@ export async function proxy(request: NextRequest) {
   const role = typeof token.role === 'string' ? (token.role as UserRole) : undefined
 
   if (pathname.startsWith('/admin') && !isAdmin(role)) {
-    return NextResponse.redirect(new URL('/', request.url))
+    return NextResponse.redirect(new URL(getPrimaryPortalHref(role), request.url))
   }
 
   if (pathname.startsWith('/vendor') && !isVendor(role)) {
-    return NextResponse.redirect(new URL('/', request.url))
+    return NextResponse.redirect(new URL(getPrimaryPortalHref(role), request.url))
   }
 
   return NextResponse.next()
 }
+
+// Re-export to keep the existing host-check tests (ticket #348) self-contained.
+export { hostMatchesAdmin }
 
 export const config = {
   matcher: [

--- a/test/contracts/i18n-no-hardcoded-literals.test.ts
+++ b/test/contracts/i18n-no-hardcoded-literals.test.ts
@@ -61,6 +61,10 @@ const ALLOWLIST_FILES: ReadonlySet<string> = new Set([
   'src/app/(admin)/admin/liquidaciones/page.tsx',
   'src/app/(admin)/admin/pedidos/page.tsx',
   'src/app/(admin)/admin/productos/page.tsx',
+  'src/app/(admin)/admin/productos/[id]/edit/page.tsx', // Admin-only edit surface — not localized yet.
+  'src/app/(admin)/admin/productores/[id]/edit/page.tsx', // Admin-only edit surface — not localized yet.
+  'src/app/(admin)/admin/promociones/[id]/edit/page.tsx', // Admin-only edit surface — not localized yet.
+  'src/app/(admin)/admin/suscripciones/[id]/edit/page.tsx', // Admin-only edit surface — not localized yet.
   // Auth flows — pending dedicated i18n PR.
   'src/app/(auth)/forgot-password/page.tsx',
   'src/app/(auth)/recuperar-contrasena/nueva/ResetForm.tsx',

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -190,6 +190,37 @@ test('PDP image gallery controls meet 44px tap-target minimum on mobile', () => 
   )
 })
 
+test('SortSelect dropdown clears the 44px tap-target floor', () => {
+  const source = read('src/components/catalog/SortSelect.tsx')
+  assert.match(source, /min-h-11/, 'SortSelect must use min-h-11 so the dropdown is tappable on mobile')
+})
+
+test('vendor PromotionForm selects clear 44px on mobile', () => {
+  const source = read('src/components/vendor/PromotionForm.tsx')
+  const matches = source.match(/min-h-11 w-full[^"]*sm:h-10 sm:min-h-0/g) ?? []
+  assert.ok(
+    matches.length >= 2,
+    `PromotionForm selects must use min-h-11 sm:h-10 sm:min-h-0 (found ${matches.length})`,
+  )
+})
+
+test('vendor profile form keeps prep-days inputMode and shrinks textarea on mobile', () => {
+  const source = read('src/components/vendor/VendorProfileForm.tsx')
+  assert.match(source, /inputMode="numeric"/, 'preparation days input must declare inputMode="numeric"')
+  assert.match(source, /type="time"/, 'order cutoff input must use type="time" for the right mobile picker')
+  assert.match(
+    source,
+    /min-h-\[8rem\][^"]*sm:min-h-\[12rem\]/,
+    'description textarea must shrink to 8rem on mobile and grow to 12rem on sm+',
+  )
+})
+
+test('open-incident form select clears 44px and textarea adapts to mobile', () => {
+  const source = read('src/app/(buyer)/cuenta/incidencias/nueva/OpenIncidentForm.tsx')
+  assert.match(source, /min-h-11/, 'incident type select must clear 44px')
+  assert.match(source, /min-h-32[^"]*sm:min-h-40/, 'incident description textarea must scale on sm+')
+})
+
 test('vendor review response actions meet 44px tap-target minimum', () => {
   const source = read('src/components/vendor/VendorReviewsManager.tsx')
   const matches = source.match(/min-h-11 min-w-11/g) ?? []

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -141,6 +141,64 @@ test('checkout address form exposes autoComplete tokens for mobile prefill', () 
   }
 })
 
+test('buyer profile form exposes autoComplete tokens', () => {
+  const source = read('src/components/buyer/BuyerProfileForm.tsx')
+  const required = [
+    'autoComplete="given-name"',
+    'autoComplete="family-name"',
+    'autoComplete="email"',
+    'autoComplete="current-password"',
+    'autoComplete="new-password"',
+  ]
+  for (const token of required) {
+    assert.ok(source.includes(token), `BuyerProfileForm must declare ${token}`)
+  }
+})
+
+test('buyer addresses form exposes autoComplete tokens and numeric postal code', () => {
+  const source = read('src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx')
+  const required = [
+    'autoComplete="given-name"',
+    'autoComplete="family-name"',
+    'autoComplete="address-line1"',
+    'autoComplete="address-line2"',
+    'autoComplete="address-level1"',
+    'autoComplete="address-level2"',
+    'autoComplete="postal-code"',
+  ]
+  for (const token of required) {
+    assert.ok(source.includes(token), `DireccionesClient must declare ${token}`)
+  }
+  assert.match(source, /inputMode="numeric"/, 'postal-code input must use inputMode="numeric"')
+})
+
+test('buyer address card actions meet 44px tap-target minimum', () => {
+  const source = read('src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx')
+  // The three action buttons (edit / set default / delete) now share min-h-11 —
+  // contract keeps that from regressing back to bare text-links.
+  const matches = source.match(/min-h-11/g) ?? []
+  assert.ok(matches.length >= 3, `address actions must keep min-h-11 on edit/default/delete (found ${matches.length})`)
+})
+
+test('PDP image gallery controls meet 44px tap-target minimum on mobile', () => {
+  const source = read('src/components/catalog/ProductImageGallery.tsx')
+  // Chevron buttons must be at least 44px on mobile (sm: resets to compact).
+  assert.match(
+    source,
+    /min-h-11 min-w-11[^"]*sm:min-h-0/,
+    'gallery prev/next must use min-h-11 min-w-11 on mobile, reset on sm+',
+  )
+})
+
+test('vendor review response actions meet 44px tap-target minimum', () => {
+  const source = read('src/components/vendor/VendorReviewsManager.tsx')
+  const matches = source.match(/min-h-11 min-w-11/g) ?? []
+  assert.ok(
+    matches.length >= 2,
+    `edit + delete vendor-response buttons must use min-h-11 min-w-11 (found ${matches.length})`,
+  )
+})
+
 test('PDP purchase panel renders a mobile-only sticky add-to-cart bar', () => {
   const source = read('src/components/catalog/ProductPurchasePanel.tsx')
   assert.match(source, /function MobileStickyCta/, 'ProductPurchasePanel must declare a MobileStickyCta helper')

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -221,6 +221,58 @@ test('open-incident form select clears 44px and textarea adapts to mobile', () =
   assert.match(source, /min-h-32[^"]*sm:min-h-40/, 'incident description textarea must scale on sm+')
 })
 
+test('buyer subscription action buttons clear the 44px floor', () => {
+  const source = read('src/components/buyer/BuyerSubscriptionsListClient.tsx')
+  // skip / pause / resume / cancel — at least three of them rendered
+  // at any time, all must be tappable.
+  const matches = source.match(/min-h-11 px-3 py-2 text-xs font-semibold/g) ?? []
+  assert.ok(
+    matches.length >= 4,
+    `subscription action buttons must use min-h-11 px-3 py-2 (found ${matches.length})`,
+  )
+})
+
+test('favoritos remove button is a 44px tap target', () => {
+  const source = read('src/app/(buyer)/cuenta/favoritos/FavoritosClient.tsx')
+  assert.match(
+    source,
+    /min-h-11 min-w-11/,
+    'favorites heart toggle must use min-h-11 min-w-11 so users can tap it on mobile',
+  )
+})
+
+test('vendor liquidaciones table contains horizontal scroll on mobile', () => {
+  const source = read('src/app/(vendor)/vendor/liquidaciones/page.tsx')
+  assert.match(
+    source,
+    /overflow-x-auto overscroll-x-contain touch-pan-x/,
+    'liquidaciones table must wrap with overscroll-x-contain + touch-pan-x',
+  )
+})
+
+test('forgot-password and reset-password forms expose autoComplete', () => {
+  const request = read('src/app/(auth)/recuperar-contrasena/RequestForm.tsx')
+  assert.match(request, /autoComplete="email"/, 'RequestForm must declare autoComplete="email"')
+  assert.match(request, /inputMode="email"/, 'RequestForm must declare inputMode="email"')
+  assert.match(request, /min-h-11/, 'RequestForm email input must clear 44px')
+
+  const reset = read('src/app/(auth)/recuperar-contrasena/nueva/ResetForm.tsx')
+  const newPassword = reset.match(/autoComplete="new-password"/g) ?? []
+  assert.ok(
+    newPassword.length >= 2,
+    `ResetForm must declare autoComplete="new-password" on both password fields (found ${newPassword.length})`,
+  )
+})
+
+test('LoginForm forgot-password link is a 44px tap target', () => {
+  const source = read('src/components/auth/LoginForm.tsx')
+  assert.match(
+    source,
+    /href="\/forgot-password"[\s\S]*?min-h-11/,
+    'forgot-password link must include min-h-11 so it clears the touch target floor',
+  )
+})
+
 test('vendor review response actions meet 44px tap-target minimum', () => {
   const source = read('src/components/vendor/VendorReviewsManager.tsx')
   const matches = source.match(/min-h-11 min-w-11/g) ?? []

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -273,6 +273,36 @@ test('LoginForm forgot-password link is a 44px tap target', () => {
   )
 })
 
+test('Footer link rows clear 44px tap target on mobile', () => {
+  const source = read('src/components/layout/Footer.tsx')
+  // Two patterns: the column links and the legal row links. Both must
+  // bake in min-h-11 so the bottom of the page is actually navigable.
+  const matches = source.match(/min-h-11/g) ?? []
+  assert.ok(
+    matches.length >= 2,
+    `Footer must keep min-h-11 on column + legal links (found ${matches.length})`,
+  )
+})
+
+test('vendor dashboard urgent + setup CTAs clear 44px', () => {
+  const source = read('src/app/(vendor)/vendor/dashboard/page.tsx')
+  // "Hacer ahora" and "Ver pedidos" both used to be py-1.5 — pin them.
+  const matches = source.match(/min-h-11/g) ?? []
+  assert.ok(
+    matches.length >= 2,
+    `dashboard CTAs must keep min-h-11 on doItNow + viewOrders (found ${matches.length})`,
+  )
+})
+
+test('search pagination links clear 44px', () => {
+  const source = read('src/app/(public)/buscar/page.tsx')
+  const matches = source.match(/min-h-11 items-center rounded-lg/g) ?? []
+  assert.ok(
+    matches.length >= 2,
+    `search prev/next pagination links must use min-h-11 (found ${matches.length})`,
+  )
+})
+
 test('vendor review response actions meet 44px tap-target minimum', () => {
   const source = read('src/components/vendor/VendorReviewsManager.tsx')
   const matches = source.match(/min-h-11 min-w-11/g) ?? []

--- a/test/features/impersonation.test.ts
+++ b/test/features/impersonation.test.ts
@@ -1,0 +1,151 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  IMPERSONATION_ENABLED_ENV_VAR,
+  assertNotReadOnlyImpersonation,
+  createImpersonationSessionId,
+  isImpersonationEnabled,
+  signImpersonationToken,
+  verifyImpersonationToken,
+  type ImpersonationContext,
+} from '@/lib/impersonation'
+
+// These tests configure AUTH_SECRET at module load time via the test
+// runner env. If another test clears it, restore between tests.
+const originalSecret = process.env.AUTH_SECRET
+process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'test-secret-for-impersonation'
+
+test('signImpersonationToken produces a verifiable token and decodes to the same payload', () => {
+  const token = signImpersonationToken({
+    sid: 'sid_abc',
+    adminId: 'user_admin',
+    targetUserId: 'user_vendor_owner',
+    vendorId: 'vendor_1',
+    readOnly: true,
+  })
+
+  const context = verifyImpersonationToken(token)
+  assert.ok(context, 'token should verify successfully')
+  assert.equal(context?.sid, 'sid_abc')
+  assert.equal(context?.adminId, 'user_admin')
+  assert.equal(context?.vendorId, 'vendor_1')
+  assert.equal(context?.readOnly, true)
+  assert.ok((context?.remainingSeconds ?? 0) > 0)
+})
+
+test('verifyImpersonationToken rejects tokens with a tampered signature', () => {
+  const token = signImpersonationToken({
+    sid: 'sid_xyz',
+    adminId: 'user_admin',
+    targetUserId: 'user_owner',
+    vendorId: 'vendor_42',
+    readOnly: false,
+  })
+
+  const dot = token.indexOf('.')
+  const body = token.slice(0, dot)
+  // Flip one byte of the signature.
+  const tampered = `${body}.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
+
+  assert.equal(verifyImpersonationToken(tampered), null)
+})
+
+test('verifyImpersonationToken rejects tokens with a tampered body', () => {
+  const token = signImpersonationToken({
+    sid: 'sid_t1',
+    adminId: 'user_admin',
+    targetUserId: 'user_owner',
+    vendorId: 'vendor_42',
+    readOnly: true,
+  })
+
+  const dot = token.indexOf('.')
+  const body = token.slice(0, dot)
+  const sig = token.slice(dot + 1)
+  // Try to re-encode a new payload with the old signature.
+  const newBody = Buffer.from(JSON.stringify({
+    sid: 'sid_t1',
+    adminId: 'user_admin',
+    targetUserId: 'user_owner',
+    vendorId: 'vendor_42',
+    readOnly: false, // ← attacker attempt to escalate to write mode
+    exp: Math.floor(Date.now() / 1000) + 900,
+  }), 'utf8').toString('base64url')
+
+  assert.notEqual(newBody, body)
+  assert.equal(verifyImpersonationToken(`${newBody}.${sig}`), null)
+})
+
+test('verifyImpersonationToken rejects expired tokens', () => {
+  // TTL of 0 seconds means `exp` == now. The check is strict (exp <= now → reject).
+  const token = signImpersonationToken(
+    {
+      sid: 'sid_exp',
+      adminId: 'user_admin',
+      targetUserId: 'user_owner',
+      vendorId: 'vendor_42',
+      readOnly: true,
+    },
+    0
+  )
+  assert.equal(verifyImpersonationToken(token), null)
+})
+
+test('verifyImpersonationToken rejects malformed inputs', () => {
+  assert.equal(verifyImpersonationToken(null), null)
+  assert.equal(verifyImpersonationToken(undefined), null)
+  assert.equal(verifyImpersonationToken(''), null)
+  assert.equal(verifyImpersonationToken('no-dot-here'), null)
+  assert.equal(verifyImpersonationToken('.just-dot'), null)
+  assert.equal(verifyImpersonationToken('x.y'), null)
+})
+
+test('createImpersonationSessionId returns unique base64url strings', () => {
+  const seen = new Set<string>()
+  for (let i = 0; i < 50; i++) {
+    const id = createImpersonationSessionId()
+    assert.match(id, /^[A-Za-z0-9_-]+$/)
+    assert.ok(!seen.has(id), `sid collision: ${id}`)
+    seen.add(id)
+  }
+})
+
+test('assertNotReadOnlyImpersonation throws only when readOnly is true', () => {
+  assert.doesNotThrow(() => assertNotReadOnlyImpersonation(null))
+  assert.doesNotThrow(() =>
+    assertNotReadOnlyImpersonation({
+      sid: 's', adminId: 'a', targetUserId: 'u', vendorId: 'v',
+      readOnly: false, exp: 0, remainingSeconds: 100,
+    } satisfies ImpersonationContext)
+  )
+  assert.throws(
+    () =>
+      assertNotReadOnlyImpersonation({
+        sid: 's', adminId: 'a', targetUserId: 'u', vendorId: 'v',
+        readOnly: true, exp: 0, remainingSeconds: 100,
+      } satisfies ImpersonationContext),
+    /read-only/
+  )
+})
+
+test('isImpersonationEnabled reflects the IMPERSONATION_ENABLED env var', () => {
+  const previous = process.env[IMPERSONATION_ENABLED_ENV_VAR]
+  try {
+    process.env[IMPERSONATION_ENABLED_ENV_VAR] = 'true'
+    assert.equal(isImpersonationEnabled(), true)
+
+    process.env[IMPERSONATION_ENABLED_ENV_VAR] = 'false'
+    assert.equal(isImpersonationEnabled(), false)
+
+    delete process.env[IMPERSONATION_ENABLED_ENV_VAR]
+    assert.equal(isImpersonationEnabled(), false)
+  } finally {
+    if (previous === undefined) delete process.env[IMPERSONATION_ENABLED_ENV_VAR]
+    else process.env[IMPERSONATION_ENABLED_ENV_VAR] = previous
+  }
+})
+
+test.after(() => {
+  if (originalSecret === undefined) delete process.env.AUTH_SECRET
+  else process.env.AUTH_SECRET = originalSecret
+})

--- a/test/features/portals.test.ts
+++ b/test/features/portals.test.ts
@@ -1,9 +1,12 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  describeCallbackRejection,
+  getAvailablePortals,
   getPortalLabel,
   getPrimaryPortalHref,
   getLoginPortalMode,
+  isValidPortalMode,
   normalizeAuthRedirectUrl,
   getPublicPortalLinks,
   resolvePostLoginDestination,
@@ -81,4 +84,188 @@ test('buyer portal label matches myAccount translation confirming duplication so
   assert.equal(getPortalLabel('CUSTOMER', 'es'), 'Mi cuenta')
   assert.notEqual(getPortalLabel('VENDOR', 'es'), 'Mi cuenta')
   assert.notEqual(getPortalLabel('SUPERADMIN', 'es'), 'Mi cuenta')
+})
+
+// ---------------------------------------------------------------------------
+// Hardening of sanitizeCallbackUrl (ticket #352).
+// Each case documents the attack class it guards against.
+// ---------------------------------------------------------------------------
+
+test('sanitizeCallbackUrl accepts allowlisted internal paths', () => {
+  const ok = [
+    '/',
+    '/cuenta',
+    '/cuenta/pedidos',
+    '/vendor/dashboard',
+    '/admin/dashboard?tab=orders',
+    '/productos',
+    '/productos?categoria=verduras',
+    '/productores/juanito-slug',
+    '/carrito',
+    '/checkout',
+  ]
+  for (const url of ok) {
+    assert.equal(sanitizeCallbackUrl(url), url, `expected accept: ${url}`)
+    assert.equal(describeCallbackRejection(url), null, `expected null reason: ${url}`)
+  }
+})
+
+test('sanitizeCallbackUrl rejects absolute and protocol-relative URLs', () => {
+  assert.equal(sanitizeCallbackUrl('https://evil.example.com'), undefined)
+  assert.equal(sanitizeCallbackUrl('http://evil.example.com'), undefined)
+  assert.equal(sanitizeCallbackUrl('//evil.example.com'), undefined)
+  assert.equal(describeCallbackRejection('//evil.example.com'), 'protocol_relative')
+  assert.equal(describeCallbackRejection('https://evil.example.com'), 'not_relative')
+})
+
+test('sanitizeCallbackUrl rejects backslash tricks (some browsers normalize \\ to /)', () => {
+  assert.equal(sanitizeCallbackUrl('/\\evil.example.com'), undefined)
+  assert.equal(sanitizeCallbackUrl('/\\\\evil.example.com'), undefined)
+  assert.equal(describeCallbackRejection('/\\evil.example.com'), 'forbidden_chars')
+})
+
+test('sanitizeCallbackUrl rejects userinfo-style `@` tokens', () => {
+  // /foo@evil.com — the URL parser in some runtimes reads this as a
+  // credential-bearing URL and may follow it as an absolute destination.
+  assert.equal(sanitizeCallbackUrl('/foo@evil.example.com'), undefined)
+  assert.equal(describeCallbackRejection('/foo@evil.example.com'), 'forbidden_chars')
+})
+
+test('sanitizeCallbackUrl rejects CR/LF and control characters', () => {
+  assert.equal(sanitizeCallbackUrl('/foo\nbar'), undefined)
+  assert.equal(sanitizeCallbackUrl('/foo\r\nSet-Cookie: x=y'), undefined)
+  assert.equal(sanitizeCallbackUrl('/foo\tbar'), undefined)
+  assert.equal(sanitizeCallbackUrl('/foo\x00bar'), undefined)
+  assert.equal(describeCallbackRejection('/foo\nbar'), 'forbidden_chars')
+})
+
+test('sanitizeCallbackUrl rejects URL-encoded forbidden characters after decode', () => {
+  // %2f%2fevil.com decodes to //evil.com
+  assert.equal(sanitizeCallbackUrl('/%2f%2fevil.example.com'), undefined)
+  // %5c → backslash
+  assert.equal(sanitizeCallbackUrl('/%5cevil.example.com'), undefined)
+  // %0a → newline
+  assert.equal(sanitizeCallbackUrl('/foo%0abar'), undefined)
+})
+
+test('sanitizeCallbackUrl rejects double-encoded attacks', () => {
+  // %252f%252fevil.com → %2f%2fevil.com → //evil.com
+  assert.equal(sanitizeCallbackUrl('/%252f%252fevil.example.com'), undefined)
+})
+
+test('sanitizeCallbackUrl rejects exotic schemes after decoding', () => {
+  // In practice any candidate starting with "javascript:" fails the
+  // "must start with /" check, but after decoding we re-check for
+  // scheme-like sequences to catch obfuscated variants.
+  assert.equal(sanitizeCallbackUrl('javascript:alert(1)'), undefined)
+  assert.equal(describeCallbackRejection('javascript:alert(1)'), 'not_relative')
+})
+
+test('sanitizeCallbackUrl rejects login and register to prevent redirect loops', () => {
+  assert.equal(sanitizeCallbackUrl('/login'), undefined)
+  assert.equal(sanitizeCallbackUrl('/login?callbackUrl=%2Fadmin%2Fdashboard'), undefined)
+  assert.equal(sanitizeCallbackUrl('/register'), undefined)
+  assert.equal(describeCallbackRejection('/login'), 'login_or_register')
+})
+
+test('sanitizeCallbackUrl rejects paths outside the allowlist', () => {
+  assert.equal(sanitizeCallbackUrl('/api/internal/secret'), undefined)
+  assert.equal(sanitizeCallbackUrl('/some-random-path'), undefined)
+  assert.equal(describeCallbackRejection('/api/internal/secret'), 'not_in_allowlist')
+})
+
+test('resolvePostLoginDestination reports role mismatch via onRoleMismatch callback', () => {
+  const rejections: Array<Record<string, unknown>> = []
+  const dest = resolvePostLoginDestination('CUSTOMER', '/admin/dashboard', {
+    onRoleMismatch: (details) => rejections.push(details),
+  })
+
+  assert.equal(dest, '/cuenta')
+  assert.equal(rejections.length, 1)
+  assert.equal(rejections[0]?.callbackMode, 'admin')
+  assert.equal(rejections[0]?.roleMode, 'buyer')
+})
+
+test('resolvePostLoginDestination does not invoke onRoleMismatch for matching callbacks', () => {
+  let called = false
+  const dest = resolvePostLoginDestination('VENDOR', '/vendor/productos', {
+    onRoleMismatch: () => { called = true },
+  })
+
+  assert.equal(dest, '/vendor/productos')
+  assert.equal(called, false)
+})
+
+// ---------------------------------------------------------------------------
+// Portal switcher + lastPortal cookie (ticket #349).
+// ---------------------------------------------------------------------------
+
+test('isValidPortalMode only accepts the three known modes', () => {
+  assert.equal(isValidPortalMode('buyer'), true)
+  assert.equal(isValidPortalMode('vendor'), true)
+  assert.equal(isValidPortalMode('admin'), true)
+  assert.equal(isValidPortalMode('BUYER'), false)
+  assert.equal(isValidPortalMode(''), false)
+  assert.equal(isValidPortalMode(null), false)
+  assert.equal(isValidPortalMode(undefined), false)
+  assert.equal(isValidPortalMode(42), false)
+})
+
+test('getAvailablePortals returns empty list for anonymous', () => {
+  assert.deepEqual(getAvailablePortals(undefined), [])
+})
+
+test('getAvailablePortals gives CUSTOMER only the buyer portal', () => {
+  const portals = getAvailablePortals('CUSTOMER')
+  assert.equal(portals.length, 1)
+  assert.equal(portals[0]?.mode, 'buyer')
+})
+
+test('getAvailablePortals gives VENDOR both buyer and vendor portals', () => {
+  const portals = getAvailablePortals('VENDOR')
+  assert.deepEqual(portals.map(p => p.mode), ['buyer', 'vendor'])
+  assert.equal(portals.find(p => p.mode === 'vendor')?.href, '/vendor/dashboard')
+})
+
+test('getAvailablePortals gives admins both buyer and admin portals', () => {
+  const support = getAvailablePortals('ADMIN_SUPPORT')
+  assert.deepEqual(support.map(p => p.mode), ['buyer', 'admin'])
+  const superAdmin = getAvailablePortals('SUPERADMIN')
+  assert.deepEqual(superAdmin.map(p => p.mode), ['buyer', 'admin'])
+})
+
+test('resolvePostLoginDestination honors lastPortal when role has access and no callback', () => {
+  // A vendor who last used the buyer portal should land back on /cuenta,
+  // not /vendor/dashboard, on their next login.
+  assert.equal(
+    resolvePostLoginDestination('VENDOR', undefined, { lastPortal: 'buyer' }),
+    '/cuenta'
+  )
+  // An admin who last used the admin portal still lands there.
+  assert.equal(
+    resolvePostLoginDestination('SUPERADMIN', undefined, { lastPortal: 'admin' }),
+    '/admin/dashboard'
+  )
+})
+
+test('resolvePostLoginDestination ignores lastPortal when role lacks access to it', () => {
+  // A CUSTOMER with a stale "vendor" cookie must NOT be redirected to the
+  // vendor dashboard — they don't have access.
+  assert.equal(
+    resolvePostLoginDestination('CUSTOMER', undefined, { lastPortal: 'vendor' }),
+    '/cuenta'
+  )
+  assert.equal(
+    resolvePostLoginDestination('CUSTOMER', undefined, { lastPortal: 'admin' }),
+    '/cuenta'
+  )
+})
+
+test('resolvePostLoginDestination lets explicit callback win over lastPortal', () => {
+  // Callback URL is an explicit user intent from the URL; it should not
+  // be overridden by the "last used" preference.
+  assert.equal(
+    resolvePostLoginDestination('VENDOR', '/vendor/productos', { lastPortal: 'buyer' }),
+    '/vendor/productos'
+  )
 })

--- a/test/features/proxy.test.ts
+++ b/test/features/proxy.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createLoginRedirectUrl } from '@/proxy'
+import { hostMatchesAdmin, isRequestOnAdminHost, ADMIN_HOST_ENV_VAR } from '@/lib/admin-host'
 
 test('createLoginRedirectUrl preserves the full protected path including query string', () => {
   const request = {
@@ -12,4 +13,88 @@ test('createLoginRedirectUrl preserves the full protected path including query s
 
   assert.equal(loginUrl.pathname, '/login')
   assert.equal(loginUrl.searchParams.get('callbackUrl'), '/checkout/pago?orderId=order_123&secret=secret_456')
+})
+
+test('createLoginRedirectUrl drops unsafe callback candidates instead of forwarding them', () => {
+  // This should never happen in practice (the request path is server-produced),
+  // but the middleware must still not launder an unsafe value into /login.
+  const request = {
+    url: 'https://marketplace.example.com/%5cevil.example.com',
+    nextUrl: new URL('https://marketplace.example.com/%5cevil.example.com'),
+  } as Parameters<typeof createLoginRedirectUrl>[0]
+
+  const loginUrl = createLoginRedirectUrl(request)
+
+  assert.equal(loginUrl.pathname, '/login')
+  // callbackUrl is intentionally absent — the unsafe path was dropped.
+  assert.equal(loginUrl.searchParams.get('callbackUrl'), null)
+})
+
+// ---------------------------------------------------------------------------
+// Admin host isolation (ticket #348).
+// ---------------------------------------------------------------------------
+
+test('hostMatchesAdmin is case-insensitive and ignores port', () => {
+  assert.equal(hostMatchesAdmin('admin.example.com', 'admin.example.com'), true)
+  assert.equal(hostMatchesAdmin('Admin.Example.Com', 'admin.example.com'), true)
+  assert.equal(hostMatchesAdmin('admin.example.com:3000', 'admin.example.com'), true)
+  assert.equal(hostMatchesAdmin('admin.example.com', 'admin.example.com:3000'), true)
+})
+
+test('hostMatchesAdmin rejects sibling and parent hosts', () => {
+  assert.equal(hostMatchesAdmin('example.com', 'admin.example.com'), false)
+  assert.equal(hostMatchesAdmin('www.example.com', 'admin.example.com'), false)
+  assert.equal(hostMatchesAdmin('evil-admin.example.com', 'admin.example.com'), false)
+  assert.equal(hostMatchesAdmin('admin.example.com.evil.com', 'admin.example.com'), false)
+})
+
+test('hostMatchesAdmin returns false when either argument is missing', () => {
+  assert.equal(hostMatchesAdmin(null, 'admin.example.com'), false)
+  assert.equal(hostMatchesAdmin('admin.example.com', undefined), false)
+  assert.equal(hostMatchesAdmin(undefined, undefined), false)
+})
+
+test('isRequestOnAdminHost short-circuits when ADMIN_HOST is unset', () => {
+  const originalValue = process.env[ADMIN_HOST_ENV_VAR]
+  delete process.env[ADMIN_HOST_ENV_VAR]
+  try {
+    const request = {
+      headers: {
+        get: (name: string) => (name === 'host' ? 'admin.example.com' : null),
+      },
+    }
+    assert.equal(isRequestOnAdminHost(request), false)
+  } finally {
+    if (originalValue !== undefined) process.env[ADMIN_HOST_ENV_VAR] = originalValue
+  }
+})
+
+test('isRequestOnAdminHost uses host header, falls back to x-forwarded-host', () => {
+  const originalValue = process.env[ADMIN_HOST_ENV_VAR]
+  process.env[ADMIN_HOST_ENV_VAR] = 'admin.example.com'
+  try {
+    const direct = {
+      headers: {
+        get: (name: string) => (name === 'host' ? 'admin.example.com' : null),
+      },
+    }
+    assert.equal(isRequestOnAdminHost(direct), true)
+
+    const viaProxy = {
+      headers: {
+        get: (name: string) => (name === 'x-forwarded-host' ? 'admin.example.com' : null),
+      },
+    }
+    assert.equal(isRequestOnAdminHost(viaProxy), true)
+
+    const publicHost = {
+      headers: {
+        get: (name: string) => (name === 'host' ? 'www.example.com' : null),
+      },
+    }
+    assert.equal(isRequestOnAdminHost(publicHost), false)
+  } finally {
+    if (originalValue === undefined) delete process.env[ADMIN_HOST_ENV_VAR]
+    else process.env[ADMIN_HOST_ENV_VAR] = originalValue
+  }
 })


### PR DESCRIPTION
Stacks on top of #357. Second pass of mobile UX fixes covering the flows the first round deferred.

## Summary
- **BuyerProfileForm**: add `autoComplete` on name / email / current + new password inputs so password managers file the entry correctly.
- **DireccionesClient**: add `autoComplete` on the whole address form + `inputMode=numeric` on the postal code; enlarge edit / set-default / delete per-card actions to `min-h-11` (they were bare text links).
- **Buyer orders list**: promote the per-order "view detail" link from a plain text-sm underline to an outlined button with `min-h-11`.
- **ProductImageGallery**: mobile prev/next chevrons were ~36px — add `min-h-11 min-w-11` on mobile and reset on `sm:`. Also wrap the mobile pagination dots in a 32×32 hit area so users can tap individual images (previously the dots themselves were 6×6).
- **VendorReviewsManager**: response edit/delete icon buttons were `p-1.5` (~28px) — raise to `min-h-11 min-w-11 p-2.5`.
- **FulfillmentActions**: "print label" / "view tracking" anchors were `py-1.5 text-xs` (~28px) — add `min-h-11` and `py-2` so they clear the touch-target floor.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (650 tests, adds 5 new mobile-ux contracts)
- [x] `npm run build`
- [ ] Manual iOS smoke: tap the gallery dots, cycle through images with chevrons, edit + delete an address, view an order detail, edit a vendor response.

## Note on base
Base is `fix/mobile-ux-improvements` (#357) so the diff reviews cleanly on top of that round. Once #357 merges to `main`, GitHub will retarget this PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)