### PR TITLE
fix(stripe-webhooks): guard subscription/invoice handlers against out-of-order delivery

### DIFF
--- a/prisma/migrations/20260415170000_subscription_last_stripe_event_at/migration.sql
+++ b/prisma/migrations/20260415170000_subscription_last_stripe_event_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN "lastStripeEventAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -905,6 +905,15 @@ model Subscription {
   // Reserved for phase 4b.
   stripeSubscriptionId  String?            @unique
 
+  // Watermark for Stripe webhook ordering. Each accepted
+  // customer.subscription.* / invoice.* event sets this to its
+  // top-level event.created timestamp; subsequent events with an
+  // older `created` are dropped as out-of-order to prevent state
+  // regressions (e.g. a stale `updated(ACTIVE)` overwriting a
+  // newer `deleted(CANCELED)`). Stripe does not guarantee delivery
+  // order, so we cannot trust the arrival sequence.
+  lastStripeEventAt     DateTime?
+
   createdAt             DateTime           @default(now())
   updatedAt             DateTime           @updatedAt
   canceledAt            DateTime?

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -51,6 +51,20 @@ function logInvalidWebhookPayload(event: Stripe.Event | WebhookEvent) {
 }
 
 /**
+ * Resolve the `event.created` unix timestamp into a JS Date. Stripe
+ * sends `created` as seconds-since-epoch; mock events from tests may
+ * omit it, in which case we fall back to "now" (the watermark guard
+ * still works for replays of the same payload).
+ */
+function eventCreatedAt(event: Stripe.Event | WebhookEvent): Date {
+  const created = (event as { created?: number }).created
+  if (typeof created === 'number' && Number.isFinite(created)) {
+    return new Date(created * 1000)
+  }
+  return new Date()
+}
+
+/**
  * Stripe webhook handler.
  * Verifies signature to prevent spoofing.
  * Handles: payment_intent.succeeded, payment_intent.payment_failed
@@ -113,18 +127,19 @@ export async function POST(req: NextRequest) {
         await handlePaymentFailed(pi.id, event.id)
         break
       }
-      // Phase 4b-α: subscription lifecycle. The handler is idempotent by
-      // construction (state-based sync — applying the same status twice
-      // is a no-op) so we do not need the OrderEvent dedupe table here.
-      // Phase 4b-β will add `invoice.paid` / `invoice.payment_failed`
-      // handling that materializes Orders + VendorFulfillments.
+      // Phase 4b-α: subscription lifecycle. The handlers below dedupe by
+      // event.created (a monotonically increasing per-object Stripe
+      // timestamp) using Subscription.lastStripeEventAt as a watermark.
+      // This protects against Stripe's documented out-of-order delivery,
+      // not just literal replays of the same eventId — the future
+      // WebhookDelivery dedupe (#308) is complementary, not a substitute.
       case 'customer.subscription.created': {
         const parsed = parseStripeSubscriptionEvent(event.data.object)
         if (!parsed) {
           logInvalidWebhookPayload(event)
           break
         }
-        await handleSubscriptionCreated(parsed)
+        await handleSubscriptionCreated(parsed, eventCreatedAt(event))
         break
       }
       case 'customer.subscription.updated':
@@ -134,7 +149,7 @@ export async function POST(req: NextRequest) {
           logInvalidWebhookPayload(event)
           break
         }
-        await handleSubscriptionSync(parsed, event.type)
+        await handleSubscriptionSync(parsed, event.type, eventCreatedAt(event))
         break
       }
       // Phase 4b-β: when Stripe charges a renewal invoice, materialize
@@ -147,7 +162,7 @@ export async function POST(req: NextRequest) {
           logInvalidWebhookPayload(event)
           break
         }
-        await handleInvoicePaid(invoice)
+        await handleInvoicePaid(invoice, eventCreatedAt(event))
         break
       }
       case 'invoice.payment_failed': {
@@ -156,7 +171,7 @@ export async function POST(req: NextRequest) {
           logInvalidWebhookPayload(event)
           break
         }
-        await handleInvoicePaymentFailed(invoice)
+        await handleInvoicePaymentFailed(invoice, eventCreatedAt(event))
         break
       }
     }
@@ -340,17 +355,18 @@ async function handlePaymentFailed(providerRef: string, eventId?: string) {
 }
 
 async function handleSubscriptionCreated(
-  payload: StripeSubscriptionEventPayload
+  payload: StripeSubscriptionEventPayload,
+  eventCreatedAt: Date
 ) {
   // Idempotent: if we already have a local row tied to this Stripe
   // subscription id, this is a replay and we skip straight to the sync
-  // path below.
+  // path below (which carries the same out-of-order guard).
   const existing = await db.subscription.findUnique({
     where: { stripeSubscriptionId: payload.id },
     select: { id: true },
   })
   if (existing) {
-    await handleSubscriptionSync(payload, 'customer.subscription.updated')
+    await handleSubscriptionSync(payload, 'customer.subscription.updated', eventCreatedAt)
     return
   }
 
@@ -411,6 +427,7 @@ async function handleSubscriptionCreated(
       nextDeliveryAt,
       currentPeriodEnd,
       stripeSubscriptionId: payload.id,
+      lastStripeEventAt: eventCreatedAt,
     },
     update: {
       // The buyer had a prior CANCELED sub for the same plan (we block
@@ -422,19 +439,23 @@ async function handleSubscriptionCreated(
       currentPeriodEnd,
       stripeSubscriptionId: payload.id,
       canceledAt: null,
+      lastStripeEventAt: eventCreatedAt,
     },
   })
 }
 
-async function handleInvoicePaid(invoice: {
-  id: string
-  subscription: string | null
-  amount_paid: number
-}) {
+async function handleInvoicePaid(
+  invoice: {
+    id: string
+    subscription: string | null
+    amount_paid: number
+  },
+  eventCreatedAt: Date
+) {
   if (!invoice.subscription) return
   const subscription = await db.subscription.findUnique({
     where: { stripeSubscriptionId: invoice.subscription },
-    select: { id: true },
+    select: { id: true, lastStripeEventAt: true },
   })
   if (!subscription) {
     // Likely: the `customer.subscription.created` event has not arrived
@@ -447,17 +468,40 @@ async function handleInvoicePaid(invoice: {
     })
     return
   }
+  // Out-of-order guard: drop stale invoice events whose `created` is
+  // older than the watermark. materializeSubscriptionRenewal also has
+  // its own per-invoice idempotency, but this catches old events
+  // before we touch Order/Payment rows.
+  if (
+    subscription.lastStripeEventAt &&
+    eventCreatedAt.getTime() < subscription.lastStripeEventAt.getTime()
+  ) {
+    console.info('[stripe-webhook][invoice-paid][stale]', {
+      stripeSubscriptionId: invoice.subscription,
+      invoiceId: invoice.id,
+      eventCreatedAt: eventCreatedAt.toISOString(),
+      lastStripeEventAt: subscription.lastStripeEventAt.toISOString(),
+    })
+    return
+  }
   await materializeSubscriptionRenewal({
     invoiceId: invoice.id,
     subscriptionId: subscription.id,
     amountPaidCents: invoice.amount_paid,
   })
+  await db.subscription.update({
+    where: { id: subscription.id },
+    data: { lastStripeEventAt: eventCreatedAt },
+  })
 }
 
-async function handleInvoicePaymentFailed(invoice: {
-  id: string
-  subscription: string | null
-}) {
+async function handleInvoicePaymentFailed(
+  invoice: {
+    id: string
+    subscription: string | null
+  },
+  eventCreatedAt: Date
+) {
   if (!invoice.subscription) return
   const subscription = await db.subscription.findUnique({
     where: { stripeSubscriptionId: invoice.subscription },
@@ -472,11 +516,30 @@ async function handleInvoicePaymentFailed(invoice: {
     },
   })
   if (!subscription) return
-  if (subscription.status === 'PAST_DUE' || subscription.status === 'CANCELED') return
+  // Out-of-order guard: drop stale events older than the watermark.
+  if (
+    subscription.lastStripeEventAt &&
+    eventCreatedAt.getTime() < subscription.lastStripeEventAt.getTime()
+  ) {
+    console.info('[stripe-webhook][invoice-payment-failed][stale]', {
+      stripeSubscriptionId: invoice.subscription,
+      invoiceId: invoice.id,
+      eventCreatedAt: eventCreatedAt.toISOString(),
+      lastStripeEventAt: subscription.lastStripeEventAt.toISOString(),
+    })
+    return
+  }
+  if (subscription.status === 'PAST_DUE' || subscription.status === 'CANCELED') {
+    await db.subscription.update({
+      where: { id: subscription.id },
+      data: { lastStripeEventAt: eventCreatedAt },
+    })
+    return
+  }
 
   await db.subscription.update({
     where: { id: subscription.id },
-    data: { status: 'PAST_DUE' },
+    data: { status: 'PAST_DUE', lastStripeEventAt: eventCreatedAt },
   })
 
   // Phase 4b-δ: email the buyer so they can update their card. Best-effort.
@@ -492,11 +555,12 @@ async function handleInvoicePaymentFailed(invoice: {
 
 async function handleSubscriptionSync(
   payload: { id: string; status: string; pause_collection?: unknown; canceled_at?: number | null },
-  eventType: 'customer.subscription.updated' | 'customer.subscription.deleted'
+  eventType: 'customer.subscription.updated' | 'customer.subscription.deleted',
+  eventCreatedAt: Date
 ) {
   const subscription = await db.subscription.findUnique({
     where: { stripeSubscriptionId: payload.id },
-    select: { id: true, status: true, canceledAt: true },
+    select: { id: true, status: true, canceledAt: true, lastStripeEventAt: true },
   })
 
   if (!subscription) {
@@ -511,6 +575,22 @@ async function handleSubscriptionSync(
     return
   }
 
+  // Out-of-order guard: drop events whose `created` is older than the
+  // watermark. Without this, a stale `updated(ACTIVE)` arriving after a
+  // newer `deleted(CANCELED)` would resurrect a cancelled subscription.
+  if (
+    subscription.lastStripeEventAt &&
+    eventCreatedAt.getTime() < subscription.lastStripeEventAt.getTime()
+  ) {
+    console.info('[stripe-webhook][subscription-sync][stale]', {
+      stripeSubscriptionId: payload.id,
+      eventType,
+      eventCreatedAt: eventCreatedAt.toISOString(),
+      lastStripeEventAt: subscription.lastStripeEventAt.toISOString(),
+    })
+    return
+  }
+
   // `customer.subscription.deleted` is Stripe's terminal cancelation
   // event — trust it over whatever `status` says on the object.
   const nextStatus =
@@ -520,7 +600,12 @@ async function handleSubscriptionSync(
 
   if (subscription.status === nextStatus) {
     // Idempotent no-op — the row is already in the state this event
-    // asks for. Common when Stripe retries a webhook.
+    // asks for. Still bump the watermark so an even older event that
+    // arrives later cannot pass the guard.
+    await db.subscription.update({
+      where: { id: subscription.id },
+      data: { lastStripeEventAt: eventCreatedAt },
+    })
     return
   }
 
@@ -534,6 +619,7 @@ async function handleSubscriptionSync(
     data: {
       status: nextStatus,
       canceledAt,
+      lastStripeEventAt: eventCreatedAt,
     },
   })
 }

--- a/test/integration/stripe-subscription-ordering.test.ts
+++ b/test/integration/stripe-subscription-ordering.test.ts
@@ -1,0 +1,218 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { POST } from '@/app/api/webhooks/stripe/route'
+import { createSubscriptionPlan } from '@/domains/subscriptions/actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Issue #417: Stripe does not guarantee webhook delivery order. The
+ * subscription/invoice handlers must guard against an older event
+ * arriving after a newer one and silently regressing state. This
+ * suite drives the same handler with deliberately reversed event
+ * timestamps and asserts the final state matches the latest event,
+ * not the last-arrived one.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  process.env.PAYMENT_PROVIDER = 'mock'
+  resetServerEnvCache()
+})
+
+async function seedSubscription(stripeSubscriptionId: string) {
+  const { user: vendorUser, vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 20 })
+  useTestSession(buildSession(vendorUser.id, 'VENDOR'))
+  const plan = await createSubscriptionPlan({
+    productId: product.id,
+    cadence: 'WEEKLY',
+    cutoffDayOfWeek: 5,
+  })
+
+  const buyer = await createUser('CUSTOMER')
+  const address = await db.address.create({
+    data: {
+      userId: buyer.id,
+      firstName: 'Order',
+      lastName: 'Tester',
+      line1: 'Calle Mayor 1',
+      city: 'Madrid',
+      province: 'Madrid',
+      postalCode: '28001',
+      country: 'ES',
+    },
+  })
+  const sub = await db.subscription.create({
+    data: {
+      buyerId: buyer.id,
+      planId: plan.id,
+      shippingAddressId: address.id,
+      status: 'ACTIVE',
+      nextDeliveryAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      currentPeriodEnd: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      stripeSubscriptionId,
+    },
+  })
+  return { sub, buyer }
+}
+
+function postSubscriptionEvent(
+  eventId: string,
+  type:
+    | 'customer.subscription.updated'
+    | 'customer.subscription.deleted'
+    | 'customer.subscription.created',
+  stripeSubscriptionId: string,
+  status: string,
+  createdSeconds: number,
+) {
+  const req = new Request('http://localhost/api/webhooks/stripe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: eventId,
+      type,
+      created: createdSeconds,
+      data: {
+        object: { id: stripeSubscriptionId, status },
+      },
+    }),
+  })
+  // The route handler is typed against NextRequest but only uses Web
+  // standard Request methods. The cast is safe and matches the pattern
+  // used by stripe-webhook.test.ts.
+  return POST(req as Parameters<typeof POST>[0])
+}
+
+test('newer subscription.deleted (t=20) wins over later-arriving stale subscription.updated (t=10)', async () => {
+  const { sub } = await seedSubscription('sub_test_ordering_1')
+
+  // Apply the NEWER event (deleted at t=20) FIRST in arrival order.
+  const r1 = await postSubscriptionEvent(
+    'evt_del_1',
+    'customer.subscription.deleted',
+    'sub_test_ordering_1',
+    'canceled',
+    2_000_000_020,
+  )
+  assert.equal(r1.status, 200)
+
+  let row = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(row?.status, 'CANCELED')
+
+  // Then the OLDER event (updated active at t=10) arrives — must be dropped.
+  const r2 = await postSubscriptionEvent(
+    'evt_upd_old',
+    'customer.subscription.updated',
+    'sub_test_ordering_1',
+    'active',
+    2_000_000_010,
+  )
+  assert.equal(r2.status, 200)
+
+  row = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(row?.status, 'CANCELED', 'stale event must NOT resurrect a CANCELED subscription')
+})
+
+test('newer subscription.updated(PAST_DUE, t=15) wins over later-arriving stale subscription.created(t=5)', async () => {
+  const { sub } = await seedSubscription('sub_test_ordering_2')
+
+  // Newer event first.
+  const r1 = await postSubscriptionEvent(
+    'evt_upd_pd',
+    'customer.subscription.updated',
+    'sub_test_ordering_2',
+    'past_due',
+    2_000_000_015,
+  )
+  assert.equal(r1.status, 200)
+  let row = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(row?.status, 'PAST_DUE')
+
+  // Older "created" event (which the route reroutes to handleSubscriptionSync
+  // for known ids) arrives later with status=active and t=5 — must be dropped.
+  const r2 = await postSubscriptionEvent(
+    'evt_created_old',
+    'customer.subscription.created',
+    'sub_test_ordering_2',
+    'active',
+    2_000_000_005,
+  )
+  assert.equal(r2.status, 200)
+  row = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(row?.status, 'PAST_DUE', 'stale created/active must not resurrect')
+})
+
+test('exact replay of the same subscription.updated is idempotent and bumps the watermark only', async () => {
+  const { sub } = await seedSubscription('sub_test_ordering_3')
+
+  const r1 = await postSubscriptionEvent(
+    'evt_pd_1',
+    'customer.subscription.updated',
+    'sub_test_ordering_3',
+    'past_due',
+    2_000_000_100,
+  )
+  assert.equal(r1.status, 200)
+  const after1 = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(after1?.status, 'PAST_DUE')
+  assert.ok(after1?.lastStripeEventAt)
+
+  const r2 = await postSubscriptionEvent(
+    'evt_pd_1',
+    'customer.subscription.updated',
+    'sub_test_ordering_3',
+    'past_due',
+    2_000_000_100,
+  )
+  assert.equal(r2.status, 200)
+  const after2 = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(after2?.status, 'PAST_DUE')
+  assert.equal(after2?.lastStripeEventAt?.getTime(), after1?.lastStripeEventAt?.getTime())
+})
+
+test('happy path: a normal sequence of strictly-increasing events flows through', async () => {
+  const { sub } = await seedSubscription('sub_test_ordering_4')
+
+  await postSubscriptionEvent(
+    'e1',
+    'customer.subscription.updated',
+    'sub_test_ordering_4',
+    'active',
+    2_000_001_000,
+  )
+  await postSubscriptionEvent(
+    'e2',
+    'customer.subscription.updated',
+    'sub_test_ordering_4',
+    'past_due',
+    2_000_001_100,
+  )
+  await postSubscriptionEvent(
+    'e3',
+    'customer.subscription.deleted',
+    'sub_test_ordering_4',
+    'canceled',
+    2_000_001_200,
+  )
+
+  const final = await db.subscription.findUnique({ where: { id: sub.id } })
+  assert.equal(final?.status, 'CANCELED')
+  assert.equal(final?.lastStripeEventAt?.getTime(), 2_000_001_200_000)
+})


### PR DESCRIPTION
## Summary

Closes #417. Stripe explicitly does **not** guarantee webhook delivery order. The previous handlers were idempotent only against literal replays of the same event id ("state-based sync"). A stale `customer.subscription.updated(active)` arriving after a newer `customer.subscription.deleted(canceled)` would silently regress the row from CANCELED back to ACTIVE — exactly the kind of bug that loses paying subscribers in production.

## Approach

Add a per-`Subscription` watermark `lastStripeEventAt` (Stripe's top-level `event.created`, monotonically increasing per object) and drop any subsequent event whose `created` is strictly older. Apply uniformly to:

- `customer.subscription.created` (re-routes to sync for known ids)
- `customer.subscription.updated`
- `customer.subscription.deleted`
- `invoice.paid`
- `invoice.payment_failed`

The handlers always bump the watermark when accepting an event, **including the no-change idempotent path**, so an even-older event arriving even later still trips the guard.

## Changes

- [prisma/schema.prisma](prisma/schema.prisma) — `Subscription.lastStripeEventAt DateTime?`
- [prisma/migrations/20260415170000_subscription_last_stripe_event_at/migration.sql](prisma/migrations/20260415170000_subscription_last_stripe_event_at/migration.sql) — additive `ADD COLUMN`, no backfill
- [src/app/api/webhooks/stripe/route.ts](src/app/api/webhooks/stripe/route.ts):
  - new `eventCreatedAt(event)` helper extracting the unix `event.created`
  - 4 handlers updated to take `eventCreatedAt: Date` and apply the watermark guard
  - dropped events log at `info` (not `error`) — out-of-order is expected, not pathological

## Tests

New file: [test/integration/stripe-subscription-ordering.test.ts](test/integration/stripe-subscription-ordering.test.ts) — 4 tests, all green:

- newer `deleted(t=20)` → stale `updated(active, t=10)` leaves row CANCELED
- newer `updated(past_due, t=15)` → stale `created(active, t=5)` stays PAST_DUE
- exact replay of the same `updated` event is idempotent (status + watermark unchanged)
- happy path: ACTIVE → PAST_DUE → CANCELED with strictly increasing timestamps

## What this PR does NOT do

- It does **not** introduce a `WebhookDelivery` table. That is sub-issue #408 of #308 and is complementary, not a substitute. The watermark catches **ordering** bugs; `WebhookDelivery` will catch **literal replays** more efficiently than the current `OrderEvent.payload` JSON-path lookup.
- It does **not** touch `payment_intent.*` handlers — those already use the `OrderEvent` dedupe path.
- It does **not** modify `materializeSubscriptionRenewal` semantics — the watermark guard runs before its per-invoice idempotency.

## Test plan

- [x] `npx prisma migrate deploy` — applies cleanly to a fresh DB
- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/stripe-subscription-ordering.test.ts` — 4/4 pass
- [ ] Full CI on PR (will rerun migration + existing webhook tests)

## Risk / rollback

Medium-low. Schema change is additive (nullable column, safe to leave or drop). Behaviour change affects only stale events — happy-path traffic is unchanged. Rollback: revert this PR; the column is harmless if left in place. If a downstream issue surfaces, an emergency hotfix can simply remove the timestamp comparison block from each handler without a schema rollback.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)