### PR TITLE
feat(pwa): offline navigation fallback (#427)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,51 +1,101 @@
-/* Mercado Productor — minimal PWA service worker.
+/* Mercado Productor — PWA service worker.
  *
- * Phase 1 (current): installability only. No runtime caching yet.
- * We keep the fetch handler intentionally transparent so nothing is ever
- * served from cache — this avoids stale auth, stale dashboards, and stale
- * checkout state while still satisfying the browser's "has a controlling
- * SW" installability requirement.
+ * Phase 2 (current): offline navigation fallback.
  *
- * When we eventually add runtime caching, the allow-list must exclude:
- *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*, /(auth)/*
- * and anything with an Authorization / Cookie header.
+ * Strategy
+ * --------
+ * - Precache exactly ONE resource on install: /offline
+ * - On navigation requests (request.mode === 'navigate') try the network
+ *   first; if it throws (device is offline) respond with the cached
+ *   /offline page.
+ * - Everything else is pass-through (we never call respondWith).
+ *
+ * Exclusions — we do NOT intercept navigations to any of these prefixes,
+ * even when offline. Serving the offline shell in place of an auth or
+ * admin screen would be more confusing than the browser's own error,
+ * and we must never cache state from them.
+ *
+ *   /api/*, /admin/*, /vendor/*, /checkout/*, /auth/*
+ *
+ * When we add static-asset caching in Phase 3 (#428), it MUST keep an
+ * allow-list and never touch these prefixes either.
  */
 
-const SW_VERSION = 'mp-sw-v1'
+const SW_VERSION = 'mp-sw-v2'
+const OFFLINE_CACHE = 'mp-offline-v1'
+const OFFLINE_URL = '/offline'
 
-self.addEventListener('install', () => {
-  // Activate immediately on first install so the page gets a controller
-  // without requiring a manual reload.
-  self.skipWaiting()
+const PROTECTED_NAV_PREFIXES = [
+  '/api/',
+  '/admin',
+  '/vendor',
+  '/checkout',
+  '/auth',
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(OFFLINE_CACHE)
+      // `reload` bypasses HTTP cache so the offline shell is always fresh
+      // at SW install time.
+      await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }))
+      await self.skipWaiting()
+    })()
+  )
 })
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
-      // Nuke any caches from a previous SW version — we are not using
-      // runtime caching yet, so no cache should survive.
+      // Drop any cache that doesn't belong to the current version set.
+      const allowed = new Set([OFFLINE_CACHE])
       const keys = await caches.keys()
-      await Promise.all(keys.map((k) => caches.delete(k)))
+      await Promise.all(
+        keys.filter((k) => !allowed.has(k)).map((k) => caches.delete(k))
+      )
       await self.clients.claim()
     })()
   )
 })
 
+function isProtectedNavigation(url) {
+  const path = url.pathname
+  return PROTECTED_NAV_PREFIXES.some((prefix) => path.startsWith(prefix))
+}
+
 self.addEventListener('fetch', (event) => {
   const req = event.request
-
-  // Only handle GETs; never intercept POST/PUT/PATCH/DELETE.
   if (req.method !== 'GET') return
 
-  // Let the browser handle everything itself. This is a no-op SW that only
-  // exists so the app is installable. We explicitly do NOT call
-  // event.respondWith, so the default network fetch runs unchanged.
-  return
+  // Only intercept top-level navigations. All sub-resource requests
+  // (scripts, images, data fetches) fall through to the network
+  // transparently.
+  if (req.mode !== 'navigate') return
+
+  const url = new URL(req.url)
+  if (url.origin !== self.location.origin) return
+  if (isProtectedNavigation(url)) return
+
+  event.respondWith(
+    (async () => {
+      try {
+        // Network-first. We intentionally don't cache successful responses
+        // here — product listings, prices and stock must stay fresh.
+        return await fetch(req)
+      } catch {
+        const cache = await caches.open(OFFLINE_CACHE)
+        const cached = await cache.match(OFFLINE_URL)
+        if (cached) return cached
+        // Last-resort: let the browser's own error surface.
+        throw new Error('offline and no cached shell available')
+      }
+    })()
+  )
 })
 
 self.addEventListener('message', (event) => {
   if (event.data === 'SKIP_WAITING') self.skipWaiting()
 })
 
-// Version tag for easier debugging from DevTools > Application > SW.
 self.__SW_VERSION = SW_VERSION

--- a/src/app/offline/RetryButton.tsx
+++ b/src/app/offline/RetryButton.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export function RetryButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (typeof window !== 'undefined') window.location.reload()
+      }}
+      className="rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+    >
+      Reintentar
+    </button>
+  )
+}

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SITE_NAME } from '@/lib/constants'
+import { RetryButton } from './RetryButton'
+
+export const dynamic = 'force-static'
+
+export const metadata: Metadata = {
+  title: 'Sin conexión',
+  robots: { index: false, follow: false },
+}
+
+export default function OfflinePage() {
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-8 text-center shadow-sm">
+        <div
+          aria-hidden
+          className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-50 text-3xl dark:bg-emerald-950/60"
+        >
+          🌿
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-[var(--foreground)]">
+          Sin conexión
+        </h1>
+        <p className="mb-6 text-sm text-[var(--foreground-soft)]">
+          No hemos podido cargar {SITE_NAME}. Revisa tu conexión e inténtalo de
+          nuevo.
+        </p>
+        <div className="flex flex-col gap-2">
+          <RetryButton />
+          <Link
+            href="/"
+            className="rounded-xl px-4 py-2.5 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+          >
+            Ir al inicio
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
Closes #427

Replaces #433 (auto-closed when stacking base was deleted). Same commit contents.

## Summary
- New static page \`src/app/offline/page.tsx\` (\`force-static\`, \`noindex\`) with a retry button
- SW bumped to \`mp-sw-v2\`:
  - Precaches \`/offline\` in \`mp-offline-v1\` on install (\`cache: 'reload'\` for freshness)
  - On \`request.mode === 'navigate'\` does network-first, falls back to \`/offline\`
  - **Never** intercepts \`/api\`, \`/admin\`, \`/vendor\`, \`/checkout\`, \`/auth\` or cross-origin navigations
  - On \`activate\` drops any cache not in the allow-list

## Why only navigations?
\`request.mode === 'navigate'\` matches exactly top-level HTML loads. Sub-resource fetches fall through untouched so API/auth/checkout calls always hit the real network.

## Test plan
- [ ] Direct visit to \`/offline\` renders
- [ ] Cache Storage: only \`mp-offline-v1\` exists
- [ ] Offline + reload \`/\` → offline shell
- [ ] Offline + navigate to \`/admin\` → browser's own error (not offline shell)
- [ ] Reconnect + Retry → navigates back

🤖 Generated with [Claude Code](https://claude.com/claude-code)