### PR TITLE
fix(mobile): /productos horizontal overflow + consistent locale toggle

### DIFF
--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -58,7 +58,7 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
   return (
     <article
       className={[
-        'group flex h-full flex-col rounded-2xl',
+        'group flex h-full min-w-0 flex-col rounded-2xl',
         'border border-[var(--border)] bg-[var(--surface)]',
         'shadow-sm hover:border-[var(--border-strong)] hover:shadow-md hover:-translate-y-1',
         'transition-all duration-200',
@@ -139,15 +139,15 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
           </div>
 
           {product.vendor && (
-            <div className="mt-1.5 flex items-center gap-1 text-xs text-[var(--muted)]">
+            <div className="mt-1.5 flex min-w-0 items-center gap-1 text-xs text-[var(--muted)]">
               {product.originRegion && (
                 <>
                   <MapPinIcon className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{product.originRegion}</span>
-                  <span className="text-[var(--muted-light)]">·</span>
+                  <span className="min-w-0 truncate">{product.originRegion}</span>
+                  <span className="shrink-0 text-[var(--muted-light)]">·</span>
                 </>
               )}
-              <span className="truncate">{product.vendor.displayName}</span>
+              <span className="min-w-0 truncate">{product.vendor.displayName}</span>
             </div>
           )}
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -205,7 +205,7 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
 
           {/* Right actions */}
           <div className="ml-auto flex items-center gap-1">
-            <LanguageToggle className="hidden sm:flex" />
+            <LanguageToggle />
             <ThemeToggle />
 
             {!userContextReady ? (
@@ -410,20 +410,20 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
               </div>
             )}
 
-            {/* Footer settings row: language + producer portal link */}
-            <div className="mx-0 my-2 border-t border-[var(--border)] sm:hidden" />
-            <div className="flex items-center justify-between gap-3 px-1 pt-1 sm:hidden">
-              <LanguageToggle />
-              {userContextReady && !currentUser && (
-                <Link
-                  href="/login?callbackUrl=%2Fvendor%2Fdashboard"
-                  onClick={() => setMobileOpen(false)}
-                  className="text-xs font-medium text-[var(--muted)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 rounded"
-                >
-                  {t('producerPortal')}
-                </Link>
-              )}
-            </div>
+            {userContextReady && !currentUser && (
+              <>
+                <div className="mx-0 my-2 border-t border-[var(--border)] sm:hidden" />
+                <div className="flex items-center justify-end px-1 pt-1 sm:hidden">
+                  <Link
+                    href="/login?callbackUrl=%2Fvendor%2Fdashboard"
+                    onClick={() => setMobileOpen(false)}
+                    className="text-xs font-medium text-[var(--muted)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 rounded"
+                  >
+                    {t('producerPortal')}
+                  </Link>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
Two reported mobile bugs on `/productos`:

- **Horizontal scroll on portrait.** `ProductCard`'s vendor row used `truncate` on flex children without `min-w-0`, so the children demanded their full intrinsic width and pushed grid tracks past the viewport. Added `min-w-0` on the article root, the vendor flex, and each truncating span; marked the dot separator `shrink-0`.
- **Right-action area looked different in landscape.** `LanguageToggle` was `hidden sm:flex`, so it only appeared next to `ThemeToggle` at ≥640px — landscape phones cross that breakpoint and suddenly showed the desktop layout. Now visible in the header bar at all sizes; the duplicated copy was removed from the mobile drawer.

## Test plan
- [ ] On a phone (portrait), open `/productos` and confirm no horizontal scroll, even with long region/vendor names.
- [ ] Rotate to landscape and confirm the header right-action area is unchanged (no surprise icons appearing).
- [ ] Verify the language toggle still works inside the mobile drawer flow (it now lives in the top bar instead of the drawer footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)