### PR TITLE
feat(pwa): installability base — manifest + SW + register (#425)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,51 @@
+/* Mercado Productor — minimal PWA service worker.
+ *
+ * Phase 1 (current): installability only. No runtime caching yet.
+ * We keep the fetch handler intentionally transparent so nothing is ever
+ * served from cache — this avoids stale auth, stale dashboards, and stale
+ * checkout state while still satisfying the browser's "has a controlling
+ * SW" installability requirement.
+ *
+ * When we eventually add runtime caching, the allow-list must exclude:
+ *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*, /(auth)/*
+ * and anything with an Authorization / Cookie header.
+ */
+
+const SW_VERSION = 'mp-sw-v1'
+
+self.addEventListener('install', () => {
+  // Activate immediately on first install so the page gets a controller
+  // without requiring a manual reload.
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      // Nuke any caches from a previous SW version — we are not using
+      // runtime caching yet, so no cache should survive.
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+      await self.clients.claim()
+    })()
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request
+
+  // Only handle GETs; never intercept POST/PUT/PATCH/DELETE.
+  if (req.method !== 'GET') return
+
+  // Let the browser handle everything itself. This is a no-op SW that only
+  // exists so the app is installable. We explicitly do NOT call
+  // event.respondWith, so the default network fetch runs unchanged.
+  return
+})
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting()
+})
+
+// Version tag for easier debugging from DevTools > Application > SW.
+self.__SW_VERSION = SW_VERSION

--- a/src/app/icons/icon-192.png/route.tsx
+++ b/src/app/icons/icon-192.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(192, 'any')
+}

--- a/src/app/icons/icon-512.png/route.tsx
+++ b/src/app/icons/icon-512.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(512, 'any')
+}

--- a/src/app/icons/icon-maskable-512.png/route.tsx
+++ b/src/app/icons/icon-maskable-512.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(512, 'maskable')
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { SITE_METADATA_BASE } from '@/lib/seo'
 import { SessionProvider } from '@/components/SessionProvider'
 import { LanguageProvider } from '@/i18n'
 import { getServerLocale } from '@/i18n/server'
+import PwaRegister from '@/components/pwa/PwaRegister'
 
 const geist = Geist({
   variable: '--font-geist-sans',
@@ -47,6 +48,15 @@ export const metadata: Metadata = {
     shortcut: siteAppearance.faviconPath,
     apple: siteAppearance.faviconPath,
   },
+  applicationName: SITE_NAME,
+  appleWebApp: {
+    capable: true,
+    title: SITE_NAME,
+    statusBarStyle: 'default',
+  },
+  formatDetection: {
+    telephone: false,
+  },
 }
 
 export const viewport: Viewport = {
@@ -56,6 +66,8 @@ export const viewport: Viewport = {
   ],
   colorScheme: 'light dark',
   viewportFit: 'cover',
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -74,6 +86,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <Suspense fallback={null}>
                 <AnalyticsProvider />
               </Suspense>
+              <PwaRegister />
               {children}
             </LanguageProvider>
           </ThemeProvider>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from 'next'
+import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants'
+import { siteAppearance } from '@/lib/brand'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: 'Mercado',
+    description: SITE_DESCRIPTION,
+    start_url: '/?source=pwa',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    background_color: siteAppearance.background,
+    theme_color: siteAppearance.themeColor,
+    categories: ['food', 'shopping', 'lifestyle'],
+    lang: 'es',
+    dir: 'ltr',
+    icons: [
+      {
+        src: '/icons/icon-192.png',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-maskable-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+  }
+}

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Registers the service worker and captures the `beforeinstallprompt` event
+ * so UI elsewhere can trigger the install prompt later.
+ *
+ * Keep this component tiny and side-effect-only: it must not render any DOM
+ * and must never break SSR — all browser APIs are touched inside useEffect.
+ */
+export default function PwaRegister() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (process.env.NODE_ENV !== 'production') return
+    if (!('serviceWorker' in navigator)) return
+
+    const register = () => {
+      navigator.serviceWorker
+        .register('/sw.js', { scope: '/' })
+        .catch((err) => {
+          // Swallow — SW registration failure must never break the app.
+          // Lighthouse will still flag it, which is what we want.
+          console.warn('[pwa] service worker registration failed', err)
+        })
+    }
+
+    // Defer until after load so we don't compete with hydration / critical
+    // requests on the first paint.
+    if (document.readyState === 'complete') register()
+    else window.addEventListener('load', register, { once: true })
+
+    const onBeforeInstallPrompt = (e: Event) => {
+      // Prevent Chrome's mini-infobar so we can decide when to prompt.
+      e.preventDefault()
+      // Stash the event on window so an install button elsewhere can call
+      // `event.prompt()` later. Typed as `unknown` to avoid leaking a
+      // non-standard global type into the app.
+      ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = e
+      window.dispatchEvent(new CustomEvent('pwa:installable'))
+    }
+
+    const onAppInstalled = () => {
+      ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = undefined
+      window.dispatchEvent(new CustomEvent('pwa:installed'))
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+    }
+  }, [])
+
+  return null
+}

--- a/src/lib/pwa/brand-icon.tsx
+++ b/src/lib/pwa/brand-icon.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from 'next/og'
+
+type IconVariant = 'any' | 'maskable'
+
+/**
+ * Renders the PWA brand mark at a given pixel size. `maskable` variants get a
+ * ~18% safe-area padding so the icon survives OS shape masking.
+ */
+export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
+  const padding = variant === 'maskable' ? size * 0.18 : size * 0.1
+  const inner = size - padding * 2
+  const radius = variant === 'maskable' ? 0 : size * 0.22
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background:
+            variant === 'maskable'
+              ? '#0f766e'
+              : 'linear-gradient(135deg, #0f766e 0%, #65a30d 100%)',
+          borderRadius: radius,
+        }}
+      >
+        <div
+          style={{
+            width: inner,
+            height: inner,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: inner * 0.78,
+            lineHeight: 1,
+          }}
+        >
+          🌿
+        </div>
+      </div>
+    ),
+    { width: size, height: size }
+  )
+}


### PR DESCRIPTION
Closes #425

## Summary
- Adds \`src/app/manifest.ts\` via Next 16 metadata API with 3 icons (192, 512, maskable 512)
- Icons generated dynamically via \`ImageResponse\` route handlers — no binaries in git
- Minimal pass-through service worker at \`public/sw.js\` (no runtime caching, no \`respondWith\`)
- \`PwaRegister\` client component registers the SW (production only) and captures \`beforeinstallprompt\` on \`window.__pwaInstallPrompt\`
- Layout adds \`applicationName\`, \`appleWebApp\`, \`formatDetection\`, and completes the viewport

## Why pass-through?
Chrome only needs a controlling SW to mark the app installable. It does **not** need to cache anything. A pass-through SW satisfies the requirement with zero risk of serving stale HTML in \`/admin\`, \`/vendor\`, \`/checkout\`, \`/auth\` or \`/api\`. Future phases (#427 offline, #428 runtime cache) will layer caching on top with explicit allow-lists.

## Why not \`next-pwa\`?
It wraps Workbox with conventions that interfere with SSR + auth in non-obvious ways. Manual control is clearer, smaller, and easier to audit with NextAuth + Stripe in the mix.

## Test plan
- [ ] \`npm run typecheck\` green ✅ (verified locally)
- [ ] \`npm run build\` green
- [ ] DevTools › Application › Manifest: no errors, 3 icons visible
- [ ] DevTools › Application › Service Workers: \`sw.js\` active, scope \`/\`, version \`mp-sw-v1\`
- [ ] Lighthouse PWA *Installable*: ✅
- [ ] Chrome Android: \"Add to Home Screen\" appears; launches in \`standalone\`
- [ ] NextAuth login/logout unaffected
- [ ] \`/admin\`, \`/vendor\`, \`/checkout\` behave identically (SW never intercepts)
- [ ] \`GET /icons/icon-192.png\`, \`/icons/icon-512.png\`, \`/icons/icon-maskable-512.png\` return valid PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)