### PR TITLE
security(orders): defense-in-depth on admin loaders + cross-actor regression suite

### DIFF
--- a/src/domains/admin/orders.ts
+++ b/src/domains/admin/orders.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from '@/generated/prisma/client'
 import type { FulfillmentStatus, IncidentStatus, OrderStatus, PaymentStatus } from '@/generated/prisma/enums'
+import { requireAdmin } from '@/lib/auth-guard'
 
 export interface AdminOrderFilters {
   q?: string
@@ -63,6 +64,10 @@ function buildOrderWhere(filters: AdminOrderFilters): Prisma.OrderWhereInput {
 }
 
 export async function getAdminOrdersPageData(filters: AdminOrderFilters) {
+  // Defense in depth: the /admin/* gate in src/proxy.ts already blocks
+  // non-admins, but this loader is plain code and could be imported from
+  // anywhere. Guard locally so a future caller can never bypass the gate.
+  await requireAdmin()
   const { db } = await import('@/lib/db')
   const where = buildOrderWhere(filters)
   const pageSize = Math.min(Math.max(filters.pageSize ?? 24, 1), 100)

--- a/src/domains/admin/producers.ts
+++ b/src/domains/admin/producers.ts
@@ -1,5 +1,6 @@
 import { db } from '@/lib/db'
 import type { VendorStatus } from '@/generated/prisma/enums'
+import { requireAdmin } from '@/lib/auth-guard'
 
 // Order statuses that count as "billed revenue" for a producer.
 // REFUNDED/CANCELLED are intentionally excluded.
@@ -85,6 +86,7 @@ function toNumber(value: string | number | bigint | null | undefined): number {
 }
 
 export async function getProducersOverview(): Promise<ProducersOverview> {
+  await requireAdmin()
   const [vendors, statusGroups, revenueRows, topProductRows, lastSeenRows, sparkRows] = await Promise.all([
     db.vendor.findMany({
       orderBy: { createdAt: 'desc' },

--- a/src/domains/admin/promotions.ts
+++ b/src/domains/admin/promotions.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth-guard'
 
 /**
  * Phase 5 of the promotions & subscriptions RFC: admin read-only
@@ -39,6 +40,7 @@ export interface PromotionsOverview {
 }
 
 export async function getPromotionsOverview(): Promise<PromotionsOverview> {
+  await requireAdmin()
   const now = new Date()
 
   const [active, archived, redemptionsAgg, vendorsRunning, rows] = await Promise.all([

--- a/src/domains/admin/subscriptions.ts
+++ b/src/domains/admin/subscriptions.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/db'
+import { requireAdmin } from '@/lib/auth-guard'
 
 /**
  * Phase 5 admin read-only overview for subscriptions. Gathers the
@@ -59,6 +60,7 @@ const CADENCE_TO_MONTHLY_MULTIPLIER: Record<
 }
 
 export async function getSubscriptionsOverview(): Promise<SubscriptionsOverview> {
+  await requireAdmin()
   const now = new Date()
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
 

--- a/test/integration/orders-auth-audit.test.ts
+++ b/test/integration/orders-auth-audit.test.ts
@@ -1,0 +1,149 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { getOrderDetail, getMyOrders, confirmOrder } from '@/domains/orders/actions'
+import { advanceFulfillment } from '@/domains/vendors/actions'
+import { getAdminOrdersPageData } from '@/domains/admin/orders'
+import { getProducersOverview } from '@/domains/admin/producers'
+import { getPromotionsOverview } from '@/domains/admin/promotions'
+import { getSubscriptionsOverview } from '@/domains/admin/subscriptions'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  // Force test mode for the auth-guard helpers, which honor
+  // globalThis.__testActionSession only when NODE_ENV === 'test'.
+  Object.assign(process.env, { NODE_ENV: 'test' })
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+async function createOrderFor(customerId: string, vendorId?: string) {
+  return db.order.create({
+    data: {
+      orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      customerId,
+      status: 'PLACED',
+      paymentStatus: 'PENDING',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+      ...(vendorId && {
+        fulfillments: { create: { vendorId, status: 'CONFIRMED' } },
+      }),
+    },
+    include: { fulfillments: true },
+  })
+}
+
+test('getOrderDetail returns null when buyer B asks for buyer A order', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const orderA = await createOrderFor(buyerA.id)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const result = await getOrderDetail(orderA.id)
+  assert.equal(result, null)
+})
+
+test('getMyOrders returns only the calling buyer orders', async () => {
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  await createOrderFor(buyerA.id)
+  const ownB = await createOrderFor(buyerB.id)
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  const orders = await getMyOrders()
+  assert.equal(orders.length, 1)
+  assert.equal(orders[0].id, ownB.id)
+})
+
+test('confirmOrder rejects buyer B trying to confirm buyer A order in mock mode', async () => {
+  Object.assign(process.env, { PAYMENT_PROVIDER: 'mock' })
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const orderA = await createOrderFor(buyerA.id)
+
+  // Plant a payment row so the lookup inside confirmOrder finds something.
+  await db.payment.create({
+    data: {
+      orderId: orderA.id,
+      provider: 'mock',
+      providerRef: 'pi_mock_test',
+      amount: 10,
+      currency: 'EUR',
+      status: 'PENDING',
+    },
+  })
+
+  useTestSession(buildSession(buyerB.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => confirmOrder(orderA.id, 'pi_mock_test'),
+    /No puedes confirmar un pedido que no te pertenece/i
+  )
+
+  const stored = await db.order.findUnique({ where: { id: orderA.id } })
+  assert.equal(stored?.paymentStatus, 'PENDING')
+})
+
+test('advanceFulfillment rejects vendor B for a fulfillment owned by vendor A', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor: vendorA } = await createVendorUser()
+  const { user: vendorBUser } = await createVendorUser()
+  const order = await createOrderFor(buyer.id, vendorA.id)
+  const fulfillmentA = order.fulfillments[0]!
+
+  useTestSession(buildSession(vendorBUser.id, 'VENDOR'))
+  await assert.rejects(() => advanceFulfillment(fulfillmentA.id, 'READY'), /no encontrad/i)
+  const stored = await db.vendorFulfillment.findUnique({
+    where: { id: fulfillmentA.id },
+  })
+  assert.equal(stored?.status, 'CONFIRMED')
+})
+
+test('getAdminOrdersPageData rejects non-admin callers', async () => {
+  const buyer = await createUser('CUSTOMER')
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  // requireAdmin redirects on failure; in tests redirect throws a
+  // NEXT_REDIRECT error which surfaces as a rejected promise.
+  await assert.rejects(() => getAdminOrdersPageData({}), /NEXT_REDIRECT|redirect/i)
+})
+
+test('getProducersOverview / getPromotionsOverview / getSubscriptionsOverview reject non-admin callers', async () => {
+  const buyer = await createUser('CUSTOMER')
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  await assert.rejects(() => getProducersOverview(), /NEXT_REDIRECT|redirect/i)
+  await assert.rejects(() => getPromotionsOverview(), /NEXT_REDIRECT|redirect/i)
+  await assert.rejects(() => getSubscriptionsOverview(), /NEXT_REDIRECT|redirect/i)
+})
+
+test('admin loaders accept SUPERADMIN sessions', async () => {
+  const admin = await db.user.create({
+    data: {
+      email: `admin-${Date.now()}@example.com`,
+      firstName: 'Admin',
+      lastName: 'Tester',
+      role: 'SUPERADMIN',
+      isActive: true,
+    },
+  })
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const orders = await getAdminOrdersPageData({})
+  assert.ok(Array.isArray(orders.orders))
+  const producers = await getProducersOverview()
+  assert.ok(Array.isArray(producers.producers))
+  const promos = await getPromotionsOverview()
+  assert.ok(Array.isArray(promos.promotions))
+  const subs = await getSubscriptionsOverview()
+  assert.ok(Array.isArray(subs.plans))
+})


### PR DESCRIPTION
## Summary

Resolves the #398 audit. Buyer-facing and vendor-facing order surfaces were already correctly scoped, but **4 admin loaders had no local auth check** and relied entirely on the `/admin/*` proxy gate. This PR adds defense-in-depth and ships the regression suite the audit was missing.

## Findings

### Real gap closed: 4 unguarded admin loaders

Each of these is a plain server-side function imported by an admin page server component. The proxy in [src/proxy.ts](src/proxy.ts) blocks non-admins at the route level, but if any non-admin route imports the loader in the future, the entire dataset leaks. Added `requireAdmin()` at the top of each:

- [src/domains/admin/orders.ts](src/domains/admin/orders.ts) — `getAdminOrdersPageData`
- [src/domains/admin/producers.ts](src/domains/admin/producers.ts) — `getProducersOverview`
- [src/domains/admin/promotions.ts](src/domains/admin/promotions.ts) — `getPromotionsOverview`
- [src/domains/admin/subscriptions.ts](src/domains/admin/subscriptions.ts) — `getSubscriptionsOverview`

`requireAdmin()` is the existing helper from [src/lib/auth-guard.ts](src/lib/auth-guard.ts) which already supports the test-session injection pattern via `globalThis.__testActionSession`.

### Already-correct (audit confirmed, no code change)

| Function | File | Pattern | Status |
|---|---|---|---|
| `getMyOrders` | `src/domains/orders/actions.ts` | `where: { customerId: session.user.id }` | ✅ |
| `getOrderDetail` | `src/domains/orders/actions.ts` | `where: { id, customerId: session.user.id }` | ✅ |
| `confirmOrder` | `src/domains/orders/actions.ts` | throws on `customerId !== session.user.id` | ✅ |
| `createOrder` | `src/domains/orders/actions.ts` | writes use `session.user.id` throughout | ✅ (untouched — see coordination note) |
| `advanceFulfillment` | `src/domains/vendors/actions.ts` | scoped via `vendor.id` from `requireVendor()` | ✅ |
| Admin write actions | `src/domains/admin/actions.ts` + `writes.ts` | `requireAdmin()` / `requireSuperadmin()` / `requireCatalogAdmin()` | ✅ |

## Tests

New file: [test/integration/orders-auth-audit.test.ts](test/integration/orders-auth-audit.test.ts) — 7 tests, all green:

- `getOrderDetail` returns null when buyer B asks for buyer A's order
- `getMyOrders` only returns the caller's orders
- `confirmOrder` (mock) rejects buyer B trying to confirm buyer A's order
- `advanceFulfillment` rejects vendor B for a fulfillment owned by vendor A
- `getAdminOrdersPageData` rejects non-admin callers (NEXT_REDIRECT)
- The 3 other admin overviews reject non-admin callers
- SUPERADMIN can call all 4 admin loaders happy-path

## Coordination with #404

`createOrder` is **intentionally untouched** in this PR. The parallel [#404 persist-first refactor](https://github.com/juanmixto/marketplace/issues/404) restructures that function. Splitting the changes keeps each PR small and reviewable; the merge order doesn't matter because this PR only audits/documents `createOrder`, it doesn't mutate it.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/orders-auth-audit.test.ts` — 7/7 pass
- [ ] Full CI on PR

## Risk / rollback

Low. 4 one-line additive guards + 1 new test file. Revert is a single PR revert. No schema change, no new deps, no behavioural change for the legitimate (admin) caller.

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)