### PR TITLE
security(addresses): unify session via getActionSession + cross-buyer regression tests

### DIFF
--- a/src/app/api/direcciones/[id]/predeterminada/route.ts
+++ b/src/app/api/direcciones/[id]/predeterminada/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@/lib/auth'
+import { getActionSession } from '@/lib/action-session'
 import { db } from '@/lib/db'
 
 interface RouteParams {
@@ -8,19 +8,18 @@ interface RouteParams {
 
 export async function PUT(_req: NextRequest, { params }: RouteParams) {
   try {
-    const session = await auth()
-    if (!session?.user?.id) {
+    const session = await getActionSession()
+    if (!session) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
     const { id } = await params
 
-    // Verify ownership
-    const address = await db.address.findUnique({
-      where: { id },
+    const address = await db.address.findFirst({
+      where: { id, userId: session.user.id },
     })
 
-    if (!address || address.userId !== session.user.id) {
+    if (!address) {
       return NextResponse.json({ error: 'Dirección no encontrada' }, { status: 404 })
     }
 

--- a/src/app/api/direcciones/[id]/route.ts
+++ b/src/app/api/direcciones/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { auth } from '@/lib/auth'
+import { getActionSession } from '@/lib/action-session'
 import { db } from '@/lib/db'
 import {
   clearOtherDefaults,
@@ -26,8 +26,8 @@ interface RouteParams {
 
 export async function PUT(req: NextRequest, { params }: RouteParams) {
   try {
-    const session = await auth()
-    if (!session?.user?.id) {
+    const session = await getActionSession()
+    if (!session) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
@@ -35,12 +35,14 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
     const body = await req.json()
     const validated = addressSchema.parse(body)
 
-    // Verify ownership
-    const existingAddress = await db.address.findUnique({
-      where: { id },
+    // Scope ownership to the session user. findFirst with both predicates
+    // returns null for both "not found" and "owned by someone else", so we
+    // collapse them into a single 404 to avoid leaking existence.
+    const existingAddress = await db.address.findFirst({
+      where: { id, userId: session.user.id },
     })
 
-    if (!existingAddress || existingAddress.userId !== session.user.id) {
+    if (!existingAddress) {
       return NextResponse.json({ error: 'Dirección no encontrada' }, { status: 404 })
     }
 
@@ -83,19 +85,18 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
 
 export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   try {
-    const session = await auth()
-    if (!session?.user?.id) {
+    const session = await getActionSession()
+    if (!session) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
     const { id } = await params
 
-    // Verify ownership
-    const address = await db.address.findUnique({
-      where: { id },
+    const address = await db.address.findFirst({
+      where: { id, userId: session.user.id },
     })
 
-    if (!address || address.userId !== session.user.id) {
+    if (!address) {
       return NextResponse.json({ error: 'Dirección no encontrada' }, { status: 404 })
     }
 

--- a/src/app/api/direcciones/route.ts
+++ b/src/app/api/direcciones/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { auth } from '@/lib/auth'
+import { getActionSession } from '@/lib/action-session'
 import { db } from '@/lib/db'
 import { clearOtherDefaults, enforceSingleDefault } from '@/domains/auth/address-defaults'
 
@@ -18,8 +18,8 @@ const addressSchema = z.object({
 
 export async function GET(_req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user?.id) {
+    const session = await getActionSession()
+    if (!session) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 
@@ -53,8 +53,8 @@ export async function GET(_req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await auth()
-    if (!session?.user?.id) {
+    const session = await getActionSession()
+    if (!session) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })
     }
 

--- a/test/integration/api-direcciones-auth.test.ts
+++ b/test/integration/api-direcciones-auth.test.ts
@@ -1,0 +1,183 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { GET, POST } from '@/app/api/direcciones/route'
+import { PUT as PUT_BY_ID, DELETE as DELETE_BY_ID } from '@/app/api/direcciones/[id]/route'
+import { PUT as PUT_DEFAULT } from '@/app/api/direcciones/[id]/predeterminada/route'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+async function createAddress(userId: string, isDefault = false) {
+  return db.address.create({
+    data: {
+      userId,
+      firstName: 'Tester',
+      lastName: 'Owner',
+      line1: 'Calle Falsa 123',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      isDefault,
+    },
+  })
+}
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new Request(url, init) as Parameters<typeof PUT_BY_ID>[0]
+}
+
+test('GET /api/direcciones returns only the authenticated user addresses', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  await createAddress(buyerA.id, true)
+  const ownB = await createAddress(buyerB.id, true)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const res = await GET(makeRequest('http://localhost/api/direcciones'))
+  assert.equal(res.status, 200)
+  const body = (await res.json()) as Array<{ id: string; userId: string }>
+  assert.equal(body.length, 1)
+  assert.equal(body[0].id, ownB.id)
+  assert.equal(body[0].userId, buyerB.id)
+})
+
+test('PUT /api/direcciones/[id] returns 404 when the address belongs to another buyer', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const addressA = await createAddress(buyerA.id)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const res = await PUT_BY_ID(
+    makeRequest(`http://localhost/api/direcciones/${addressA.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        firstName: 'Hijack',
+        lastName: 'Attempt',
+        line1: 'Otra calle 1',
+        city: 'Madrid',
+        province: 'Madrid',
+        postalCode: '28002',
+        isDefault: false,
+      }),
+      headers: { 'content-type': 'application/json' },
+    }),
+    { params: Promise.resolve({ id: addressA.id }) }
+  )
+  assert.equal(res.status, 404)
+
+  const stored = await db.address.findUnique({ where: { id: addressA.id } })
+  assert.equal(stored?.firstName, 'Tester')
+  assert.equal(stored?.line1, 'Calle Falsa 123')
+})
+
+test('DELETE /api/direcciones/[id] returns 404 when the address belongs to another buyer', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const addressA = await createAddress(buyerA.id)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const res = await DELETE_BY_ID(
+    makeRequest(`http://localhost/api/direcciones/${addressA.id}`, { method: 'DELETE' }),
+    { params: Promise.resolve({ id: addressA.id }) }
+  )
+  assert.equal(res.status, 404)
+
+  const stored = await db.address.findUnique({ where: { id: addressA.id } })
+  assert.ok(stored, 'address must still exist after rejected cross-buyer delete')
+})
+
+test('PUT /api/direcciones/[id]/predeterminada returns 404 for cross-buyer set-default', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const addressA = await createAddress(buyerA.id, false)
+  await createAddress(buyerB.id, true)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const res = await PUT_DEFAULT(
+    makeRequest(`http://localhost/api/direcciones/${addressA.id}/predeterminada`, { method: 'PUT' }),
+    { params: Promise.resolve({ id: addressA.id }) }
+  )
+  assert.equal(res.status, 404)
+
+  const stored = await db.address.findUnique({ where: { id: addressA.id } })
+  assert.equal(stored?.isDefault, false)
+})
+
+test('legitimate owner can still update + delete + set-default their own address', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const address = await createAddress(buyer.id, false)
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+
+  const updateRes = await PUT_BY_ID(
+    makeRequest(`http://localhost/api/direcciones/${address.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        firstName: 'Updated',
+        lastName: 'Owner',
+        line1: 'Calle Nueva 9',
+        city: 'Madrid',
+        province: 'Madrid',
+        postalCode: '28010',
+        isDefault: true,
+      }),
+      headers: { 'content-type': 'application/json' },
+    }),
+    { params: Promise.resolve({ id: address.id }) }
+  )
+  assert.equal(updateRes.status, 200)
+
+  const setDefaultRes = await PUT_DEFAULT(
+    makeRequest(`http://localhost/api/direcciones/${address.id}/predeterminada`, { method: 'PUT' }),
+    { params: Promise.resolve({ id: address.id }) }
+  )
+  assert.equal(setDefaultRes.status, 200)
+
+  const deleteRes = await DELETE_BY_ID(
+    makeRequest(`http://localhost/api/direcciones/${address.id}`, { method: 'DELETE' }),
+    { params: Promise.resolve({ id: address.id }) }
+  )
+  assert.equal(deleteRes.status, 200)
+  const gone = await db.address.findUnique({ where: { id: address.id } })
+  assert.equal(gone, null)
+})
+
+test('POST /api/direcciones always assigns userId from the session, ignoring any client-provided userId', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const stranger = await createUser('CUSTOMER')
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const res = await POST(
+    makeRequest('http://localhost/api/direcciones', {
+      method: 'POST',
+      body: JSON.stringify({
+        firstName: 'Owner',
+        lastName: 'Pwn',
+        line1: 'Calle Test 1',
+        city: 'Madrid',
+        province: 'Madrid',
+        postalCode: '28001',
+        isDefault: false,
+        // Schema strips this, but we assert on the persisted row anyway.
+        userId: stranger.id,
+      }),
+      headers: { 'content-type': 'application/json' },
+    })
+  )
+  assert.equal(res.status, 201)
+  const created = (await res.json()) as { id: string; userId: string }
+  assert.equal(created.userId, buyer.id)
+})


### PR DESCRIPTION
## Summary

Resolves the #399 audit. The `/api/direcciones` handlers were already filtering by `userId`, so ownership was correct — but they called `auth()` directly instead of `getActionSession()` (the convention used everywhere else and documented in `docs/conventions.md`), and they used `findUnique`-then-compare instead of a scoped `findFirst`. This PR hardens the pattern and adds the regression tests the audit was missing.

## Changes

- `src/app/api/direcciones/route.ts` — `GET` and `POST` switched to `getActionSession()`.
- `src/app/api/direcciones/[id]/route.ts` — `PUT` and `DELETE` switched to `getActionSession()` and use `findFirst({ where: { id, userId } })` so ownership is a query predicate.
- `src/app/api/direcciones/[id]/predeterminada/route.ts` — same migration.
- `test/integration/api-direcciones-auth.test.ts` — new suite, 6 tests:
  - GET returns only the authenticated user's addresses
  - PUT cross-buyer → 404, original row untouched
  - DELETE cross-buyer → 404, row still exists
  - PUT predeterminada cross-buyer → 404, `isDefault` unchanged
  - Legitimate owner can update + set-default + delete their own row
  - POST always assigns `userId` from session, ignores client-provided `userId`

## Audit findings (already-correct vs hardened)

| Handler | Before | After |
|---|---|---|
| GET | ✅ scoped via `where: { userId }` | ✅ unchanged + session helper unified |
| POST | ✅ `userId` from session | ✅ unchanged + session helper unified |
| PUT [id] | ⚠️ findUnique then check | ✅ scoped findFirst |
| DELETE [id] | ⚠️ findUnique then check | ✅ scoped findFirst |
| PUT predeterminada | ⚠️ findUnique then check | ✅ scoped findFirst |

No exploitable bug was found — the previous comparison was correct. The change removes an unnecessary code pattern and adds the test evidence the audit was missing.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/api-direcciones-auth.test.ts` — 6/6 pass
- [ ] Full CI on PR

## Risk / rollback

Low. Additive. No schema change, no new deps. Revert is a single PR revert; pattern is functionally identical to before.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)