### PR TITLE
security(vendor): close 2 audit gaps + cross-vendor isolation regression suite

### DIFF
--- a/src/domains/settlements/approve.ts
+++ b/src/domains/settlements/approve.ts
@@ -126,6 +126,11 @@ export async function adjustSettlement(
  * Get settlements pending review
  */
 export async function getPendingSettlements() {
+  const session = await getActionSession()
+  if (!session?.user || session.user.role !== 'SUPERADMIN') {
+    throw new Error('No autorizado')
+  }
+
   return db.settlement.findMany({
     where: { status: 'DRAFT' },
     include: {

--- a/src/domains/shipping/actions.ts
+++ b/src/domains/shipping/actions.ts
@@ -14,14 +14,13 @@ import type {
   PostalAddress,
   ShipmentDraft,
   ShipmentRecord,
-  ShipmentStatusInternal,
 } from '@/domains/shipping/domain/types'
-import { isValidTransition } from '@/domains/shipping/domain/state-machine'
-import type {
-  FulfillmentStatus,
-  ShipmentStatus,
-  ShipmentEventSource,
-} from '@/generated/prisma/enums'
+import {
+  SHIPMENT_TO_PRISMA,
+  fulfillmentStatusForShipment,
+  appendShipmentEvent,
+  applyShipmentTransition,
+} from '@/domains/shipping/transitions'
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
 
@@ -114,52 +113,6 @@ function toFromAddress(addr: {
     province: addr.province,
     postalCode: addr.postalCode,
     countryCode: addr.countryCode,
-  }
-}
-
-// ─── Status mapping ───────────────────────────────────────────────────────────
-
-const SHIPMENT_TO_PRISMA: Record<ShipmentStatusInternal, ShipmentStatus> = {
-  DRAFT: 'DRAFT',
-  LABEL_REQUESTED: 'LABEL_REQUESTED',
-  LABEL_CREATED: 'LABEL_CREATED',
-  IN_TRANSIT: 'IN_TRANSIT',
-  OUT_FOR_DELIVERY: 'OUT_FOR_DELIVERY',
-  DELIVERED: 'DELIVERED',
-  EXCEPTION: 'EXCEPTION',
-  CANCELLED: 'CANCELLED',
-  FAILED: 'FAILED',
-}
-
-const PRISMA_TO_SHIPMENT: Record<ShipmentStatus, ShipmentStatusInternal> = {
-  DRAFT: 'DRAFT',
-  LABEL_REQUESTED: 'LABEL_REQUESTED',
-  LABEL_CREATED: 'LABEL_CREATED',
-  IN_TRANSIT: 'IN_TRANSIT',
-  OUT_FOR_DELIVERY: 'OUT_FOR_DELIVERY',
-  DELIVERED: 'DELIVERED',
-  EXCEPTION: 'EXCEPTION',
-  CANCELLED: 'CANCELLED',
-  FAILED: 'FAILED',
-}
-
-function fulfillmentStatusForShipment(
-  status: ShipmentStatusInternal,
-): FulfillmentStatus | null {
-  switch (status) {
-    case 'LABEL_CREATED':
-      return 'READY'
-    case 'IN_TRANSIT':
-    case 'OUT_FOR_DELIVERY':
-      return 'SHIPPED'
-    case 'DELIVERED':
-      return 'DELIVERED'
-    case 'FAILED':
-      return 'LABEL_FAILED'
-    case 'CANCELLED':
-      return 'CANCELLED'
-    default:
-      return null
   }
 }
 
@@ -479,130 +432,7 @@ export async function markFulfillmentIncident(fulfillmentId: string) {
   return { ok: true as const }
 }
 
-// ─── Internal transition helpers ──────────────────────────────────────────────
-
-interface AppendEventInput {
-  shipmentId: string
-  source: ShipmentEventSource
-  type: string
-  status?: ShipmentStatus
-  message?: string
-  payload?: unknown
-  occurredAt?: Date
-}
-
-export async function appendShipmentEvent(input: AppendEventInput): Promise<void> {
-  await db.shipmentEvent.create({
-    data: {
-      shipmentId: input.shipmentId,
-      source: input.source,
-      type: input.type,
-      status: input.status,
-      message: input.message,
-      payload: (input.payload ?? null) as unknown as object,
-      occurredAt: input.occurredAt ?? new Date(),
-    },
-  })
-}
-
-interface ApplyTransitionInput {
-  shipmentId: string
-  nextStatus: ShipmentStatusInternal
-  source: ShipmentEventSource
-  type: string
-  message?: string
-  payload?: unknown
-  occurredAt?: Date
-}
-
-/**
- * Applies a shipment transition if legal, writes the ShipmentEvent,
- * mirrors to the parent VendorFulfillment and recomputes the parent
- * Order status. Called by both the webhook handler and admin actions.
- */
-export async function applyShipmentTransition(input: ApplyTransitionInput) {
-  const shipment = await db.shipment.findUnique({
-    where: { id: input.shipmentId },
-    include: { fulfillment: true },
-  })
-  if (!shipment) return { applied: false as const, reason: 'not_found' }
-
-  const current = PRISMA_TO_SHIPMENT[shipment.status]
-  if (!isValidTransition(current, input.nextStatus)) {
-    await appendShipmentEvent({
-      shipmentId: shipment.id,
-      source: input.source,
-      type: `${input.type}.rejected`,
-      message: `from=${current} to=${input.nextStatus}`,
-      payload: input.payload,
-      occurredAt: input.occurredAt,
-    })
-    return { applied: false as const, reason: 'invalid_transition' }
-  }
-
-  const now = new Date()
-  await db.shipment.update({
-    where: { id: shipment.id },
-    data: {
-      status: SHIPMENT_TO_PRISMA[input.nextStatus],
-      handedOverAt: input.nextStatus === 'IN_TRANSIT' ? now : undefined,
-      deliveredAt: input.nextStatus === 'DELIVERED' ? now : undefined,
-      cancelledAt: input.nextStatus === 'CANCELLED' ? now : undefined,
-      failedAt: input.nextStatus === 'FAILED' ? now : undefined,
-    },
-  })
-
-  await appendShipmentEvent({
-    shipmentId: shipment.id,
-    source: input.source,
-    type: input.type,
-    status: SHIPMENT_TO_PRISMA[input.nextStatus],
-    message: input.message,
-    payload: input.payload,
-    occurredAt: input.occurredAt,
-  })
-
-  const nextFulfillment = fulfillmentStatusForShipment(input.nextStatus)
-  if (nextFulfillment) {
-    await db.vendorFulfillment.update({
-      where: { id: shipment.fulfillmentId },
-      data: {
-        status: nextFulfillment,
-        ...(nextFulfillment === 'SHIPPED' && { shippedAt: now }),
-        ...(nextFulfillment === 'DELIVERED' && { deliveredAt: now }),
-      },
-    })
-    await recomputeOrderStatus(shipment.fulfillment.orderId)
-  }
-
-  safeRevalidatePath('/vendor/pedidos')
-  return { applied: true as const }
-}
-
-async function recomputeOrderStatus(orderId: string): Promise<void> {
-  const fulfillments = await db.vendorFulfillment.findMany({
-    where: { orderId },
-    select: { status: true },
-  })
-  if (fulfillments.length === 0) return
-
-  const anyShipped = fulfillments.some(f =>
-    ['SHIPPED', 'DELIVERED'].includes(f.status),
-  )
-  const allShipped = fulfillments.every(f =>
-    ['SHIPPED', 'DELIVERED', 'CANCELLED'].includes(f.status),
-  )
-  const allDelivered = fulfillments.every(f =>
-    ['DELIVERED', 'CANCELLED'].includes(f.status),
-  )
-
-  let next: 'PROCESSING' | 'PARTIALLY_SHIPPED' | 'SHIPPED' | 'DELIVERED' | null = null
-  if (allDelivered) next = 'DELIVERED'
-  else if (allShipped) next = 'SHIPPED'
-  else if (anyShipped) next = 'PARTIALLY_SHIPPED'
-
-  if (next) {
-    await db.order.update({ where: { id: orderId }, data: { status: next } })
-  }
-}
+// Internal transition helpers (applyShipmentTransition, appendShipmentEvent,
+// status maps) live in `transitions.ts` to keep them off the server-action
+// RPC surface. They are re-imported above for use by the actions in this file.
 

--- a/src/domains/shipping/transitions.ts
+++ b/src/domains/shipping/transitions.ts
@@ -1,0 +1,189 @@
+/**
+ * Internal shipment transition helpers.
+ *
+ * These functions used to live in `actions.ts` (a `'use server'` module),
+ * which exposed them as RPC endpoints any authenticated user could call
+ * with arbitrary shipmentIds. They are pure service helpers — only the
+ * Sendcloud webhook handler and other server actions in this domain
+ * should reach them — so they live in a non-`'use server'` module to
+ * keep them off the RPC surface.
+ */
+
+import { db } from '@/lib/db'
+import { safeRevalidatePath } from '@/lib/revalidate'
+import type { ShipmentStatusInternal } from '@/domains/shipping/domain/types'
+import { isValidTransition } from '@/domains/shipping/domain/state-machine'
+import type {
+  FulfillmentStatus,
+  ShipmentStatus,
+  ShipmentEventSource,
+} from '@/generated/prisma/enums'
+
+export const SHIPMENT_TO_PRISMA: Record<ShipmentStatusInternal, ShipmentStatus> = {
+  DRAFT: 'DRAFT',
+  LABEL_REQUESTED: 'LABEL_REQUESTED',
+  LABEL_CREATED: 'LABEL_CREATED',
+  IN_TRANSIT: 'IN_TRANSIT',
+  OUT_FOR_DELIVERY: 'OUT_FOR_DELIVERY',
+  DELIVERED: 'DELIVERED',
+  EXCEPTION: 'EXCEPTION',
+  CANCELLED: 'CANCELLED',
+  FAILED: 'FAILED',
+}
+
+export const PRISMA_TO_SHIPMENT: Record<ShipmentStatus, ShipmentStatusInternal> = {
+  DRAFT: 'DRAFT',
+  LABEL_REQUESTED: 'LABEL_REQUESTED',
+  LABEL_CREATED: 'LABEL_CREATED',
+  IN_TRANSIT: 'IN_TRANSIT',
+  OUT_FOR_DELIVERY: 'OUT_FOR_DELIVERY',
+  DELIVERED: 'DELIVERED',
+  EXCEPTION: 'EXCEPTION',
+  CANCELLED: 'CANCELLED',
+  FAILED: 'FAILED',
+}
+
+export function fulfillmentStatusForShipment(
+  status: ShipmentStatusInternal,
+): FulfillmentStatus | null {
+  switch (status) {
+    case 'LABEL_CREATED':
+      return 'READY'
+    case 'IN_TRANSIT':
+    case 'OUT_FOR_DELIVERY':
+      return 'SHIPPED'
+    case 'DELIVERED':
+      return 'DELIVERED'
+    case 'FAILED':
+      return 'LABEL_FAILED'
+    case 'CANCELLED':
+      return 'CANCELLED'
+    default:
+      return null
+  }
+}
+
+export interface AppendEventInput {
+  shipmentId: string
+  source: ShipmentEventSource
+  type: string
+  status?: ShipmentStatus
+  message?: string
+  payload?: unknown
+  occurredAt?: Date
+}
+
+export async function appendShipmentEvent(input: AppendEventInput): Promise<void> {
+  await db.shipmentEvent.create({
+    data: {
+      shipmentId: input.shipmentId,
+      source: input.source,
+      type: input.type,
+      status: input.status,
+      message: input.message,
+      payload: (input.payload ?? null) as unknown as object,
+      occurredAt: input.occurredAt ?? new Date(),
+    },
+  })
+}
+
+export interface ApplyTransitionInput {
+  shipmentId: string
+  nextStatus: ShipmentStatusInternal
+  source: ShipmentEventSource
+  type: string
+  message?: string
+  payload?: unknown
+  occurredAt?: Date
+}
+
+/**
+ * Applies a shipment transition if legal, writes the ShipmentEvent,
+ * mirrors to the parent VendorFulfillment and recomputes the parent
+ * Order status. Called by both the webhook handler and admin actions.
+ */
+export async function applyShipmentTransition(input: ApplyTransitionInput) {
+  const shipment = await db.shipment.findUnique({
+    where: { id: input.shipmentId },
+    include: { fulfillment: true },
+  })
+  if (!shipment) return { applied: false as const, reason: 'not_found' }
+
+  const current = PRISMA_TO_SHIPMENT[shipment.status]
+  if (!isValidTransition(current, input.nextStatus)) {
+    await appendShipmentEvent({
+      shipmentId: shipment.id,
+      source: input.source,
+      type: `${input.type}.rejected`,
+      message: `from=${current} to=${input.nextStatus}`,
+      payload: input.payload,
+      occurredAt: input.occurredAt,
+    })
+    return { applied: false as const, reason: 'invalid_transition' }
+  }
+
+  const now = new Date()
+  await db.shipment.update({
+    where: { id: shipment.id },
+    data: {
+      status: SHIPMENT_TO_PRISMA[input.nextStatus],
+      handedOverAt: input.nextStatus === 'IN_TRANSIT' ? now : undefined,
+      deliveredAt: input.nextStatus === 'DELIVERED' ? now : undefined,
+      cancelledAt: input.nextStatus === 'CANCELLED' ? now : undefined,
+      failedAt: input.nextStatus === 'FAILED' ? now : undefined,
+    },
+  })
+
+  await appendShipmentEvent({
+    shipmentId: shipment.id,
+    source: input.source,
+    type: input.type,
+    status: SHIPMENT_TO_PRISMA[input.nextStatus],
+    message: input.message,
+    payload: input.payload,
+    occurredAt: input.occurredAt,
+  })
+
+  const nextFulfillment = fulfillmentStatusForShipment(input.nextStatus)
+  if (nextFulfillment) {
+    await db.vendorFulfillment.update({
+      where: { id: shipment.fulfillmentId },
+      data: {
+        status: nextFulfillment,
+        ...(nextFulfillment === 'SHIPPED' && { shippedAt: now }),
+        ...(nextFulfillment === 'DELIVERED' && { deliveredAt: now }),
+      },
+    })
+    await recomputeOrderStatus(shipment.fulfillment.orderId)
+  }
+
+  safeRevalidatePath('/vendor/pedidos')
+  return { applied: true as const }
+}
+
+async function recomputeOrderStatus(orderId: string): Promise<void> {
+  const fulfillments = await db.vendorFulfillment.findMany({
+    where: { orderId },
+    select: { status: true },
+  })
+  if (fulfillments.length === 0) return
+
+  const anyShipped = fulfillments.some(f =>
+    ['SHIPPED', 'DELIVERED'].includes(f.status),
+  )
+  const allShipped = fulfillments.every(f =>
+    ['SHIPPED', 'DELIVERED', 'CANCELLED'].includes(f.status),
+  )
+  const allDelivered = fulfillments.every(f =>
+    ['DELIVERED', 'CANCELLED'].includes(f.status),
+  )
+
+  let next: 'PROCESSING' | 'PARTIALLY_SHIPPED' | 'SHIPPED' | 'DELIVERED' | null = null
+  if (allDelivered) next = 'DELIVERED'
+  else if (allShipped) next = 'SHIPPED'
+  else if (anyShipped) next = 'PARTIALLY_SHIPPED'
+
+  if (next) {
+    await db.order.update({ where: { id: orderId }, data: { status: next } })
+  }
+}

--- a/src/domains/shipping/webhooks/sendcloud.ts
+++ b/src/domains/shipping/webhooks/sendcloud.ts
@@ -3,7 +3,7 @@ import { mapSendcloudStatus } from '@/domains/shipping/providers/sendcloud/mappe
 import {
   appendShipmentEvent,
   applyShipmentTransition,
-} from '@/domains/shipping/actions'
+} from '@/domains/shipping/transitions'
 import type { ShipmentStatusInternal } from '@/domains/shipping/domain/types'
 
 export { verifySendcloudSignature } from './signature'

--- a/test/integration/vendor-cross-vendor-isolation.test.ts
+++ b/test/integration/vendor-cross-vendor-isolation.test.ts
@@ -1,0 +1,215 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  updateProduct,
+  deleteProduct,
+  advanceFulfillment,
+  setProductStock,
+} from '@/domains/vendors/actions'
+import {
+  updatePromotion,
+  archivePromotion,
+  unarchivePromotion,
+} from '@/domains/promotions/actions'
+import { upsertDefaultVendorAddress } from '@/domains/shipping/vendor-address-actions'
+import { getPendingSettlements } from '@/domains/settlements/approve'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+async function createPromotionFor(vendorId: string) {
+  return db.promotion.create({
+    data: {
+      vendorId,
+      name: 'Promo test',
+      kind: 'PERCENTAGE',
+      scope: 'VENDOR',
+      value: 10,
+      perUserLimit: 1,
+      startsAt: new Date(),
+      endsAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    },
+  })
+}
+
+test('vendor B cannot updateProduct of vendor A', async () => {
+  const { user: userA, vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+  const productA = await createActiveProduct(vendorA.id, { name: 'Vino A' })
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(
+    () => updateProduct(productA.id, { name: 'Hijack' }),
+    /Producto no encontrado|no encontrado/i
+  )
+
+  const stored = await db.product.findUnique({ where: { id: productA.id } })
+  assert.equal(stored?.name, 'Vino A')
+  // Silence unused var warning — we still use it to anchor the test setup.
+  void userA
+})
+
+test('vendor B cannot deleteProduct of vendor A', async () => {
+  const { vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+  const productA = await createActiveProduct(vendorA.id)
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(() => deleteProduct(productA.id), /no encontrado/i)
+
+  const stored = await db.product.findUnique({ where: { id: productA.id } })
+  assert.ok(stored, 'product must still exist after rejected cross-vendor delete')
+})
+
+test('vendor B cannot setProductStock of vendor A', async () => {
+  const { vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+  const productA = await createActiveProduct(vendorA.id, { stock: 5 })
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(
+    () => setProductStock({ productId: productA.id, stock: 99 }),
+    /no encontrado/i
+  )
+
+  const stored = await db.product.findUnique({ where: { id: productA.id } })
+  assert.equal(stored?.stock, 5)
+})
+
+test('vendor B cannot updatePromotion of vendor A', async () => {
+  const { vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+  const promo = await createPromotionFor(vendorA.id)
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(
+    () =>
+      updatePromotion(promo.id, {
+        name: 'Hijacked',
+        kind: 'PERCENTAGE',
+        scope: 'VENDOR',
+        value: 99,
+        perUserLimit: 1,
+        startsAt: new Date().toISOString(),
+        endsAt: new Date(Date.now() + 86400000).toISOString(),
+      }),
+    /Promoci[óo]n no encontrada/i
+  )
+
+  const stored = await db.promotion.findUnique({ where: { id: promo.id } })
+  assert.equal(stored?.name, 'Promo test')
+})
+
+test('vendor B cannot archivePromotion or unarchivePromotion of vendor A', async () => {
+  const { vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+  const promo = await createPromotionFor(vendorA.id)
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(() => archivePromotion(promo.id), /no encontrada/i)
+  await assert.rejects(() => unarchivePromotion(promo.id), /no encontrada/i)
+
+  const stored = await db.promotion.findUnique({ where: { id: promo.id } })
+  assert.equal(stored?.archivedAt, null)
+})
+
+test('vendor B cannot advanceFulfillment of vendor A', async () => {
+  const { user: userA, vendor: vendorA } = await createVendorUser()
+  const { user: userB } = await createVendorUser()
+
+  // Build a minimal order with a fulfillment owned by vendor A.
+  const order = await db.order.create({
+    data: {
+      orderNumber: `ORD-${Date.now()}`,
+      customerId: userA.id,
+      status: 'PLACED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+      fulfillments: {
+        create: { vendorId: vendorA.id, status: 'CONFIRMED' },
+      },
+    },
+    include: { fulfillments: true },
+  })
+  const fulfillmentA = order.fulfillments[0]!
+
+  useTestSession(buildSession(userB.id, 'VENDOR'))
+  await assert.rejects(
+    () => advanceFulfillment(fulfillmentA.id, 'READY'),
+    /no encontrad|not found|denegad/i
+  )
+
+  const stored = await db.vendorFulfillment.findUnique({
+    where: { id: fulfillmentA.id },
+  })
+  assert.equal(stored?.status, 'CONFIRMED')
+})
+
+test('upsertDefaultVendorAddress always assigns vendorId from the session', async () => {
+  const { user: userA, vendor: vendorA } = await createVendorUser()
+  const { user: userB, vendor: vendorB } = await createVendorUser()
+
+  useTestSession(buildSession(userA.id, 'VENDOR'))
+  const result = await upsertDefaultVendorAddress({
+    label: 'Almacén',
+    contactName: 'Vendor A',
+    phone: '600600600',
+    line1: 'Calle Productor 1',
+    line2: '',
+    city: 'Madrid',
+    province: 'Madrid',
+    postalCode: '28001',
+    countryCode: 'ES',
+  })
+  assert.equal(result.ok, true)
+
+  const addresses = await db.vendorAddress.findMany()
+  assert.equal(addresses.length, 1)
+  assert.equal(addresses[0].vendorId, vendorA.id)
+
+  // Vendor B never appears as the owner just because their id is in scope.
+  void userB
+  void vendorB
+})
+
+test('getPendingSettlements rejects callers without SUPERADMIN role', async () => {
+  const { user: vendorUser } = await createVendorUser()
+
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  await assert.rejects(() => getPendingSettlements(), /No autorizado/i)
+
+  useTestSession(buildSession(vendorUser.id, 'CUSTOMER'))
+  await assert.rejects(() => getPendingSettlements(), /No autorizado/i)
+})
+
+test('getPendingSettlements allows SUPERADMIN', async () => {
+  const adminUser = await db.user.create({
+    data: {
+      email: `admin-${Date.now()}@example.com`,
+      firstName: 'Admin',
+      lastName: 'Tester',
+      role: 'SUPERADMIN',
+      isActive: true,
+    },
+  })
+  useTestSession(buildSession(adminUser.id, 'SUPERADMIN'))
+  const rows = await getPendingSettlements()
+  assert.ok(Array.isArray(rows))
+})


### PR DESCRIPTION
## Summary

Resolves the #400 audit. Two real gaps found and closed; the rest of the vendor portal was already correctly scoped, so the remaining work is regression-test evidence.

## Findings (real gaps closed)

### 1. `getPendingSettlements()` had no role check

[src/domains/settlements/approve.ts](src/domains/settlements/approve.ts) exposed an unguarded list of every vendor's pending settlements via a server action. The other 4 settlement actions in the same file already gate by `SUPERADMIN`. Added the same guard.

### 2. Internal shipment helpers exposed as RPC

`appendShipmentEvent` and `applyShipmentTransition` were exported from [src/domains/shipping/actions.ts](src/domains/shipping/actions.ts) (a `'use server'` module), so Next 16 turned them into RPC endpoints any authenticated client could call with arbitrary `shipmentId` values. They are pure service helpers — the only legitimate callers are other server actions in the same domain and the Sendcloud webhook handler.

Fix: extract both helpers (and their dependencies — `SHIPMENT_TO_PRISMA`, `PRISMA_TO_SHIPMENT`, `fulfillmentStatusForShipment`, `recomputeOrderStatus`) to a new module [src/domains/shipping/transitions.ts](src/domains/shipping/transitions.ts) that does **not** carry `'use server'`. Re-import them from `actions.ts` and `webhooks/sendcloud.ts`. Zero behavioural change — the functions are byte-identical, just no longer reachable as an RPC.

## Already-correct (audit confirmed, no code change)

| Module | Pattern | Status |
|---|---|---|
| `src/domains/vendors/actions.ts` | `requireVendor()` + scoped `findFirst({ vendorId })` on every action | ✅ |
| `src/domains/promotions/actions.ts` | `requireVendor()` + scoped `findFirst({ vendorId })` | ✅ |
| `src/domains/shipping/admin-actions.ts` | `requireAdminSession()` on every export | ✅ |
| `src/domains/shipping/vendor-address-actions.ts` | `requireVendorSession()` + `vendorId` predicate | ✅ |
| `src/domains/shipping/actions.ts` (vendor + admin actions) | `requireVendorSession()` / `requireAdminSession()` + `vendorId` scoping | ✅ |
| `src/domains/settlements/approve.ts` (other 4 functions) | inline `SUPERADMIN` role check | ✅ |

## Tests

New file: [test/integration/vendor-cross-vendor-isolation.test.ts](test/integration/vendor-cross-vendor-isolation.test.ts), 9 tests, all green:

- vendor B cannot updateProduct / deleteProduct / setProductStock of vendor A
- vendor B cannot updatePromotion / archive / unarchive of vendor A
- vendor B cannot advanceFulfillment of vendor A
- upsertDefaultVendorAddress always assigns `vendorId` from the session
- getPendingSettlements rejects VENDOR and CUSTOMER, allows SUPERADMIN

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/vendor-cross-vendor-isolation.test.ts` — 9/9 pass
- [ ] Full CI on PR

## Risk / rollback

Low. The 2 fixes are surgical: an additive `if` for the settlements function, and a file move + import rewrite for shipping helpers (zero functional change). Revert is a single PR revert. No schema change, no new deps.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)