### PR TITLE
fix(vendor): show category icon in product form dropdown

### DIFF
--- a/src/components/vendor/ProductForm.tsx
+++ b/src/components/vendor/ProductForm.tsx
@@ -345,7 +345,7 @@ export function ProductForm({ categories, initialData, vendorLocation }: Product
             <option value="">{t('vendor.noCategory')}</option>
             {categories.map(category => (
               <option key={category.id} value={category.id}>
-                {category.name}
+                {category.icon ? `${category.icon} ${category.name}` : category.name}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- Prepend `category.icon` to each `<option>` label in the vendor product form so the dropdown matches the icon treatment used in the header and filter panel.

## Test plan
- [ ] Visit `/vendor/productos/nuevo` and confirm category options render with their emoji prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)