### PR TITLE
test(e2e): smoke — public browse flow

### DIFF
--- a/e2e/smoke/public-browse.spec.ts
+++ b/e2e/smoke/public-browse.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('public browse @smoke', () => {
+  test('home page renders with hero and featured content', async ({ page }) => {
+    await page.goto('/')
+    // The home page should expose a primary heading. We don't pin the exact
+    // copy — marketing tweaks it often — just that an h1 is rendered.
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible({
+      timeout: 5_000,
+    })
+    // And at least one link into the catalog (product or producer card) is
+    // reachable from the landing page.
+    await expect(
+      page.getByRole('link', { name: /producto|productor|ver|comprar/i }).first(),
+    ).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('catalog lists seeded products', async ({ page }) => {
+    await page.goto('/productos')
+    await expect(page.getByText(/tomates cherry/i).first()).toBeVisible({
+      timeout: 5_000,
+    })
+  })
+
+  test('product detail renders without hydration errors', async ({ page }) => {
+    await page.goto('/productos/tomates-cherry-ecologicos')
+    // Product name as a heading — level is intentionally unasserted so a
+    // future h1/h2 swap doesn't break the smoke test.
+    await expect(
+      page.getByRole('heading', { name: /tomates cherry/i }).first(),
+    ).toBeVisible({ timeout: 5_000 })
+    // Price. Seed says €3.50; accept comma or dot decimal, or just the € sign.
+    await expect(page.getByText(/3[.,]5|€/).first()).toBeVisible({ timeout: 5_000 })
+    // Add-to-cart style button.
+    await expect(
+      page.getByRole('button', { name: /añadir al carrito|añadir|carrito/i }).first(),
+    ).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('navigation back to catalog works from product detail', async ({ page }) => {
+    await page.goto('/productos/tomates-cherry-ecologicos')
+    // Click any link that points back to the catalog index. Using href is
+    // resilient to copy changes (breadcrumb vs "ver más", etc.).
+    await page.locator('a[href="/productos"]').first().click()
+    await expect(page).toHaveURL(/\/productos\/?$/, { timeout: 5_000 })
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 of the CI testing strategy from #362: a single Playwright smoke spec covering the anonymous buyer happy path.

- New file: `e2e/smoke/public-browse.spec.ts`
- Four `@smoke`-tagged tests: home renders, catalog lists seeded products, product detail renders, and nav back to catalog works
- Fully anonymous — no `loginAs`, no DB writes
- Uses role/text selectors and regex matchers (no brittle class selectors, no hardcoded waits)

Closes #363

## Test plan

- [ ] CI e2e-smoke job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)