### PR TITLE
fix(i18n): home hero stats — labelKey pattern + locale-aware formatting

### DIFF
--- a/src/app/(public)/HomePageClient.tsx
+++ b/src/app/(public)/HomePageClient.tsx
@@ -96,12 +96,32 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
 
               {/* Stats */}
               <div className="mt-10 grid grid-cols-3 gap-6 border-t border-white/10 pt-8">
-                {heroStats.map(s => (
-                  <div key={s.label}>
-                    <p className="text-2xl font-bold text-white">{s.value}</p>
-                    <p className="mt-0.5 text-sm text-emerald-300/80">{s.label}</p>
-                  </div>
-                ))}
+                {heroStats.map(s => {
+                  const intlLocale = locale === 'en' ? 'en-US' : 'es-ES'
+                  let value: string
+                  if (s.kind === 'count') {
+                    if (s.count > 0) {
+                      const formatted = new Intl.NumberFormat(intlLocale, {
+                        notation: 'compact',
+                        compactDisplay: 'short',
+                        maximumFractionDigits: s.count >= 1000 ? 1 : 0,
+                      }).format(s.count)
+                      value = `${formatted}+`
+                    } else {
+                      value = '0'
+                    }
+                  } else if (s.kind === 'rating') {
+                    value = `${s.rating.toFixed(1)}★`
+                  } else {
+                    value = t(s.valueKey)
+                  }
+                  return (
+                    <div key={s.labelKey}>
+                      <p className="text-2xl font-bold text-white">{value}</p>
+                      <p className="mt-0.5 text-sm text-emerald-300/80">{t(s.labelKey)}</p>
+                    </div>
+                  )
+                })}
               </div>
             </div>
 

--- a/src/domains/catalog/home.ts
+++ b/src/domains/catalog/home.ts
@@ -4,32 +4,40 @@ export interface HomeStatsInput {
   averageRating: number | null
 }
 
-export interface HomeStat {
-  value: string
-  label: string
-}
-
-function formatCompactCount(value: number) {
-  return new Intl.NumberFormat('es-ES', {
-    notation: 'compact',
-    compactDisplay: 'short',
-    maximumFractionDigits: value >= 1000 ? 1 : 0,
-  }).format(value)
-}
+// Locale-agnostic stat descriptor. The server helper emits only
+// i18n keys + raw numbers; HomePageClient resolves them at render
+// time via useT() + Intl.NumberFormat. Keeping the helper pure lets
+// the home page stay cached (revalidate = 3600) across locales.
+//
+// See src/i18n/README.md §3 for the labelKey pattern and PR #387
+// follow-up for why this file was originally returning hardcoded ES.
+export type HomeStat =
+  | { kind: 'count'; labelKey: 'home.stats.activeVendors' | 'home.stats.activeProducts'; count: number }
+  | { kind: 'rating'; labelKey: 'home.stats.averageRating'; rating: number }
+  | { kind: 'newBadge'; labelKey: 'home.stats.marketplaceGrowing'; valueKey: 'home.stats.newBadge' }
 
 export function buildHomeStats(input: HomeStatsInput): HomeStat[] {
   return [
     {
-      value: input.activeVendors > 0 ? `${formatCompactCount(input.activeVendors)}+` : '0',
-      label: 'Productores activos',
+      kind: 'count',
+      labelKey: 'home.stats.activeVendors',
+      count: input.activeVendors,
     },
     {
-      value: input.activeProducts > 0 ? `${formatCompactCount(input.activeProducts)}+` : '0',
-      label: 'Productos publicados',
+      kind: 'count',
+      labelKey: 'home.stats.activeProducts',
+      count: input.activeProducts,
     },
-    {
-      value: input.averageRating ? `${input.averageRating.toFixed(1)}★` : 'Nueva',
-      label: input.averageRating ? 'Valoración media' : 'Marketplace en crecimiento',
-    },
+    input.averageRating
+      ? {
+          kind: 'rating',
+          labelKey: 'home.stats.averageRating',
+          rating: input.averageRating,
+        }
+      : {
+          kind: 'newBadge',
+          labelKey: 'home.stats.marketplaceGrowing',
+          valueKey: 'home.stats.newBadge',
+        },
   ]
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -89,6 +89,13 @@ const en: Record<TranslationKeys, string> = {
   'hero.quickAccess': 'Quick access',
   'hero.loginCta': 'View demo credentials →',
 
+  // Home hero stats
+  'home.stats.activeVendors': 'Active producers',
+  'home.stats.activeProducts': 'Published products',
+  'home.stats.averageRating': 'Average rating',
+  'home.stats.marketplaceGrowing': 'Marketplace growing',
+  'home.stats.newBadge': 'New',
+
   // Trust bar
   'trust.shipping': 'Shipping across the peninsula',
   'trust.payment': 'Secure payment guaranteed',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -87,6 +87,13 @@ const es = {
   'hero.quickAccess': 'Accesos rápidos',
   'hero.loginCta': 'Ver credenciales demo →',
 
+  // Home hero stats
+  'home.stats.activeVendors': 'Productores activos',
+  'home.stats.activeProducts': 'Productos publicados',
+  'home.stats.averageRating': 'Valoración media',
+  'home.stats.marketplaceGrowing': 'Marketplace en crecimiento',
+  'home.stats.newBadge': 'Nueva',
+
   // Trust bar
   'trust.shipping': 'Envío a toda la península',
   'trust.payment': 'Pago seguro garantizado',

--- a/test/features/catalog-home.test.ts
+++ b/test/features/catalog-home.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { buildHomeStats } from '@/domains/catalog/home'
 
-test('buildHomeStats formats active catalog metrics for the hero', () => {
+test('buildHomeStats emits labelKey descriptors for the hero', () => {
   const stats = buildHomeStats({
     activeVendors: 12,
     activeProducts: 148,
@@ -10,19 +10,22 @@ test('buildHomeStats formats active catalog metrics for the hero', () => {
   })
 
   assert.deepEqual(stats, [
-    { value: '12+', label: 'Productores activos' },
-    { value: '148+', label: 'Productos publicados' },
-    { value: '4.7★', label: 'Valoración media' },
+    { kind: 'count', labelKey: 'home.stats.activeVendors', count: 12 },
+    { kind: 'count', labelKey: 'home.stats.activeProducts', count: 148 },
+    { kind: 'rating', labelKey: 'home.stats.averageRating', rating: 4.67 },
   ])
 })
 
-test('buildHomeStats falls back gracefully when rating is not available yet', () => {
+test('buildHomeStats falls back to the newBadge descriptor when rating is not available yet', () => {
   const stats = buildHomeStats({
     activeVendors: 1,
     activeProducts: 3,
     averageRating: null,
   })
 
-  assert.equal(stats[2]?.value, 'Nueva')
-  assert.equal(stats[2]?.label, 'Marketplace en crecimiento')
+  assert.deepEqual(stats[2], {
+    kind: 'newBadge',
+    labelKey: 'home.stats.marketplaceGrowing',
+    valueKey: 'home.stats.newBadge',
+  })
 })

--- a/test/features/home-formatting.test.ts
+++ b/test/features/home-formatting.test.ts
@@ -7,28 +7,39 @@ function readSource(path: string) {
   return readFileSync(new URL(path, import.meta.url), 'utf8')
 }
 
-test('buildHomeStats formats compact counters for large catalog numbers', () => {
+test('buildHomeStats carries raw counters through the descriptor shape', () => {
   const stats = buildHomeStats({
     activeVendors: 1234,
     activeProducts: 18250,
     averageRating: 4.92,
   })
 
-  assert.equal(stats[0]?.value, '1,2 mil+')
-  assert.equal(stats[1]?.value, '18,3 mil+')
-  assert.equal(stats[2]?.value, '4.9★')
+  assert.equal(stats[0]?.kind, 'count')
+  assert.equal(stats[0]?.kind === 'count' ? stats[0].count : null, 1234)
+  assert.equal(stats[1]?.kind, 'count')
+  assert.equal(stats[1]?.kind === 'count' ? stats[1].count : null, 18250)
+  assert.equal(stats[2]?.kind, 'rating')
+  assert.equal(stats[2]?.kind === 'rating' ? stats[2].rating : null, 4.92)
 })
 
-test('buildHomeStats shows zero values when there is no live catalog yet', () => {
+test('buildHomeStats emits the growing-marketplace labelKey when there is no live catalog yet', () => {
   const stats = buildHomeStats({
     activeVendors: 0,
     activeProducts: 0,
     averageRating: null,
   })
 
-  assert.equal(stats[0]?.value, '0')
-  assert.equal(stats[1]?.value, '0')
-  assert.equal(stats[2]?.label, 'Marketplace en crecimiento')
+  assert.equal(stats[0]?.kind === 'count' ? stats[0].count : null, 0)
+  assert.equal(stats[1]?.kind === 'count' ? stats[1].count : null, 0)
+  assert.equal(stats[2]?.labelKey, 'home.stats.marketplaceGrowing')
+})
+
+test('HomePageClient formats the hero counters with locale-aware Intl.NumberFormat', () => {
+  const source = readSource('../../src/app/(public)/HomePageClient.tsx')
+
+  assert.match(source, /new Intl\.NumberFormat\(intlLocale/)
+  assert.match(source, /notation: 'compact'/)
+  assert.match(source, /t\(s\.labelKey\)/)
 })
 
 test('home page client uses locale-aware helpers for quick-access cards and category labels', () => {


### PR DESCRIPTION
## Summary
- The home page hero stats ("Productores activos", "Productos publicados", "Valoración media", fallback "Nueva / Marketplace en crecimiento") were hardcoded Spanish strings returned by `buildHomeStats()` in `src/domains/catalog/home.ts`. Because the contract test in `test/contracts/i18n-no-hardcoded-literals.test.ts` only scans `src/app/**`, it never saw this code path — visitors with `locale=en` still got the Spanish labels under an otherwise-translated hero (see user report / screenshot).
- Refactored `buildHomeStats()` to the `labelKey` pattern documented in `src/i18n/README.md` §3: the helper now returns a discriminated union of pure descriptors (`{ kind, labelKey, count | rating | valueKey }`) and is fully locale-agnostic, so the home page's `revalidate = 3600` cache stays correct across locales.
- `HomePageClient` resolves the `labelKey` via `useT()` and now formats the raw counters at render time with `Intl.NumberFormat` seeded from the active locale (`es-ES` / `en-US` compact notation), so `1234` → `1,2 mil+` in Spanish and `1.2K+` in English instead of the old always-Spanish output.
- Added five `home.stats.*` keys to both `locales/es.ts` and `locales/en.ts`.
- Rewrote `catalog-home.test.ts` and `home-formatting.test.ts` to assert the new descriptor contract, and added a source-regex test that pins the locale-aware `Intl.NumberFormat(intlLocale, …)` call in `HomePageClient` so a future refactor that re-hardcodes `'es-ES'` fails CI.

Follow-ups not in this PR (flagged by the full audit the user requested, tracked separately to keep the diff scoped):
- `src/lib/navigation.ts` (buyer account items still hardcoded ES — user-facing)
- `src/components/catalog/ProductPromotions.tsx` (scope/status labels + offer badges)
- `src/components/ui/modal.tsx` (default aria-label / close button)
- Several auth flows still in the `i18n-no-hardcoded-literals` allowlist (forgot/reset password, register)
- The contract test itself does not scan `src/components/**` or `src/domains/**` — expanding its coverage is a separate PR.

## Test plan
- [x] `node ./scripts/run-node-tests.mjs test/features/catalog-home.test.ts test/features/home-formatting.test.ts test/contracts/i18n-parity.test.ts` → 697 pass / 0 fail
- [x] `npx tsc --noEmit` → clean
- [ ] Manual: load `/` with `mp_locale=en` cookie and confirm the hero stats row renders English labels ("Active producers", "Published products", "Average rating") and English-formatted counters
- [ ] Manual: load `/` with `mp_locale=es` and confirm nothing regressed visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)