### PR TITLE
test(e2e): smoke — admin and vendor route guards

### DIFF
--- a/e2e/smoke/admin-guards.spec.ts
+++ b/e2e/smoke/admin-guards.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { TEST_USERS, loginAs } from '../helpers/auth'
+
+test.describe('admin and vendor guards @smoke', () => {
+  test('buyer is blocked from /admin/dashboard', async ({ page }) => {
+    await loginAs(page, TEST_USERS.customer)
+    await page.goto('/admin/dashboard')
+    // Accept any destination except /admin/*. The exact redirect target
+    // (home, login, vendor portal) is allowed to change.
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 5000 })
+      .not.toMatch(/^\/admin/)
+  })
+
+  test('vendor is blocked from /admin/dashboard', async ({ page }) => {
+    await loginAs(page, TEST_USERS.vendor)
+    await page.goto('/admin/dashboard')
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 5000 })
+      .not.toMatch(/^\/admin/)
+  })
+
+  test('buyer is blocked from /vendor/dashboard', async ({ page }) => {
+    await loginAs(page, TEST_USERS.customer)
+    await page.goto('/vendor/dashboard')
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 5000 })
+      .not.toMatch(/^\/vendor/)
+  })
+
+  test('admin can reach /admin/dashboard', async ({ page }) => {
+    await loginAs(page, TEST_USERS.admin)
+    await page.goto('/admin/dashboard')
+    // Sanity: admin stays on an admin route.
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 10000 })
+      .toMatch(/^\/admin/)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `e2e/smoke/admin-guards.spec.ts` pinning cross-role route guard behavior.
- Verifies buyers and vendors cannot reach `/admin/*`, buyers cannot reach `/vendor/*`, and admins can reach `/admin/dashboard`.
- Assertions check pathname does NOT start with `/admin` (or `/vendor`) rather than pinning an exact redirect target, so the guard contract is locked without over-constraining redirect destinations.

## Test plan
- [ ] CI runs `npx playwright test e2e/smoke/admin-guards.spec.ts`
- [ ] Buyer/vendor blocked from `/admin/dashboard`
- [ ] Buyer blocked from `/vendor/dashboard`
- [ ] Admin reaches `/admin/dashboard`

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)