### PR TITLE
refactor(checkout): persist-first — create Payment row before Stripe PaymentIntent

### DIFF
--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -396,14 +396,16 @@ export async function createOrder(
     }
   }
 
-  // Create payment intent (mock or Stripe)
-  const payment = await createPaymentIntent(
-    Math.round(grandTotal * 100), // cents
-    { userId: sessionUserId },
-    connectDestination ? { connect: connectDestination } : undefined
-  )
-
-  // Create order in transaction
+  // Persist-first (#404): we used to call createPaymentIntent() here,
+  // BEFORE the transaction. If anything inside the transaction failed
+  // (stock conflict, deadlock, promotion budget drained, schema drift,
+  // etc.), the external Stripe PaymentIntent was orphaned with no
+  // matching local Payment row. Now we open the transaction first and
+  // create the Payment row with providerRef = null. createPaymentIntent
+  // runs AFTER commit and the Payment row is then updated with the
+  // real providerRef. If the post-commit provider call fails, we mark
+  // the Payment as FAILED and re-throw so the buyer gets a friendly
+  // "try again" message.
   const env = getServerEnv()
 
   async function createOrderRecord(includeShippingAddressSnapshot: boolean) {
@@ -573,7 +575,10 @@ export async function createOrder(
           payments: {
             create: {
               provider: env.paymentProvider === 'mock' ? 'mock' : 'stripe',
-              providerRef: payment.id,
+              // providerRef is filled in AFTER the transaction commits
+              // by createPaymentIntent, then linked back to this row
+              // via payment.update below.
+              providerRef: null,
               amount: grandTotal,
               currency: 'EUR',
               status: 'PENDING',
@@ -610,6 +615,67 @@ export async function createOrder(
     })
 
     order = await createOrderRecord(false)
+  }
+
+  // Post-commit: the order + a placeholder Payment row exist. Now we
+  // talk to the payment provider. If it throws we mark the Payment row
+  // as FAILED, emit an OrderEvent for ops visibility, and re-throw so
+  // createCheckoutOrder maps it to a friendly "try again" message.
+  let payment
+  try {
+    payment = await createPaymentIntent(
+      Math.round(grandTotal * 100), // cents
+      { userId: sessionUserId },
+      connectDestination ? { connect: connectDestination } : undefined
+    )
+  } catch (paymentError) {
+    try {
+      await db.payment.updateMany({
+        where: { orderId: order.id, providerRef: null, status: 'PENDING' },
+        data: { status: 'FAILED' },
+      })
+      await db.order.updateMany({
+        where: { id: order.id, paymentStatus: 'PENDING' },
+        data: { paymentStatus: 'FAILED' },
+      })
+      await db.orderEvent.create({
+        data: {
+          orderId: order.id,
+          type: 'PAYMENT_INTENT_CREATION_FAILED',
+          payload: {
+            recordedAt: new Date().toISOString(),
+            error:
+              paymentError instanceof Error
+                ? paymentError.message
+                : String(paymentError),
+          },
+        },
+      })
+    } catch (cleanupError) {
+      console.error('[checkout] failed to mark payment as FAILED after provider error', {
+        orderId: order.id,
+        cleanupError,
+      })
+    }
+    throw paymentError
+  }
+
+  // Link the placeholder Payment row to the real provider id. updateMany
+  // with the (orderId, providerRef=null) predicate so a retry that
+  // somehow ran twice cannot overwrite an already-linked row.
+  const linked = await db.payment.updateMany({
+    where: { orderId: order.id, providerRef: null, status: 'PENDING' },
+    data: { providerRef: payment.id },
+  })
+  if (linked.count !== 1) {
+    // Defensive: if we somehow committed an order without exactly one
+    // unlinked PENDING payment row, surface it loudly so it is caught
+    // in dev / CI rather than going to production undetected.
+    console.error('[checkout] expected exactly one unlinked Payment row to update, found', {
+      orderId: order.id,
+      count: linked.count,
+      providerRef: payment.id,
+    })
   }
 
   const affectedProductSlugs = [...new Set(products.map(product => product.slug))]

--- a/src/domains/payments/provider.ts
+++ b/src/domains/payments/provider.ts
@@ -31,11 +31,33 @@ export interface ConnectDestination {
   applicationFeeAmountCents: number
 }
 
+declare global {
+  // eslint-disable-next-line no-var
+  var __testCreatePaymentIntentOverride:
+    | ((amountCents: number) => Promise<PaymentIntent>)
+    | undefined
+}
+
+export function setTestCreatePaymentIntentOverride(
+  fn: ((amountCents: number) => Promise<PaymentIntent>) | undefined,
+): void {
+  globalThis.__testCreatePaymentIntentOverride = fn
+}
+
 export async function createPaymentIntent(
   amountCents: number,
   metadata: Record<string, string>,
   options?: { connect?: ConnectDestination }
 ): Promise<PaymentIntent> {
+  // Test-only injection point so integration tests can drive the
+  // provider-failure path without monkey-patching ES module exports
+  // or hitting the real Stripe SDK. Mirrors the test-session pattern
+  // in src/lib/action-session.ts. Production NODE_ENV ('production' /
+  // 'development') ignores the override even if it leaks.
+  if (process.env.NODE_ENV === 'test' && globalThis.__testCreatePaymentIntentOverride) {
+    return globalThis.__testCreatePaymentIntentOverride(amountCents)
+  }
+
   const env = getServerEnv()
 
   if (env.paymentProvider === 'mock') {

--- a/test/integration/checkout-persist-first.test.ts
+++ b/test/integration/checkout-persist-first.test.ts
@@ -1,0 +1,151 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createOrder } from '@/domains/orders/actions'
+import { setTestCreatePaymentIntentOverride } from '@/domains/payments/provider'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Issue #404: persist-first refactor for createOrder. The Stripe
+ * PaymentIntent must be created AFTER the DB transaction commits, so a
+ * failure inside the transaction cannot leave an orphan external
+ * PaymentIntent. These tests pin the new contract:
+ *
+ *   - happy path: a Payment row exists with the real providerRef
+ *   - provider-failure path: the Order exists, the Payment row is
+ *     marked FAILED with providerRef = null, an OrderEvent of type
+ *     PAYMENT_INTENT_CREATION_FAILED is emitted, and the caller sees
+ *     the underlying error (createCheckoutOrder maps it to a friendly
+ *     message via getCheckoutErrorMessage).
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { PAYMENT_PROVIDER: 'mock' })
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  setTestCreatePaymentIntentOverride(undefined)
+  resetServerEnvCache()
+})
+
+async function buildCheckoutInputs() {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, {
+    basePrice: 12,
+    stock: 5,
+    trackStock: true,
+  })
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  return {
+    buyer,
+    product,
+    items: [{ productId: product.id, quantity: 1 }],
+    formData: {
+      address: {
+        firstName: 'Persist',
+        lastName: 'First',
+        line1: 'Calle Lab 1',
+        city: 'Madrid',
+        province: 'Madrid',
+        postalCode: '28001',
+      },
+      saveAddress: false,
+    },
+  }
+}
+
+test('happy path (mock): creates Order + Payment with providerRef set after commit', async () => {
+  const { buyer, items, formData } = await buildCheckoutInputs()
+
+  const result = await createOrder(items, formData)
+  assert.ok(result.orderId)
+  assert.ok(result.clientSecret.startsWith('mock_pi_'))
+
+  const order = await db.order.findUnique({
+    where: { id: result.orderId },
+    include: { payments: true },
+  })
+  assert.ok(order, 'order must exist')
+  assert.equal(order.customerId, buyer.id)
+  assert.equal(order.payments.length, 1)
+  const payment = order.payments[0]!
+  assert.equal(payment.status, 'PENDING')
+  assert.equal(payment.provider, 'mock')
+  assert.ok(payment.providerRef, 'providerRef must be linked back after commit')
+  assert.ok(payment.providerRef.startsWith('mock_pi_'))
+})
+
+test('provider failure post-commit: order persists, Payment row marked FAILED, OrderEvent emitted', async () => {
+  const { items, formData } = await buildCheckoutInputs()
+
+  // Force createPaymentIntent to throw AFTER the DB transaction has
+  // committed. The provider exposes a test-only override hook that
+  // returns whatever this function returns (or throws what it throws).
+  setTestCreatePaymentIntentOverride(async () => {
+    throw new Error('stripe down: simulated post-commit failure')
+  })
+
+  await assert.rejects(
+    () => createOrder(items, formData),
+    /stripe down: simulated post-commit failure/i
+  )
+
+  // The Order MUST still exist (transaction committed). Find by the
+  // last placed customer order.
+  const orders = await db.order.findMany({
+    orderBy: { placedAt: 'desc' },
+    include: { payments: true, events: true },
+  })
+  assert.equal(orders.length, 1, 'exactly one order persisted')
+  const order = orders[0]!
+  assert.equal(order.paymentStatus, 'FAILED')
+  assert.equal(order.payments.length, 1)
+  const payment = order.payments[0]!
+  assert.equal(payment.status, 'FAILED')
+  assert.equal(payment.providerRef, null)
+
+  const failureEvent = order.events.find(
+    e => e.type === 'PAYMENT_INTENT_CREATION_FAILED'
+  )
+  assert.ok(failureEvent, 'PAYMENT_INTENT_CREATION_FAILED event must be emitted')
+})
+
+test('stock conflict inside transaction: NO payment provider call, no Payment row', async () => {
+  const { items, formData, product } = await buildCheckoutInputs()
+  // Drain the stock so the transaction throws on the FOR UPDATE check.
+  await db.product.update({
+    where: { id: product.id },
+    data: { stock: 0 },
+  })
+
+  // Spy on createPaymentIntent so we can assert it was NEVER called.
+  // The override would normally throw if invoked; we count calls via
+  // a closure counter.
+  let providerCalls = 0
+  setTestCreatePaymentIntentOverride(async () => {
+    providerCalls += 1
+    throw new Error('createPaymentIntent should NOT be called when stock fails')
+  })
+
+  await assert.rejects(() => createOrder(items, formData), /Stock insuficiente/i)
+
+  assert.equal(providerCalls, 0, 'createPaymentIntent must not run on stock failure')
+
+  const orders = await db.order.findMany()
+  assert.equal(orders.length, 0)
+  const payments = await db.payment.findMany()
+  assert.equal(payments.length, 0)
+})


### PR DESCRIPTION
## Summary

Closes #404. Restructures `createOrder` so the Stripe PaymentIntent is created **after** the DB transaction commits, eliminating the orphan-PaymentIntent window the parent #306 issue describes.

## Old vs new flow

**Before:**
1. validate → load products → stock precheck → calculate pricing
2. `createPaymentIntent` (Stripe HTTP call)
3. `db.$transaction { reserve stock + create Order + create Payment(providerRef = pi.id) }`

If step 3 threw for **any** reason (FOR UPDATE conflict, deadlock, drained promotion budget, schema drift, FK violation), the Stripe PaymentIntent from step 2 was orphaned with no local row to reconcile. It would silently expire or generate fraud-alert noise once the webhook arrived.

**After:**
1. validate → load products → stock precheck → calculate pricing
2. `db.$transaction { reserve stock + create Order + create Payment(providerRef = null) }`
3. `createPaymentIntent` (Stripe HTTP call) — only runs if the tx committed
4. `payment.updateMany({ where: { orderId, providerRef: null, status: PENDING }, data: { providerRef: pi.id } })`

If step 3 fails after the commit:
- mark the Payment row as `FAILED`
- mark `order.paymentStatus` as `FAILED`
- emit `OrderEvent { type: 'PAYMENT_INTENT_CREATION_FAILED' }`
- re-throw so `createCheckoutOrder` maps it via `getCheckoutErrorMessage` to the existing "ha habido un problema temporal al iniciar el pago" message — UX unchanged

The post-commit linking update is scoped by `(orderId, providerRef: null, status: PENDING)` so a stray retry can never overwrite a row that already has a real `providerRef`. We also assert that exactly one row was linked and log loudly if not (caught in dev/CI, not in prod silently).

## Why no schema change

`Payment.providerRef` is already `String? @unique` in [prisma/schema.prisma:668](prisma/schema.prisma#L668). Postgres `UNIQUE` allows multiple `NULL` values, so multiple in-flight orders can each have a placeholder Payment row without colliding.

## Test-only override hook in the provider

To exercise the post-commit failure path without monkey-patching ES module exports or hitting the real Stripe SDK, the provider gains a tiny test-only injection point:

```ts
setTestCreatePaymentIntentOverride(fn?: (amountCents) => Promise<PaymentIntent>): void
```

It is gated on `process.env.NODE_ENV === 'test'` via `globalThis`, mirroring the existing test-session pattern in [src/lib/action-session.ts](src/lib/action-session.ts). Production builds ignore the override even if it leaks.

## Tests

New file: [test/integration/checkout-persist-first.test.ts](test/integration/checkout-persist-first.test.ts) — 3 tests, all green:

1. **Happy path (mock):** `Order` + `Payment` exist after `createOrder`; `Payment.providerRef` is linked back to a `mock_pi_*` id.
2. **Post-commit provider failure:** Order persists with `paymentStatus: FAILED`; `Payment.status: FAILED` with `providerRef: null`; `OrderEvent` of type `PAYMENT_INTENT_CREATION_FAILED` emitted.
3. **Stock conflict inside tx:** `createPaymentIntent` is **never** called; no Order row, no Payment row.

Regression suites still green:

| Suite | Tests | Status |
|---|---|---|
| `test/integration/order-create.test.ts` | 16 | ✅ |
| `test/integration/stripe-webhook.test.ts` | 4 | ✅ |
| `test/integration/promotions-checkout.test.ts` | 12 | ✅ |
| `test/integration/stock-concurrency.test.ts` | 2 | ✅ |

## Coordination with #398

[#398 (orders auth audit)](https://github.com/juanmixto/marketplace/issues/398) also touches `src/domains/orders/actions.ts`. That PR was instructed to leave `createOrder` untouched, so the merge order is non-restrictive — whichever PR lands second rebases trivially.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/checkout-persist-first.test.ts` — 3/3
- [x] All checkout regression suites listed above — green
- [ ] Full CI on PR

## Risk / rollback

Medium. Touches the heart of checkout. Mitigation: the change is a localized reordering + a failure-cleanup block; the diff is ~80 lines net. No schema change. Rollback is a single PR revert. If the post-commit linking fails on a row that already has a `providerRef` (e.g. someone else wires a duplicate provider call later), the new defensive `count !== 1` log will surface it before it becomes silent.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)