### PR TITLE
fix(audit): wrap admin mutations + audit log in single transaction (#381)

### DIFF
--- a/src/domains/admin/actions.ts
+++ b/src/domains/admin/actions.ts
@@ -4,7 +4,7 @@ import { UserRole } from '@/generated/prisma/enums'
 import { db } from '@/lib/db'
 import { z } from 'zod'
 import { setMarketplaceConfig } from '@/lib/config'
-import { createAuditLog, getAuditRequestIp, type AuditValue } from '@/lib/audit'
+import { createAuditLog, getAuditRequestIp, mutateWithAudit, type AuditValue } from '@/lib/audit'
 import { requireAdmin } from '@/lib/auth-guard'
 import { hasRole, isAdmin } from '@/lib/roles'
 import { getActionSession } from '@/lib/action-session'
@@ -93,21 +93,26 @@ export async function approveVendor(vendorId: string) {
   }
 
   const before = getVendorAuditSnapshot(vendor)
-  const updatedVendor = await db.vendor.update({
-    where: { id: vendorId },
-    data: { status: 'ACTIVE' },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'VENDOR_APPROVED',
-    entityType: 'Vendor',
-    entityId: vendorId,
-    before,
-    after: getVendorAuditSnapshot(updatedVendor),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedVendor = await tx.vendor.update({
+      where: { id: vendorId },
+      data: { status: 'ACTIVE' },
+    })
+    return {
+      result: updatedVendor,
+      audit: {
+        action: 'VENDOR_APPROVED',
+        entityType: 'Vendor',
+        entityId: vendorId,
+        before,
+        after: getVendorAuditSnapshot(updatedVendor),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productores')
@@ -123,22 +128,26 @@ export async function rejectVendor(vendorId: string) {
   const vendor = await db.vendor.findUnique({ where: { id: vendorId } })
   if (!vendor) throw new Error('Productor no encontrado')
   const before = getVendorAuditSnapshot(vendor)
-
-  const updatedVendor = await db.vendor.update({
-    where: { id: vendorId },
-    data: { status: 'REJECTED' },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'VENDOR_REJECTED',
-    entityType: 'Vendor',
-    entityId: vendorId,
-    before,
-    after: getVendorAuditSnapshot(updatedVendor),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedVendor = await tx.vendor.update({
+      where: { id: vendorId },
+      data: { status: 'REJECTED' },
+    })
+    return {
+      result: updatedVendor,
+      audit: {
+        action: 'VENDOR_REJECTED',
+        entityType: 'Vendor',
+        entityId: vendorId,
+        before,
+        after: getVendorAuditSnapshot(updatedVendor),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productores')
@@ -154,22 +163,26 @@ export async function suspendVendor(vendorId: string) {
   const vendor = await db.vendor.findUnique({ where: { id: vendorId } })
   if (!vendor) throw new Error('Productor no encontrado')
   const before = getVendorAuditSnapshot(vendor)
-
-  const updatedVendor = await db.vendor.update({
-    where: { id: vendorId },
-    data: { status: 'SUSPENDED_TEMP' },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'VENDOR_SUSPENDED',
-    entityType: 'Vendor',
-    entityId: vendorId,
-    before,
-    after: getVendorAuditSnapshot(updatedVendor),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedVendor = await tx.vendor.update({
+      where: { id: vendorId },
+      data: { status: 'SUSPENDED_TEMP' },
+    })
+    return {
+      result: updatedVendor,
+      audit: {
+        action: 'VENDOR_SUSPENDED',
+        entityType: 'Vendor',
+        entityId: vendorId,
+        before,
+        after: getVendorAuditSnapshot(updatedVendor),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productores')

--- a/src/domains/admin/actions.ts
+++ b/src/domains/admin/actions.ts
@@ -267,6 +267,10 @@ export async function updateMarketplaceConfigAction(formData: FormData) {
     previousConfig.map(item => [item.key, item.value])
   ) as AuditValue
 
+  // NOTE: `setMarketplaceConfig` is not a direct Prisma call (it upserts via
+  // a helper), so we cannot wrap it with `mutateWithAudit`/`$transaction`
+  // here. Fall back to the legacy direct audit call with `db` passed
+  // explicitly; the audit write will still raise on failure (#381).
   await createAuditLog({
     action: 'MARKETPLACE_CONFIG_UPDATED',
     entityType: 'MarketplaceConfig',
@@ -276,7 +280,7 @@ export async function updateMarketplaceConfigAction(formData: FormData) {
     actorId: session.user.id,
     actorRole: session.user.role,
     ip,
-  })
+  }, db)
 
   safeRevalidatePath('/admin/configuracion')
   safeRevalidatePath('/admin/dashboard')
@@ -303,32 +307,37 @@ export async function createCommissionRule(formData: FormData) {
     throw new Error('Debes seleccionar al menos un productor o una categoría')
   }
 
-  const createdRule = await db.commissionRule.create({
-    data: {
-      vendorId: parsed.vendorId ?? null,
-      categoryId: parsed.categoryId ?? null,
-      type: parsed.type,
-      rate: parsed.rate,
-      isActive: true,
-    },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'COMMISSION_RULE_CREATED',
-    entityType: 'CommissionRule',
-    entityId: createdRule.id,
-    after: {
-      id: createdRule.id,
-      vendorId: createdRule.vendorId,
-      categoryId: createdRule.categoryId,
-      type: createdRule.type,
-      rate: Number(createdRule.rate),
-      isActive: createdRule.isActive,
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const createdRule = await tx.commissionRule.create({
+      data: {
+        vendorId: parsed.vendorId ?? null,
+        categoryId: parsed.categoryId ?? null,
+        type: parsed.type,
+        rate: parsed.rate,
+        isActive: true,
+      },
+    })
+    return {
+      result: createdRule,
+      audit: {
+        action: 'COMMISSION_RULE_CREATED',
+        entityType: 'CommissionRule',
+        entityId: createdRule.id,
+        after: {
+          id: createdRule.id,
+          vendorId: createdRule.vendorId,
+          categoryId: createdRule.categoryId,
+          type: createdRule.type,
+          rate: Number(createdRule.rate),
+          isActive: createdRule.isActive,
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/comisiones')
@@ -344,31 +353,36 @@ export async function toggleCommissionRule(ruleId: string) {
   const rule = await db.commissionRule.findUnique({ where: { id: ruleId } })
   if (!rule) throw new Error('Regla no encontrada')
 
-  const updatedRule = await db.commissionRule.update({
-    where: { id: ruleId },
-    data: { isActive: !rule.isActive },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'COMMISSION_RULE_TOGGLED',
-    entityType: 'CommissionRule',
-    entityId: ruleId,
-    before: {
-      id: rule.id,
-      isActive: rule.isActive,
-      type: rule.type,
-      rate: Number(rule.rate),
-    },
-    after: {
-      id: updatedRule.id,
-      isActive: updatedRule.isActive,
-      type: updatedRule.type,
-      rate: Number(updatedRule.rate),
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedRule = await tx.commissionRule.update({
+      where: { id: ruleId },
+      data: { isActive: !rule.isActive },
+    })
+    return {
+      result: updatedRule,
+      audit: {
+        action: 'COMMISSION_RULE_TOGGLED',
+        entityType: 'CommissionRule',
+        entityId: ruleId,
+        before: {
+          id: rule.id,
+          isActive: rule.isActive,
+          type: rule.type,
+          rate: Number(rule.rate),
+        },
+        after: {
+          id: updatedRule.id,
+          isActive: updatedRule.isActive,
+          type: updatedRule.type,
+          rate: Number(updatedRule.rate),
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/comisiones')
@@ -384,24 +398,29 @@ export async function deleteCommissionRule(ruleId: string) {
   const rule = await db.commissionRule.findUnique({ where: { id: ruleId } })
   if (!rule) throw new Error('Regla no encontrada')
 
-  await db.commissionRule.delete({ where: { id: ruleId } })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'COMMISSION_RULE_DELETED',
-    entityType: 'CommissionRule',
-    entityId: ruleId,
-    before: {
-      id: rule.id,
-      vendorId: rule.vendorId,
-      categoryId: rule.categoryId,
-      type: rule.type,
-      rate: Number(rule.rate),
-      isActive: rule.isActive,
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const deletedRule = await tx.commissionRule.delete({ where: { id: ruleId } })
+    return {
+      result: deletedRule,
+      audit: {
+        action: 'COMMISSION_RULE_DELETED',
+        entityType: 'CommissionRule',
+        entityId: ruleId,
+        before: {
+          id: rule.id,
+          vendorId: rule.vendorId,
+          categoryId: rule.categoryId,
+          type: rule.type,
+          rate: Number(rule.rate),
+          isActive: rule.isActive,
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/comisiones')
@@ -419,28 +438,33 @@ export async function createShippingZone(formData: FormData) {
     provinces: formData.get('provinces'),
   })
 
-  const createdZone = await db.shippingZone.create({
-    data: {
-      name: parsed.name,
-      provinces: parsed.provinces.split(',').map(value => value.trim()).filter(Boolean),
-      isActive: true,
-    },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'SHIPPING_ZONE_CREATED',
-    entityType: 'ShippingZone',
-    entityId: createdZone.id,
-    after: {
-      id: createdZone.id,
-      name: createdZone.name,
-      provinces: createdZone.provinces,
-      isActive: createdZone.isActive,
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const createdZone = await tx.shippingZone.create({
+      data: {
+        name: parsed.name,
+        provinces: parsed.provinces.split(',').map(value => value.trim()).filter(Boolean),
+        isActive: true,
+      },
+    })
+    return {
+      result: createdZone,
+      audit: {
+        action: 'SHIPPING_ZONE_CREATED',
+        entityType: 'ShippingZone',
+        entityId: createdZone.id,
+        after: {
+          id: createdZone.id,
+          name: createdZone.name,
+          provinces: createdZone.provinces,
+          isActive: createdZone.isActive,
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/envios')
@@ -461,33 +485,38 @@ export async function addShippingRate(formData: FormData) {
     freeAbove: formData.get('freeAbove') || undefined,
   })
 
-  const createdRate = await db.shippingRate.create({
-    data: {
-      zoneId: parsed.zoneId,
-      name: parsed.name,
-      minOrderAmount: parsed.minOrderAmount ?? null,
-      price: parsed.price,
-      freeAbove: parsed.freeAbove ?? null,
-      isActive: true,
-    },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'SHIPPING_RATE_CREATED',
-    entityType: 'ShippingRate',
-    entityId: createdRate.id,
-    after: {
-      id: createdRate.id,
-      zoneId: createdRate.zoneId,
-      name: createdRate.name,
-      minOrderAmount: createdRate.minOrderAmount == null ? null : Number(createdRate.minOrderAmount),
-      price: Number(createdRate.price),
-      freeAbove: createdRate.freeAbove == null ? null : Number(createdRate.freeAbove),
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const createdRate = await tx.shippingRate.create({
+      data: {
+        zoneId: parsed.zoneId,
+        name: parsed.name,
+        minOrderAmount: parsed.minOrderAmount ?? null,
+        price: parsed.price,
+        freeAbove: parsed.freeAbove ?? null,
+        isActive: true,
+      },
+    })
+    return {
+      result: createdRate,
+      audit: {
+        action: 'SHIPPING_RATE_CREATED',
+        entityType: 'ShippingRate',
+        entityId: createdRate.id,
+        after: {
+          id: createdRate.id,
+          zoneId: createdRate.zoneId,
+          name: createdRate.name,
+          minOrderAmount: createdRate.minOrderAmount == null ? null : Number(createdRate.minOrderAmount),
+          price: Number(createdRate.price),
+          freeAbove: createdRate.freeAbove == null ? null : Number(createdRate.freeAbove),
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/envios')
@@ -503,24 +532,29 @@ export async function deleteShippingRate(rateId: string) {
   const rate = await db.shippingRate.findUnique({ where: { id: rateId } })
   if (!rate) throw new Error('Tarifa no encontrada')
 
-  await db.shippingRate.delete({ where: { id: rateId } })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'SHIPPING_RATE_DELETED',
-    entityType: 'ShippingRate',
-    entityId: rateId,
-    before: {
-      id: rate.id,
-      zoneId: rate.zoneId,
-      name: rate.name,
-      minOrderAmount: rate.minOrderAmount == null ? null : Number(rate.minOrderAmount),
-      price: Number(rate.price),
-      freeAbove: rate.freeAbove == null ? null : Number(rate.freeAbove),
-    },
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const deletedRate = await tx.shippingRate.delete({ where: { id: rateId } })
+    return {
+      result: deletedRate,
+      audit: {
+        action: 'SHIPPING_RATE_DELETED',
+        entityType: 'ShippingRate',
+        entityId: rateId,
+        before: {
+          id: rate.id,
+          zoneId: rate.zoneId,
+          name: rate.name,
+          minOrderAmount: rate.minOrderAmount == null ? null : Number(rate.minOrderAmount),
+          price: Number(rate.price),
+          freeAbove: rate.freeAbove == null ? null : Number(rate.freeAbove),
+        },
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/envios')
@@ -548,24 +582,29 @@ export async function reviewProduct(
   }
 
   const before = getProductAuditSnapshot(product)
-  const updatedProduct = await db.product.update({
-    where: { id: productId },
-    data:
-      validAction === 'approve'
-        ? { status: 'ACTIVE', rejectionNote: null }
-        : { status: 'REJECTED', rejectionNote: note ?? 'No cumple los requisitos del catálogo' },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: validAction === 'approve' ? 'PRODUCT_APPROVED' : 'PRODUCT_REJECTED',
-    entityType: 'Product',
-    entityId: productId,
-    before,
-    after: getProductAuditSnapshot(updatedProduct),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  const updatedProduct = await mutateWithAudit(async tx => {
+    const updated = await tx.product.update({
+      where: { id: productId },
+      data:
+        validAction === 'approve'
+          ? { status: 'ACTIVE', rejectionNote: null }
+          : { status: 'REJECTED', rejectionNote: note ?? 'No cumple los requisitos del catálogo' },
+    })
+    return {
+      result: updated,
+      audit: {
+        action: validAction === 'approve' ? 'PRODUCT_APPROVED' : 'PRODUCT_REJECTED',
+        entityType: 'Product',
+        entityId: productId,
+        before,
+        after: getProductAuditSnapshot(updated),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productos')
@@ -583,22 +622,26 @@ export async function suspendProduct(productId: string, reason: string) {
   const product = await db.product.findUnique({ where: { id: productId } })
   if (!product) throw new Error('Producto no encontrado')
   const before = getProductAuditSnapshot(product)
-
-  const updatedProduct = await db.product.update({
-    where: { id: productId },
-    data: { status: 'SUSPENDED', rejectionNote: reason },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'PRODUCT_SUSPENDED',
-    entityType: 'Product',
-    entityId: productId,
-    before,
-    after: getProductAuditSnapshot(updatedProduct),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  const updatedProduct = await mutateWithAudit(async tx => {
+    const updated = await tx.product.update({
+      where: { id: productId },
+      data: { status: 'SUSPENDED', rejectionNote: reason },
+    })
+    return {
+      result: updated,
+      audit: {
+        action: 'PRODUCT_SUSPENDED',
+        entityType: 'Product',
+        entityId: productId,
+        before,
+        after: getProductAuditSnapshot(updated),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productos')
@@ -617,21 +660,26 @@ export async function approveSettlement(settlementId: string) {
   }
 
   const before = getSettlementAuditSnapshot(settlement)
-  const updatedSettlement = await db.settlement.update({
-    where: { id: settlementId },
-    data: { status: 'APPROVED' },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'SETTLEMENT_APPROVED',
-    entityType: 'Settlement',
-    entityId: settlementId,
-    before,
-    after: getSettlementAuditSnapshot(updatedSettlement),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedSettlement = await tx.settlement.update({
+      where: { id: settlementId },
+      data: { status: 'APPROVED' },
+    })
+    return {
+      result: updatedSettlement,
+      audit: {
+        action: 'SETTLEMENT_APPROVED',
+        entityType: 'Settlement',
+        entityId: settlementId,
+        before,
+        after: getSettlementAuditSnapshot(updatedSettlement),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/liquidaciones')
@@ -648,21 +696,26 @@ export async function markSettlementPaid(settlementId: string) {
   }
 
   const before = getSettlementAuditSnapshot(settlement)
-  const updatedSettlement = await db.settlement.update({
-    where: { id: settlementId },
-    data: { status: 'PAID', paidAt: new Date() },
-  })
   const ip = await getAuditRequestIp()
 
-  await createAuditLog({
-    action: 'SETTLEMENT_PAID',
-    entityType: 'Settlement',
-    entityId: settlementId,
-    before,
-    after: getSettlementAuditSnapshot(updatedSettlement),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+  await mutateWithAudit(async tx => {
+    const updatedSettlement = await tx.settlement.update({
+      where: { id: settlementId },
+      data: { status: 'PAID', paidAt: new Date() },
+    })
+    return {
+      result: updatedSettlement,
+      audit: {
+        action: 'SETTLEMENT_PAID',
+        entityType: 'Settlement',
+        entityId: settlementId,
+        before,
+        after: getSettlementAuditSnapshot(updatedSettlement),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/liquidaciones')

--- a/src/domains/admin/writes.ts
+++ b/src/domains/admin/writes.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { createAuditLog, getAuditRequestIp } from '@/lib/audit'
+import { getAuditRequestIp, mutateWithAudit } from '@/lib/audit'
 import { requireCatalogAdmin, requireSuperadmin } from '@/lib/auth-guard'
 import { revalidateCatalogExperience, safeRevalidatePath } from '@/lib/revalidate'
 import { parseExpirationDateInput } from '@/domains/catalog/availability'
@@ -157,36 +157,40 @@ export async function adminUpdateProduct(productId: string, input: AdminProductI
   if (!product) throw new Error('Producto no encontrado')
 
   const before = productSnapshot(product)
-
-  const updated = await db.product.update({
-    where: { id: productId },
-    data: {
-      name: data.name,
-      description: data.description ?? null,
-      categoryId: data.categoryId && data.categoryId.length > 0 ? data.categoryId : null,
-      basePrice: data.basePrice,
-      compareAtPrice: data.compareAtPrice ?? null,
-      taxRate: data.taxRate,
-      unit: data.unit,
-      stock: data.stock,
-      trackStock: data.trackStock,
-      status: data.status,
-      originRegion: data.originRegion ?? null,
-      rejectionNote: data.rejectionNote ?? null,
-      expiresAt: parseExpirationDateInput(data.expiresAt),
-    },
-  })
-
   const ip = await getAuditRequestIp()
-  await createAuditLog({
-    action: 'PRODUCT_EDITED',
-    entityType: 'Product',
-    entityId: productId,
-    before,
-    after: productSnapshot(updated),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+
+  const updated = await mutateWithAudit(async tx => {
+    const updatedProduct = await tx.product.update({
+      where: { id: productId },
+      data: {
+        name: data.name,
+        description: data.description ?? null,
+        categoryId: data.categoryId && data.categoryId.length > 0 ? data.categoryId : null,
+        basePrice: data.basePrice,
+        compareAtPrice: data.compareAtPrice ?? null,
+        taxRate: data.taxRate,
+        unit: data.unit,
+        stock: data.stock,
+        trackStock: data.trackStock,
+        status: data.status,
+        originRegion: data.originRegion ?? null,
+        rejectionNote: data.rejectionNote ?? null,
+        expiresAt: parseExpirationDateInput(data.expiresAt),
+      },
+    })
+    return {
+      result: updatedProduct,
+      audit: {
+        action: 'PRODUCT_EDITED',
+        entityType: 'Product',
+        entityId: productId,
+        before,
+        after: productSnapshot(updatedProduct),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productos')
@@ -238,29 +242,33 @@ export async function adminUpdateVendor(vendorId: string, input: AdminVendorInpu
   }
 
   const before = vendorSnapshot(vendor)
-
-  const updated = await db.vendor.update({
-    where: { id: vendorId },
-    data: {
-      displayName: data.displayName,
-      slug: data.slug,
-      description: data.description ?? null,
-      location: data.location ?? null,
-      status: data.status,
-      commissionRate: data.commissionRate,
-    },
-  })
-
   const ip = await getAuditRequestIp()
-  await createAuditLog({
-    action: 'VENDOR_EDITED',
-    entityType: 'Vendor',
-    entityId: vendorId,
-    before,
-    after: vendorSnapshot(updated),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+
+  const updated = await mutateWithAudit(async tx => {
+    const updatedVendor = await tx.vendor.update({
+      where: { id: vendorId },
+      data: {
+        displayName: data.displayName,
+        slug: data.slug,
+        description: data.description ?? null,
+        location: data.location ?? null,
+        status: data.status,
+        commissionRate: data.commissionRate,
+      },
+    })
+    return {
+      result: updatedVendor,
+      audit: {
+        action: 'VENDOR_EDITED',
+        entityType: 'Vendor',
+        entityId: vendorId,
+        before,
+        after: vendorSnapshot(updatedVendor),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/productores')
@@ -348,35 +356,39 @@ export async function adminUpdatePromotion(promotionId: string, input: AdminProm
   const value = data.kind === 'FREE_SHIPPING' ? 0 : data.value
 
   const before = promotionSnapshot(current)
-
-  const updated = await db.promotion.update({
-    where: { id: promotionId },
-    data: {
-      name: data.name,
-      code,
-      kind: data.kind,
-      value,
-      scope: data.scope,
-      productId: data.scope === 'PRODUCT' ? data.productId ?? null : null,
-      categoryId: data.scope === 'CATEGORY' ? data.categoryId ?? null : null,
-      minSubtotal: data.minSubtotal ?? null,
-      maxRedemptions: data.maxRedemptions ?? null,
-      perUserLimit: data.perUserLimit ?? 1,
-      startsAt: new Date(data.startsAt),
-      endsAt: new Date(data.endsAt),
-    },
-  })
-
   const ip = await getAuditRequestIp()
-  await createAuditLog({
-    action: 'PROMOTION_EDITED',
-    entityType: 'Promotion',
-    entityId: promotionId,
-    before,
-    after: promotionSnapshot(updated),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+
+  await mutateWithAudit(async tx => {
+    const updated = await tx.promotion.update({
+      where: { id: promotionId },
+      data: {
+        name: data.name,
+        code,
+        kind: data.kind,
+        value,
+        scope: data.scope,
+        productId: data.scope === 'PRODUCT' ? data.productId ?? null : null,
+        categoryId: data.scope === 'CATEGORY' ? data.categoryId ?? null : null,
+        minSubtotal: data.minSubtotal ?? null,
+        maxRedemptions: data.maxRedemptions ?? null,
+        perUserLimit: data.perUserLimit ?? 1,
+        startsAt: new Date(data.startsAt),
+        endsAt: new Date(data.endsAt),
+      },
+    })
+    return {
+      result: updated,
+      audit: {
+        action: 'PROMOTION_EDITED',
+        entityType: 'Promotion',
+        entityId: promotionId,
+        before,
+        after: promotionSnapshot(updated),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/promociones')
@@ -414,28 +426,32 @@ export async function adminUpdateSubscriptionPlan(planId: string, input: AdminSu
   if (!plan) throw new Error('Plan no encontrado')
 
   const before = planSnapshot(plan)
-
-  const updated = await db.subscriptionPlan.update({
-    where: { id: planId },
-    data: {
-      cadence: data.cadence,
-      priceSnapshot: data.priceSnapshot,
-      taxRateSnapshot: data.taxRateSnapshot,
-      cutoffDayOfWeek: data.cutoffDayOfWeek,
-      archivedAt: data.archived ? (plan.archivedAt ?? new Date()) : null,
-    },
-  })
-
   const ip = await getAuditRequestIp()
-  await createAuditLog({
-    action: 'SUBSCRIPTION_PLAN_EDITED',
-    entityType: 'SubscriptionPlan',
-    entityId: planId,
-    before,
-    after: planSnapshot(updated),
-    actorId: session.user.id,
-    actorRole: session.user.role,
-    ip,
+
+  await mutateWithAudit(async tx => {
+    const updated = await tx.subscriptionPlan.update({
+      where: { id: planId },
+      data: {
+        cadence: data.cadence,
+        priceSnapshot: data.priceSnapshot,
+        taxRateSnapshot: data.taxRateSnapshot,
+        cutoffDayOfWeek: data.cutoffDayOfWeek,
+        archivedAt: data.archived ? (plan.archivedAt ?? new Date()) : null,
+      },
+    })
+    return {
+      result: updated,
+      audit: {
+        action: 'SUBSCRIPTION_PLAN_EDITED',
+        entityType: 'SubscriptionPlan',
+        entityId: planId,
+        before,
+        after: planSnapshot(updated),
+        actorId: session.user.id,
+        actorRole: session.user.role,
+        ip,
+      },
+    }
   })
 
   safeRevalidatePath('/admin/suscripciones')

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -25,6 +25,37 @@ interface AuditLogWriter {
   }
 }
 
+/**
+ * Runs a mutation callback inside a `db.$transaction` and persists the
+ * resulting `AuditLog` row in the same transaction. If either the
+ * mutation or the audit insert fails, both roll back. This is the
+ * standard helper every admin server action should use when it
+ * changes state that must be forensically tracked.
+ *
+ * Pattern (see src/domains/admin/actions.ts for real usages):
+ *
+ *   const ip = await getAuditRequestIp()
+ *   const updated = await mutateWithAudit(async tx => {
+ *     const u = await tx.vendor.update({ where: { id }, data: {...} })
+ *     return {
+ *       result: u,
+ *       audit: { action, entityType, entityId, before, after, actorId, actorRole, ip },
+ *     }
+ *   })
+ */
+export async function mutateWithAudit<T>(
+  mutation: (
+    tx: Prisma.TransactionClient
+  ) => Promise<{ result: T; audit: AuditLogInput }>
+): Promise<T> {
+  const { db } = await import('@/lib/db')
+  return db.$transaction(async tx => {
+    const { result, audit } = await mutation(tx)
+    await createAuditLog(audit, tx)
+    return result
+  })
+}
+
 export function extractAuditIp(headerStore: Pick<Headers, 'get'>) {
   const forwardedFor = headerStore.get('x-forwarded-for')
   if (forwardedFor) {
@@ -66,33 +97,39 @@ function isProxyTrustedFromEnv(): boolean {
   return false
 }
 
+/**
+ * Writes an AuditLog row.
+ *
+ * Expected to be called from inside a `db.$transaction(async tx => ...)`
+ * callback with `tx` passed as the second argument. Doing so makes the
+ * audit write atomic with the mutation that triggered it: if the audit
+ * insert fails, the mutation rolls back. Without this guarantee the
+ * forensic trail would have silent holes that compliance cannot
+ * reconstruct from.
+ *
+ * Failures are deliberately NOT caught here. A DB-level audit error
+ * must propagate out of the transaction so the caller's mutation
+ * rolls back and the operator sees a loud failure. Previous fire-and-
+ * forget semantics (try/catch + console.error) were removed in #381.
+ */
 export async function createAuditLog(
   input: AuditLogInput,
   client?: AuditLogWriter
 ) {
-  try {
-    const writer = client ?? await loadAuditClient()
+  const writer = client ?? await loadAuditClient()
 
-    await writer.auditLog.create({
-      data: {
-        action: input.action,
-        entityType: input.entityType,
-        entityId: input.entityId,
-        before: input.before,
-        after: input.after,
-        actorId: input.actorId,
-        actorRole: input.actorRole,
-        ip: input.ip ?? null,
-      },
-    })
-  } catch (error) {
-    console.error('Failed to write audit log', {
+  await writer.auditLog.create({
+    data: {
       action: input.action,
       entityType: input.entityType,
       entityId: input.entityId,
-      error,
-    })
-  }
+      before: input.before,
+      after: input.after,
+      actorId: input.actorId,
+      actorRole: input.actorRole,
+      ip: input.ip ?? null,
+    },
+  })
 }
 
 export function readAuditPayload<TBefore = unknown, TAfter = TBefore>(entry: {

--- a/test/features/audit.test.ts
+++ b/test/features/audit.test.ts
@@ -63,14 +63,16 @@ test('extractAuditIp handles x-forwarded-for with single IP', () => {
   assert.equal(ip, '10.0.0.5')
 })
 
-test('createAuditLog swallows persistence failures so admin actions keep running', async () => {
+test('createAuditLog propagates persistence failures so callers roll back', async () => {
+  // Contract flipped in #381: the helper used to swallow errors via
+  // try/catch + console.error, which silently left a mutation
+  // committed without a forensic trail. It now re-throws, so the
+  // enclosing db.$transaction aborts the mutation and the operator
+  // sees a loud failure instead of a missing audit row.
   let calls = 0
-  const originalConsoleError = console.error
-  console.error = () => undefined
-
-  try {
-    await assert.doesNotReject(async () => {
-      await createAuditLog(
+  await assert.rejects(
+    () =>
+      createAuditLog(
         {
           action: 'VENDOR_APPROVED',
           entityType: 'Vendor',
@@ -88,12 +90,10 @@ test('createAuditLog swallows persistence failures so admin actions keep running
               throw new Error('db offline')
             },
           },
-        }
-      )
-    })
-  } finally {
-    console.error = originalConsoleError
-  }
+        },
+      ),
+    /db offline/,
+  )
 
   assert.equal(calls, 1)
 })

--- a/test/integration/admin-audit-log.test.ts
+++ b/test/integration/admin-audit-log.test.ts
@@ -18,12 +18,13 @@ import {
 // second row. Guards against silent regressions in src/lib/audit.ts
 // or in any caller that forgets the audit side effect.
 //
-// Known gap NOT covered by this test: `createAuditLog` wraps its
-// db.create in a try/catch that only console.errors on failure, so
-// an audit insert can silently fail while the mutation commits. The
-// audit write also lives outside db.$transaction in admin/actions.ts.
-// Both are pre-existing structural concerns — fixing them changes
-// production behavior and belongs in a separate PR, not in this test.
+// As of #381 the mutation + audit insert run inside a single
+// `db.$transaction` via `mutateWithAudit`, so a failing audit write
+// will roll back the mutation instead of silently leaving a hole in
+// the forensic trail. A dedicated rollback test (inject a failing
+// auditLog.create and assert the vendor row is unchanged) requires
+// mocking support the integration harness does not currently expose;
+// add one when `helpers.ts` grows a `withFailingAuditLog` fixture.
 
 beforeEach(async () => {
   await resetIntegrationDatabase()


### PR DESCRIPTION
## Summary

Closes #381.

Admin mutations used to write their `AuditLog` row outside the Prisma transaction, and `createAuditLog` swallowed errors with `try/catch + console.error`. An audit insert could silently fail while the mutation committed, leaving forensic holes that compliance cannot reconstruct from.

This PR:

- Adds `mutateWithAudit(tx => ...)` in `src/lib/audit.ts` — runs the caller's mutation and the audit insert inside a single `db.$transaction`. If either fails, both roll back.
- Removes the try/catch swallow in `createAuditLog`. Audit failures now propagate out loudly.
- Migrates every admin caller of `createAuditLog` to the new helper.

Reference transformations (already in the WIP commit): `approveVendor`, `rejectVendor`, `suspendVendor` in `src/domains/admin/actions.ts`.

## Functions migrated in this PR

**`src/domains/admin/actions.ts`**
- `createCommissionRule`
- `toggleCommissionRule`
- `deleteCommissionRule`
- `createShippingZone`
- `addShippingRate`
- `deleteShippingRate`
- `reviewProduct` (keeps `revalidateCatalogExperience` outside the tx; `mutateWithAudit` returns the updated product so the outer scope still has the slug)
- `suspendProduct` (same pattern as `reviewProduct`)
- `approveSettlement`
- `markSettlementPaid`

**`src/domains/admin/writes.ts`**
- `adminUpdateProduct`
- `adminUpdateVendor`
- `adminUpdatePromotion`
- `adminUpdateSubscriptionPlan`

`cancelOrder` is untouched — it already uses `$transaction` and writes `OrderEvent`, not `AuditLog`.

## The `updateMarketplaceConfigAction` exception

`updateMarketplaceConfigAction` persists via `setMarketplaceConfig(...)`, a helper that is NOT a direct Prisma call, so it cannot participate in `db.$transaction`. It keeps the legacy `createAuditLog(..., db)` path with `db` passed explicitly, and a one-line comment explains why. The audit write still raises on failure now (no more swallow), so the worst case is a mutation that committed with a missing audit row — a regression to the pre-PR status quo for this one caller, not a new hole.

## Test changes

`test/integration/admin-audit-log.test.ts` — dropped the stale "Known gap NOT covered" paragraph. The positive-case tests still run. A dedicated rollback test (inject a failing `auditLog.create` and assert the vendor row is unchanged) requires mocking support the integration harness does not expose; the comment points at where to add it once `helpers.ts` grows a `withFailingAuditLog` fixture.

## Test plan

- [x] `npx tsc -p tsconfig.test.json --noEmit` — zero errors on touched files
- [ ] Run `admin-audit-log` integration test against a real DB (not available in worktree)
- [ ] Manual smoke on staging: approve vendor, review product, edit promotion — confirm audit rows land and no regressions

Closes #381

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>