### PR TITLE
fix(dev): LAN access — login + HMR via 192.168.x.y:3000

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,12 @@ export function buildHeaderRules(isDevelopment = process.env.NODE_ENV === 'devel
 }
 
 const nextConfig: NextConfig = {
+  // Allow LAN access to the dev server (e.g. testing on a phone via
+  // http://192.168.x.y:3000). Without this, Next.js 16 blocks cross-origin
+  // requests to /_next/* dev resources, which breaks HMR and the dev overlay
+  // when the page is loaded from a non-localhost host.
+  // The pattern matches any host on a typical home/office private network.
+  allowedDevOrigins: ['192.168.*.*', '10.*.*.*', '*.local'],
   experimental: {
     staleTimes: {
       // Default is 300 s (matches revalidate = 300). That causes Link-navigation to serve

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,4 +1,5 @@
 import { handlers as nextAuthHandlers } from '@/lib/auth'
+import { reqWithHostHeader } from '@/lib/auth-host'
 import { NextRequest, NextResponse } from 'next/server'
 import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
 
@@ -6,7 +7,9 @@ import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
  * NextAuth has built-in handlers for GET/POST to /api/auth/[...nextauth]
  * We wrap the POST handler to add rate limiting for login attempts
  */
-export const GET = nextAuthHandlers.GET
+export function GET(req: NextRequest) {
+  return nextAuthHandlers.GET(reqWithHostHeader(req))
+}
 
 export async function POST(req: NextRequest) {
   // Check if this is a signin request (NextAuth uses query params)
@@ -34,6 +37,5 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // Pass through to NextAuth handler
-  return nextAuthHandlers.POST(req)
+  return nextAuthHandlers.POST(reqWithHostHeader(req))
 }

--- a/src/lib/auth-host.ts
+++ b/src/lib/auth-host.ts
@@ -65,6 +65,30 @@ export function normalizeAuthHostEnv(env: NodeJS.ProcessEnv) {
   return nextEnv
 }
 
+/**
+ * Rebuild a NextRequest so its URL reflects the actual `Host` header instead
+ * of whichever hostname `next dev` decided to bake into `req.url`. In dev,
+ * Next.js constructs `req.url` from its bind hostname (e.g. `localhost`),
+ * so a request reaching the server via `192.168.1.76:3000` still appears as
+ * `http://localhost:3000/...` to route handlers. Auth.js then derives its
+ * callback URL from `req.url` and redirects users to a host that doesn't
+ * carry their session cookie. This helper re-anchors the URL on the real
+ * host so cross-origin LAN access (mobile/tablet testing) works.
+ */
+export function reqWithHostHeader<T extends Request>(req: T): T {
+  const host = req.headers.get('x-forwarded-host') ?? req.headers.get('host')
+  if (!host) return req
+  const proto = req.headers.get('x-forwarded-proto') ?? new URL(req.url).protocol.replace(/:$/, '')
+  const url = new URL(req.url)
+  if (url.host === host && url.protocol === `${proto}:`) return req
+  url.host = host
+  url.protocol = `${proto}:`
+  // `Request` (and `NextRequest`) accept another Request as the init argument
+  // and inherit its method/body/headers — so this reuses the original body.
+  const Ctor = req.constructor as new (input: string, init: T) => T
+  return new Ctor(url.toString(), req)
+}
+
 export function applyNormalizedAuthHostEnv(env: NodeJS.ProcessEnv) {
   const normalizedEnv = normalizeAuthHostEnv(env)
 


### PR DESCRIPTION
## Summary

Two dev-only bugs surfaced when accessing the dev server from a LAN IP (e.g. testing on a phone via `http://192.168.1.76:3000`):

- **Credentials login bounced back to `/login`.** In `next dev`, Next.js builds `req.url` from its bind hostname (`localhost`), so a request reaching via a LAN IP still arrives at route handlers as `http://localhost:3000/...`. Auth.js derives its callback URL from `req.url`, redirects to `localhost`, and the browser follows that to a different origin where the freshly-set session cookie isn't sent → middleware bounces back to login.
- **HMR / dev overlay broken from non-localhost hosts.** Next.js 16 blocks cross-origin requests to `/_next/*` dev resources by default (`Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "192.168.1.76"`).

## Changes

- `reqWithHostHeader()` in `src/lib/auth-host.ts` rebuilds the request URL from the real `Host` header (with `x-forwarded-host`/`x-forwarded-proto` fallback), preserving body/method/headers via the `Request(url, init)` constructor.
- `src/app/api/auth/[...nextauth]/route.ts` wires it into both GET and POST handlers.
- `next.config.ts` adds `allowedDevOrigins: ['192.168.*.*', '10.*.*.*', '*.local']` so HMR and dev resources work from phones/tablets on the same Wi-Fi.

## Test plan

- [x] Reproduced the broken redirect with `curl` against `192.168.1.76:3000` (returned `Location: http://localhost:3000/cuenta`).
- [x] After fix, same `curl` returns `Location: http://192.168.1.76:3000/cuenta` and the session cookie is set on the LAN origin.
- [x] `curl` against `localhost:3000` still redirects to `http://localhost:3000/cuenta` — no regression.
- [x] `tsc --noEmit` clean.
- [x] Full test suite (697 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)