### PR TITLE
feat(pwa): offline navigation fallback (#427)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,51 @@
+/* Mercado Productor — minimal PWA service worker.
+ *
+ * Phase 1 (current): installability only. No runtime caching yet.
+ * We keep the fetch handler intentionally transparent so nothing is ever
+ * served from cache — this avoids stale auth, stale dashboards, and stale
+ * checkout state while still satisfying the browser's "has a controlling
+ * SW" installability requirement.
+ *
+ * When we eventually add runtime caching, the allow-list must exclude:
+ *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*, /(auth)/*
+ * and anything with an Authorization / Cookie header.
+ */
+
+const SW_VERSION = 'mp-sw-v1'
+
+self.addEventListener('install', () => {
+  // Activate immediately on first install so the page gets a controller
+  // without requiring a manual reload.
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      // Nuke any caches from a previous SW version — we are not using
+      // runtime caching yet, so no cache should survive.
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+      await self.clients.claim()
+    })()
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request
+
+  // Only handle GETs; never intercept POST/PUT/PATCH/DELETE.
+  if (req.method !== 'GET') return
+
+  // Let the browser handle everything itself. This is a no-op SW that only
+  // exists so the app is installable. We explicitly do NOT call
+  // event.respondWith, so the default network fetch runs unchanged.
+  return
+})
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'SKIP_WAITING') self.skipWaiting()
+})
+
+// Version tag for easier debugging from DevTools > Application > SW.
+self.__SW_VERSION = SW_VERSION

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,51 +1,101 @@
-/* Mercado Productor — minimal PWA service worker.
+/* Mercado Productor — PWA service worker.
  *
- * Phase 1 (current): installability only. No runtime caching yet.
- * We keep the fetch handler intentionally transparent so nothing is ever
- * served from cache — this avoids stale auth, stale dashboards, and stale
- * checkout state while still satisfying the browser's "has a controlling
- * SW" installability requirement.
+ * Phase 2 (current): offline navigation fallback.
  *
- * When we eventually add runtime caching, the allow-list must exclude:
- *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*, /(auth)/*
- * and anything with an Authorization / Cookie header.
+ * Strategy
+ * --------
+ * - Precache exactly ONE resource on install: /offline
+ * - On navigation requests (request.mode === 'navigate') try the network
+ *   first; if it throws (device is offline) respond with the cached
+ *   /offline page.
+ * - Everything else is pass-through (we never call respondWith).
+ *
+ * Exclusions — we do NOT intercept navigations to any of these prefixes,
+ * even when offline. Serving the offline shell in place of an auth or
+ * admin screen would be more confusing than the browser's own error,
+ * and we must never cache state from them.
+ *
+ *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*
+ *
+ * When we add static-asset caching in Phase 3 (#428), it MUST keep an
+ * allow-list and never touch these prefixes either.
  */
 
-const SW_VERSION = 'mp-sw-v1'
+const SW_VERSION = 'mp-sw-v2'
+const OFFLINE_CACHE = 'mp-offline-v1'
+const OFFLINE_URL = '/offline'
 
-self.addEventListener('install', () => {
-  // Activate immediately on first install so the page gets a controller
-  // without requiring a manual reload.
-  self.skipWaiting()
+const PROTECTED_NAV_PREFIXES = [
+  '/api/',
+  '/admin',
+  '/vendor',
+  '/checkout',
+  '/auth',
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(OFFLINE_CACHE)
+      // `reload` bypasses HTTP cache so the offline shell is always fresh
+      // at SW install time.
+      await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }))
+      await self.skipWaiting()
+    })()
+  )
 })
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
-      // Nuke any caches from a previous SW version — we are not using
-      // runtime caching yet, so no cache should survive.
+      // Drop any cache that doesn't belong to the current version set.
+      const allowed = new Set([OFFLINE_CACHE])
       const keys = await caches.keys()
-      await Promise.all(keys.map((k) => caches.delete(k)))
+      await Promise.all(
+        keys.filter((k) => !allowed.has(k)).map((k) => caches.delete(k))
+      )
       await self.clients.claim()
     })()
   )
 })
 
+function isProtectedNavigation(url) {
+  const path = url.pathname
+  return PROTECTED_NAV_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
 self.addEventListener('fetch', (event) => {
   const req = event.request
-
-  // Only handle GETs; never intercept POST/PUT/PATCH/DELETE.
   if (req.method !== 'GET') return
 
-  // Let the browser handle everything itself. This is a no-op SW that only
-  // exists so the app is installable. We explicitly do NOT call
-  // event.respondWith, so the default network fetch runs unchanged.
-  return
+  // Only intercept top-level navigations. All sub-resource requests
+  // (scripts, images, data fetches) fall through to the network
+  // transparently.
+  if (req.mode !== 'navigate') return
+
+  const url = new URL(req.url)
+  if (url.origin !== self.location.origin) return
+  if (isProtectedNavigation(url)) return
+
+  event.respondWith(
+    (async () => {
+      try {
+        // Network-first. We intentionally don't cache successful responses
+        // here — product listings, prices and stock must stay fresh.
+        return await fetch(req)
+      } catch {
+        const cache = await caches.open(OFFLINE_CACHE)
+        const cached = await cache.match(OFFLINE_URL)
+        if (cached) return cached
+        // Last-resort: let the browser's own error surface.
+        throw new Error('offline and no cached shell available')
+      }
+    })()
+  )
 })
 
 self.addEventListener('message', (event) => {
   if (event.data === 'SKIP_WAITING') self.skipWaiting()
 })
 
-// Version tag for easier debugging from DevTools > Application > SW.
 self.__SW_VERSION = SW_VERSION

--- a/src/app/icons/icon-192.png/route.tsx
+++ b/src/app/icons/icon-192.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(192, 'any')
+}

--- a/src/app/icons/icon-512.png/route.tsx
+++ b/src/app/icons/icon-512.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(512, 'any')
+}

--- a/src/app/icons/icon-maskable-512.png/route.tsx
+++ b/src/app/icons/icon-maskable-512.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(512, 'maskable')
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { SITE_METADATA_BASE } from '@/lib/seo'
 import { SessionProvider } from '@/components/SessionProvider'
 import { LanguageProvider } from '@/i18n'
 import { getServerLocale } from '@/i18n/server'
+import PwaRegister from '@/components/pwa/PwaRegister'
 
 const geist = Geist({
   variable: '--font-geist-sans',
@@ -47,6 +48,15 @@ export const metadata: Metadata = {
     shortcut: siteAppearance.faviconPath,
     apple: siteAppearance.faviconPath,
   },
+  applicationName: SITE_NAME,
+  appleWebApp: {
+    capable: true,
+    title: SITE_NAME,
+    statusBarStyle: 'default',
+  },
+  formatDetection: {
+    telephone: false,
+  },
 }
 
 export const viewport: Viewport = {
@@ -56,6 +66,8 @@ export const viewport: Viewport = {
   ],
   colorScheme: 'light dark',
   viewportFit: 'cover',
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -74,6 +86,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <Suspense fallback={null}>
                 <AnalyticsProvider />
               </Suspense>
+              <PwaRegister />
               {children}
             </LanguageProvider>
           </ThemeProvider>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,40 @@
+import type { MetadataRoute } from 'next'
+import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants'
+import { siteAppearance } from '@/lib/brand'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: 'Mercado',
+    description: SITE_DESCRIPTION,
+    start_url: '/?source=pwa',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    background_color: siteAppearance.background,
+    theme_color: siteAppearance.themeColor,
+    categories: ['food', 'shopping', 'lifestyle'],
+    lang: 'es',
+    dir: 'ltr',
+    icons: [
+      {
+        src: '/icons/icon-192.png',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-maskable-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+  }
+}

--- a/src/app/offline/RetryButton.tsx
+++ b/src/app/offline/RetryButton.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export function RetryButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (typeof window !== 'undefined') window.location.reload()
+      }}
+      className="rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+    >
+      Reintentar
+    </button>
+  )
+}

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SITE_NAME } from '@/lib/constants'
+import { RetryButton } from './RetryButton'
+
+export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Sin conexión',
+  robots: { index: false, follow: false },
+}
+
+export default function OfflinePage() {
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-8 text-center shadow-sm">
+        <div
+          aria-hidden
+          className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-50 text-3xl dark:bg-emerald-950/60"
+        >
+          🌿
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-[var(--foreground)]">
+          Sin conexión
+        </h1>
+        <p className="mb-6 text-sm text-[var(--foreground-soft)]">
+          No hemos podido cargar {SITE_NAME}. Revisa tu conexión e inténtalo de
+          nuevo.
+        </p>
+        <div className="flex flex-col gap-2">
+          <RetryButton />
+          <Link
+            href="/"
+            className="rounded-xl px-4 py-2.5 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+          >
+            Ir al inicio
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,6 +19,7 @@ import type { UserRole } from '@/generated/prisma/enums'
 import { SignOutButton } from '@/components/auth/SignOutButton'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { LanguageToggle } from '@/components/LanguageToggle'
+import InstallButton from '@/components/pwa/InstallButton'
 import { useLocale, useT } from '@/i18n'
 import { useSession } from 'next-auth/react'
 
@@ -114,6 +115,12 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
   const portalHref = getPrimaryPortalHref(currentUser?.role)
   const portalLabel = getPortalLabel(currentUser?.role, locale)
   const isBuyerPortal = portalHref === '/cuenta'
+  // Hide the install CTA in work surfaces (admin, vendor, checkout) so we
+  // never interrupt a buy flow or an operator's task with an install prompt.
+  const canShowInstallCta =
+    !pathname.startsWith('/admin') &&
+    !pathname.startsWith('/vendor') &&
+    !pathname.startsWith('/checkout')
   const cartAriaLabel = cartHasItems
     ? `${t('cart')}, ${cartCountLabel}`
     : t('cart')
@@ -205,6 +212,7 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
 
           {/* Right actions */}
           <div className="ml-auto flex items-center gap-1">
+            {canShowInstallCta && <InstallButton />}
             <LanguageToggle />
             <ThemeToggle />
 

--- a/src/components/pwa/InstallButton.tsx
+++ b/src/components/pwa/InstallButton.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+
+/**
+ * Minimum Chromium `beforeinstallprompt` event shape — not exported by
+ * lib.dom.d.ts, so we redeclare it narrowly here.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[]
+  prompt: () => Promise<void>
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+}
+
+const DISMISS_KEY = 'mp.pwa.install.dismissedAt'
+const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+function recentlyDismissed(): boolean {
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY)
+    if (!raw) return false
+    const ts = Number.parseInt(raw, 10)
+    if (!Number.isFinite(ts)) return false
+    return Date.now() - ts < DISMISS_TTL_MS
+  } catch {
+    return false
+  }
+}
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.matchMedia('(display-mode: standalone)').matches) return true
+  // iOS Safari surfaces standalone mode on navigator, not matchMedia.
+  const iosNav = navigator as Navigator & { standalone?: boolean }
+  return iosNav.standalone === true
+}
+
+export default function InstallButton() {
+  const t = useT()
+  const [prompt, setPrompt] = useState<BeforeInstallPromptEvent | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (isStandalone()) return
+    if (recentlyDismissed()) return
+
+    // If PwaRegister already captured the event before this component
+    // mounted, read it from the stash so we don't miss the single-shot
+    // beforeinstallprompt.
+    const stashed =
+      (window as unknown as { __pwaInstallPrompt?: BeforeInstallPromptEvent })
+        .__pwaInstallPrompt ?? null
+    if (stashed) {
+      setPrompt(stashed)
+      setVisible(true)
+    }
+
+    const onInstallable = () => {
+      const event =
+        (window as unknown as { __pwaInstallPrompt?: BeforeInstallPromptEvent })
+          .__pwaInstallPrompt ?? null
+      if (!event) return
+      setPrompt(event)
+      setVisible(true)
+    }
+
+    const onInstalled = () => {
+      setPrompt(null)
+      setVisible(false)
+    }
+
+    window.addEventListener('pwa:installable', onInstallable)
+    window.addEventListener('pwa:installed', onInstalled)
+    return () => {
+      window.removeEventListener('pwa:installable', onInstallable)
+      window.removeEventListener('pwa:installed', onInstalled)
+    }
+  }, [])
+
+  if (!visible || !prompt) return null
+
+  const onClick = async () => {
+    try {
+      await prompt.prompt()
+      const { outcome } = await prompt.userChoice
+      if (outcome === 'dismissed') {
+        try {
+          localStorage.setItem(DISMISS_KEY, String(Date.now()))
+        } catch {
+          // localStorage may be unavailable in private mode — ignore.
+        }
+      }
+    } catch {
+      // prompt() can throw if called more than once — fall through.
+    } finally {
+      // The BeforeInstallPromptEvent is single-use; hide the button either way.
+      setVisible(false)
+      setPrompt(null)
+      ;(window as unknown as { __pwaInstallPrompt?: BeforeInstallPromptEvent })
+        .__pwaInstallPrompt = undefined
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={t('pwa.install.tooltip')}
+      aria-label={t('pwa.install.cta')}
+      className="hidden items-center gap-1.5 rounded-xl border border-emerald-200/70 bg-emerald-50/60 px-3 py-2 text-sm font-medium text-emerald-800 transition-colors hover:bg-emerald-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] dark:border-emerald-500/30 dark:bg-emerald-950/40 dark:text-emerald-200 dark:hover:bg-emerald-900/60 md:inline-flex"
+    >
+      <ArrowDownTrayIcon className="h-4 w-4" aria-hidden />
+      <span>{t('pwa.install.cta')}</span>
+    </button>
+  )
+}

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Registers the service worker and captures the `beforeinstallprompt` event
+ * so UI elsewhere can trigger the install prompt later.
+ *
+ * Keep this component tiny and side-effect-only: it must not render any DOM
+ * and must never break SSR — all browser APIs are touched inside useEffect.
+ */
+export default function PwaRegister() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (process.env.NODE_ENV !== 'production') return
+    if (!('serviceWorker' in navigator)) return
+
+    const register = () => {
+      navigator.serviceWorker
+        .register('/sw.js', { scope: '/' })
+        .catch((err) => {
+          // Swallow — SW registration failure must never break the app.
+          // Lighthouse will still flag it, which is what we want.
+          console.warn('[pwa] service worker registration failed', err)
+        })
+    }
+
+    // Defer until after load so we don't compete with hydration / critical
+    // requests on the first paint.
+    if (document.readyState === 'complete') register()
+    else window.addEventListener('load', register, { once: true })
+
+    const onBeforeInstallPrompt = (e: Event) => {
+      // Prevent Chrome's mini-infobar so we can decide when to prompt.
+      e.preventDefault()
+      // Stash the event on window so an install button elsewhere can call
+      // `event.prompt()` later. Typed as `unknown` to avoid leaking a
+      // non-standard global type into the app.
+      ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = e
+      window.dispatchEvent(new CustomEvent('pwa:installable'))
+    }
+
+    const onAppInstalled = () => {
+      ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = undefined
+      window.dispatchEvent(new CustomEvent('pwa:installed'))
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+    }
+  }, [])
+
+  return null
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1161,6 +1161,9 @@ const en: Record<TranslationKeys, string> = {
   'adminProducers.actions.suspend': 'Suspend',
   'adminProducers.actions.reactivate': 'Reactivate',
   'adminProducers.actions.error': 'Action failed',
+
+  'pwa.install.cta': 'Install app',
+  'pwa.install.tooltip': 'Launch faster from your home screen',
 }
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1159,6 +1159,9 @@ const es = {
   'adminProducers.actions.suspend': 'Suspender',
   'adminProducers.actions.reactivate': 'Reactivar',
   'adminProducers.actions.error': 'Acción fallida',
+
+  'pwa.install.cta': 'Instalar app',
+  'pwa.install.tooltip': 'Accede más rápido desde tu pantalla de inicio',
 } as const satisfies Record<string, string>
 
 export default es

--- a/src/lib/pwa/brand-icon.tsx
+++ b/src/lib/pwa/brand-icon.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from 'next/og'
+
+type IconVariant = 'any' | 'maskable'
+
+/**
+ * Renders the PWA brand mark at a given pixel size. `maskable` variants get a
+ * ~18% safe-area padding so the icon survives OS shape masking.
+ */
+export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
+  const padding = variant === 'maskable' ? size * 0.18 : size * 0.1
+  const inner = size - padding * 2
+  const radius = variant === 'maskable' ? 0 : size * 0.22
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background:
+            variant === 'maskable'
+              ? '#0f766e'
+              : 'linear-gradient(135deg, #0f766e 0%, #65a30d 100%)',
+          borderRadius: radius,
+        }}
+      >
+        <div
+          style={{
+            width: inner,
+            height: inner,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: inner * 0.78,
+            lineHeight: 1,
+          }}
+        >
+          🌿
+        </div>
+      </div>
+    ),
+    { width: size, height: size }
+  )
+}


### PR DESCRIPTION
Closes #427

Stacked on top of #432.

## Summary
- New static page \`src/app/offline/page.tsx\` (\`force-static\`, \`noindex\`) with a small retry button
- SW bumped to \`mp-sw-v2\`:
  - Precaches \`/offline\` in the \`mp-offline-v1\` cache on install (with \`cache: 'reload'\` to guarantee freshness)
  - On \`request.mode === 'navigate'\` does network-first, falls back to \`/offline\` on network error
  - **Never** intercepts \`/api\`, \`/admin\`, \`/vendor\`, \`/checkout\`, \`/auth\` or cross-origin navigations
  - On \`activate\` drops any cache not in the allow-list so old caches from v1 are purged
- Zero caching of successful responses — product pages, prices and stock stay fresh on every load

## Why only navigations?
\`request.mode === 'navigate'\` matches exactly top-level HTML loads. Scripts, images, and \`fetch()\` calls from inside the app get \`mode: 'cors'\`/\`'no-cors'\`/\`'same-origin'\` and fall through the handler untouched. That keeps API calls and auth flows on the normal network path even when offline — the user sees the real error instead of a ghost offline shell.

## Test plan
- [ ] \`npm run typecheck\` green ✅ (verified locally)
- [ ] Direct visit to \`/offline\` renders the page
- [ ] DevTools › Application › Cache Storage: only \`mp-offline-v1\` exists, contains \`/offline\`
- [ ] DevTools › Network › Offline, reload \`/\` → offline shell appears
- [ ] DevTools › Network › Offline, navigate to \`/admin\` → browser's own error (not offline shell)
- [ ] DevTools › Network › Offline, \`fetch('/api/whatever')\` from console → normal fetch error
- [ ] Reconnect + Retry button → original page loads
- [ ] Old \`mp-sw-v1\` clients upgrade cleanly (activate purges old caches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)