### PR TITLE
test(integration): admin audit log contract on approveVendor (+ testability fixes)

### DIFF
--- a/src/domains/admin/actions.ts
+++ b/src/domains/admin/actions.ts
@@ -2,7 +2,6 @@
 
 import { UserRole } from '@/generated/prisma/enums'
 import { db } from '@/lib/db'
-import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 import { setMarketplaceConfig } from '@/lib/config'
 import { createAuditLog, getAuditRequestIp, type AuditValue } from '@/lib/audit'
@@ -111,8 +110,8 @@ export async function approveVendor(vendorId: string) {
     ip,
   })
 
-  revalidatePath('/admin/productores')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/productores')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 /**
@@ -142,8 +141,8 @@ export async function rejectVendor(vendorId: string) {
     ip,
   })
 
-  revalidatePath('/admin/productores')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/productores')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 /**
@@ -173,8 +172,8 @@ export async function suspendVendor(vendorId: string) {
     ip,
   })
 
-  revalidatePath('/admin/productores')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/productores')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 // ─── Product moderation ───────────────────────────────────────────────────────
@@ -266,12 +265,12 @@ export async function updateMarketplaceConfigAction(formData: FormData) {
     ip,
   })
 
-  revalidatePath('/admin/configuracion')
-  revalidatePath('/admin/dashboard')
-  revalidatePath('/admin/auditoria')
-  revalidatePath('/')
-  revalidatePath('/carrito')
-  revalidatePath('/checkout')
+  safeRevalidatePath('/admin/configuracion')
+  safeRevalidatePath('/admin/dashboard')
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/')
+  safeRevalidatePath('/carrito')
+  safeRevalidatePath('/checkout')
 }
 
 export async function createCommissionRule(formData: FormData) {
@@ -319,8 +318,8 @@ export async function createCommissionRule(formData: FormData) {
     ip,
   })
 
-  revalidatePath('/admin/comisiones')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/comisiones')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function toggleCommissionRule(ruleId: string) {
@@ -359,8 +358,8 @@ export async function toggleCommissionRule(ruleId: string) {
     ip,
   })
 
-  revalidatePath('/admin/comisiones')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/comisiones')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function deleteCommissionRule(ruleId: string) {
@@ -392,8 +391,8 @@ export async function deleteCommissionRule(ruleId: string) {
     ip,
   })
 
-  revalidatePath('/admin/comisiones')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/comisiones')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function createShippingZone(formData: FormData) {
@@ -431,8 +430,8 @@ export async function createShippingZone(formData: FormData) {
     ip,
   })
 
-  revalidatePath('/admin/envios')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/envios')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function addShippingRate(formData: FormData) {
@@ -478,8 +477,8 @@ export async function addShippingRate(formData: FormData) {
     ip,
   })
 
-  revalidatePath('/admin/envios')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/envios')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function deleteShippingRate(rateId: string) {
@@ -511,8 +510,8 @@ export async function deleteShippingRate(rateId: string) {
     ip,
   })
 
-  revalidatePath('/admin/envios')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/envios')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 /**
@@ -556,9 +555,9 @@ export async function reviewProduct(
     ip,
   })
 
-  revalidatePath('/admin/productos')
-  revalidatePath('/admin/auditoria')
-  revalidatePath('/vendor/productos')
+  safeRevalidatePath('/admin/productos')
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/vendor/productos')
   revalidateCatalogExperience({ productSlug: updatedProduct.slug })
 }
 
@@ -589,9 +588,9 @@ export async function suspendProduct(productId: string, reason: string) {
     ip,
   })
 
-  revalidatePath('/admin/productos')
-  revalidatePath('/admin/auditoria')
-  revalidatePath('/vendor/productos')
+  safeRevalidatePath('/admin/productos')
+  safeRevalidatePath('/admin/auditoria')
+  safeRevalidatePath('/vendor/productos')
   revalidateCatalogExperience({ productSlug: updatedProduct.slug })
 }
 
@@ -622,8 +621,8 @@ export async function approveSettlement(settlementId: string) {
     ip,
   })
 
-  revalidatePath('/admin/liquidaciones')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/liquidaciones')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 export async function markSettlementPaid(settlementId: string) {
@@ -653,8 +652,8 @@ export async function markSettlementPaid(settlementId: string) {
     ip,
   })
 
-  revalidatePath('/admin/liquidaciones')
-  revalidatePath('/admin/auditoria')
+  safeRevalidatePath('/admin/liquidaciones')
+  safeRevalidatePath('/admin/auditoria')
 }
 
 // ─── Order management ─────────────────────────────────────────────────────────

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -48,10 +48,14 @@ export function extractAuditIp(headerStore: Pick<Headers, 'get'>) {
  * forensic investigation, so when in doubt we record `null`.
  */
 export async function getAuditRequestIp() {
-  const headerStore = await headers()
+  // Short-circuit before touching next/headers: the proxy-trust gate is the
+  // real decision here, and calling `headers()` outside a request scope (in
+  // integration tests, cron jobs, scripts) throws. Checking trust first
+  // keeps the production path identical and unlocks test callers.
   if (!isProxyTrustedFromEnv()) {
     return null
   }
+  const headerStore = await headers()
   return extractAuditIp(headerStore)
 }
 

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -1,9 +1,19 @@
 import { redirect } from 'next/navigation'
+import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 import { UserRole, type UserRole as UserRoleValue } from '@/generated/prisma/enums'
 import { isAdmin, hasRole, CATALOG_ADMIN_ROLES, SUPERADMIN_ROLES } from '@/lib/roles'
 
-export async function requireAuth() {
+export async function requireAuth(): Promise<Session> {
+  // Test-mode shortcut: honor the action-session global the same way
+  // getActionSession does. Keeps admin actions (which call
+  // requireAdmin/requireAuth) exercisable from integration tests without
+  // going through NextAuth, which has no request context in Node.
+  if (process.env.NODE_ENV === 'test' && typeof globalThis.__testActionSession !== 'undefined') {
+    const testSession = globalThis.__testActionSession
+    if (!testSession) throw new Error('requireAuth: unauthenticated (no test session set)')
+    return testSession as unknown as Session
+  }
   const session = await auth()
   if (!session?.user) redirect('/login')
   return session

--- a/test/integration/admin-audit-log.test.ts
+++ b/test/integration/admin-audit-log.test.ts
@@ -1,0 +1,99 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { approveVendor } from '@/domains/admin/actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+// Pins the forensic contract for admin mutations: a successful
+// `approveVendor` must persist exactly one VENDOR_APPROVED AuditLog
+// row bound to the acting admin, and a no-op repeat must not add a
+// second row. Guards against silent regressions in src/lib/audit.ts
+// or in any caller that forgets the audit side effect.
+//
+// Known gap NOT covered by this test: `createAuditLog` wraps its
+// db.create in a try/catch that only console.errors on failure, so
+// an audit insert can silently fail while the mutation commits. The
+// audit write also lives outside db.$transaction in admin/actions.ts.
+// Both are pre-existing structural concerns — fixing them changes
+// production behavior and belongs in a separate PR, not in this test.
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+  resetServerEnvCache()
+})
+
+async function createApplyingVendor() {
+  const vendorUser = await createUser('VENDOR')
+  return db.vendor.create({
+    data: {
+      userId: vendorUser.id,
+      slug: `applying-${randomUUID().slice(0, 8)}`,
+      displayName: 'Applying Vendor',
+      status: 'APPLYING',
+      stripeOnboarded: false,
+    },
+  })
+}
+
+test('approveVendor writes exactly one VENDOR_APPROVED audit row', async () => {
+  const admin = await createUser('SUPERADMIN')
+  const vendor = await createApplyingVendor()
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+
+  await approveVendor(vendor.id)
+
+  const updated = await db.vendor.findUniqueOrThrow({ where: { id: vendor.id } })
+  assert.equal(updated.status, 'ACTIVE')
+
+  const auditRows = await db.auditLog.findMany({
+    where: { entityType: 'Vendor', entityId: vendor.id },
+  })
+  assert.equal(auditRows.length, 1, 'expected exactly one audit row for the approval')
+
+  const row = auditRows[0]!
+  assert.equal(row.action, 'VENDOR_APPROVED')
+  assert.equal(row.entityType, 'Vendor')
+  assert.equal(row.entityId, vendor.id)
+  assert.equal(row.actorId, admin.id)
+  assert.equal(row.actorRole, 'SUPERADMIN')
+  assert.ok(row.createdAt instanceof Date)
+  // TRUST_PROXY_HEADERS is unset in the integration harness, so the
+  // audit IP gate returns null without touching next/headers.
+  assert.equal(row.ip, null)
+})
+
+test('approveVendor on an already-active vendor throws and does NOT write a second audit row', async () => {
+  const admin = await createUser('SUPERADMIN')
+  const vendor = await createApplyingVendor()
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+
+  await approveVendor(vendor.id)
+  await assert.rejects(
+    () => approveVendor(vendor.id),
+    /activo|suspendido/i,
+    'second approval should reject with a user-visible error',
+  )
+
+  const auditRows = await db.auditLog.findMany({
+    where: { entityType: 'Vendor', entityId: vendor.id },
+  })
+  assert.equal(
+    auditRows.length,
+    1,
+    'second call must not create an additional audit row',
+  )
+})


### PR DESCRIPTION
## Summary
Bundles one integration test with the minimal production fixes it required.

### Test
`test/integration/admin-audit-log.test.ts` pins the admin audit log contract on a real mutation:
1. `approveVendor` writes exactly one `VENDOR_APPROVED` audit row with the correct actor, target, type, and null `ip` (TRUST_PROXY_HEADERS unset in tests).
2. Calling `approveVendor` on an already-active vendor rejects and does **not** create a second audit row.

### Production fixes (all small, all production-neutral)
- **`src/lib/audit.ts`** — `getAuditRequestIp()` short-circuits on the proxy-trust gate before calling `next/headers`. `headers()` throws outside a request scope; the trust check is the actual forensic decision, so moving it first costs nothing in production and unlocks Node test callers.
- **`src/domains/admin/actions.ts`** — replaces 30+ raw `revalidatePath` calls with `safeRevalidatePath` (which already exists in `src/lib/revalidate.ts` and is used symmetrically in `src/domains/admin/writes.ts`). Raw `revalidatePath` throws `Invariant: static generation store missing` outside a Next render context.
- **`src/lib/auth-guard.ts`** — `requireAuth` honors `globalThis.__testActionSession` in `NODE_ENV=test`, mirroring what `getActionSession` already does. Lets admin server actions run under `node:test` without NextAuth.

### Known gap documented in the test file, deliberately NOT fixed here
The audit insert lives outside `db.$transaction` in `admin/actions.ts`, and `createAuditLog` swallows errors via try/catch in `src/lib/audit.ts`. Both are pre-existing structural forensic concerns — a silent audit failure leaves a mutation committed without a trail. Fixing them changes production behavior in a way that deserves its own PR and its own review, not a drive-by inside a test ticket.

Closes #373

## Test plan
- [x] `npm run typecheck:test` — clean.
- [ ] CI `Integration` job green.
- [ ] CI `Verify` and `Build And Migrate` green (no regressions in the safeRevalidatePath migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)