### PR TITLE
fix(vendor): portal product actions menu to fix stacking + multi-open

### DIFF
--- a/src/components/vendor/ProductActions.tsx
+++ b/src/components/vendor/ProductActions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { submitForReview, deleteProduct } from '@/domains/vendors/actions'
 import { Modal } from '@/components/ui/modal'
@@ -13,13 +14,53 @@ interface Props {
   product: { id: string; name: string; status: string; slug: string; expiresAt?: Date | string | null }
 }
 
+const PRODUCT_ACTIONS_OPEN_EVENT = 'product-actions:open'
+
 export function ProductActions({ product }: Props) {
   const t = useT()
   const isExpired = isProductExpired(product.expiresAt)
+  const instanceId = useId()
+  const buttonRef = useRef<HTMLButtonElement>(null)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [coords, setCoords] = useState<{ top: number; right: number } | null>(null)
   const [deleteModal, setDeleteModal] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    function onOtherOpen(e: Event) {
+      if ((e as CustomEvent).detail !== instanceId) setMenuOpen(false)
+    }
+    window.addEventListener(PRODUCT_ACTIONS_OPEN_EVENT, onOtherOpen)
+    return () => window.removeEventListener(PRODUCT_ACTIONS_OPEN_EVENT, onOtherOpen)
+  }, [instanceId])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function close() { setMenuOpen(false) }
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') setMenuOpen(false) }
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [menuOpen])
+
+  function toggleMenu() {
+    if (menuOpen) {
+      setMenuOpen(false)
+      return
+    }
+    const rect = buttonRef.current?.getBoundingClientRect()
+    if (rect) {
+      setCoords({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+    }
+    setMenuOpen(true)
+    window.dispatchEvent(new CustomEvent(PRODUCT_ACTIONS_OPEN_EVENT, { detail: instanceId }))
+  }
 
   async function handleSubmitReview() {
     setLoading(true)
@@ -47,9 +88,10 @@ export function ProductActions({ product }: Props) {
 
   return (
     <>
-      <div className="relative shrink-0">
+      <div className="shrink-0">
         <button
-          onClick={() => setMenuOpen(v => !v)}
+          ref={buttonRef}
+          onClick={toggleMenu}
           aria-label={t('vendor.productActions.menuLabel')}
           aria-haspopup="menu"
           aria-expanded={menuOpen}
@@ -57,48 +99,54 @@ export function ProductActions({ product }: Props) {
         >
           <EllipsisVerticalIcon className="h-5 w-5" />
         </button>
-        {menuOpen && (
-          <>
-            <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
-            <div className="absolute right-0 top-full z-20 mt-1 w-44 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-1 shadow-2xl ring-1 ring-black/5 backdrop-blur dark:ring-white/10">
+      </div>
+      {menuOpen && coords && typeof document !== 'undefined' && createPortal(
+        <>
+          <div className="fixed inset-0 z-[100]" onClick={() => setMenuOpen(false)} />
+          <div
+            role="menu"
+            style={{ top: coords.top, right: coords.right }}
+            className="fixed z-[101] w-44 rounded-xl border border-[var(--border)] bg-[var(--surface)] py-1 shadow-2xl ring-1 ring-black/5 dark:ring-white/10"
+          >
+            <Link
+              href={`/vendor/productos/${product.id}`}
+              className="block px-4 py-2 text-sm text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+              onClick={() => setMenuOpen(false)}
+            >
+              {t('vendor.productActions.edit')}
+            </Link>
+            {['DRAFT', 'REJECTED'].includes(product.status) && (
+              <button
+                onClick={handleSubmitReview}
+                disabled={loading}
+                aria-busy={loading || undefined}
+                className="block w-full px-4 py-2 text-left text-sm text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-emerald-400 dark:hover:bg-emerald-950/35"
+              >
+                {loading ? t('vendor.productActions.sending') : t('vendor.productActions.sendReview')}
+              </button>
+            )}
+            {product.status === 'ACTIVE' && !isExpired && (
               <Link
-                href={`/vendor/productos/${product.id}`}
+                href={`/productos/${product.slug}`}
+                target="_blank"
                 className="block px-4 py-2 text-sm text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
                 onClick={() => setMenuOpen(false)}
               >
-                {t('vendor.productActions.edit')}
+                {t('vendor.productActions.viewInStore')}
               </Link>
-              {['DRAFT', 'REJECTED'].includes(product.status) && (
-                <button
-                  onClick={handleSubmitReview}
-                  disabled={loading}
-                  aria-busy={loading || undefined}
-                  className="block w-full px-4 py-2 text-left text-sm text-emerald-700 transition hover:bg-emerald-50 disabled:cursor-not-allowed disabled:opacity-60 dark:text-emerald-400 dark:hover:bg-emerald-950/35"
-                >
-                  {loading ? t('vendor.productActions.sending') : t('vendor.productActions.sendReview')}
-                </button>
-              )}
-              {product.status === 'ACTIVE' && !isExpired && (
-                <Link
-                  href={`/productos/${product.slug}`}
-                  target="_blank"
-                  className="block px-4 py-2 text-sm text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
-                >
-                  {t('vendor.productActions.viewInStore')}
-                </Link>
-              )}
-              <div className="border-t border-[var(--border)] mt-1 pt-1">
-                <button
-                  onClick={() => { setDeleteModal(true); setMenuOpen(false) }}
-                  className="block w-full px-4 py-2 text-left text-sm text-red-600 transition hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/35"
-                >
-                  {t('vendor.productActions.delete')}
-                </button>
-              </div>
+            )}
+            <div className="border-t border-[var(--border)] mt-1 pt-1">
+              <button
+                onClick={() => { setDeleteModal(true); setMenuOpen(false) }}
+                className="block w-full px-4 py-2 text-left text-sm text-red-600 transition hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/35"
+              >
+                {t('vendor.productActions.delete')}
+              </button>
             </div>
-          </>
-        )}
-      </div>
+          </div>
+        </>,
+        document.body
+      )}
 
       <Modal
         open={deleteModal}


### PR DESCRIPTION
## Summary
- The 3-dot menu in `/vendor/productos` was rendered absolutely inside a `relative z-[2]` row wrapper, so later sibling rows painted over it — making it look transparent and blocking interaction with items beneath.
- Each `ProductActions` instance kept independent open state with no cross-instance coordination, so opening one menu did not close the others.

## Fix
- Render the dropdown via `createPortal` to `document.body` with `position: fixed`, anchored to the trigger button's `getBoundingClientRect()`. This escapes the row's stacking context entirely.
- Broadcast a `product-actions:open` window event on open carrying the instance id; every other instance listens and closes itself when a different id opens.
- Also closes on `Escape`, scroll, and resize for polish.

## Test plan
- [ ] On `/vendor/productos` (list + grid view), open the 3-dot menu on a row with rows below — menu paints fully on top, no transparency or bleed-through.
- [ ] Click another row's 3-dot trigger — the previously open menu closes and the new one opens in a single click.
- [ ] Click the backdrop, press Escape, scroll, or resize — menu closes.
- [ ] Each menu item (Edit / Send to review / View in store / Delete) still works and dark + light theme look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)