### PR TITLE
feat(pwa): iOS install hint + PWA playbook (#429)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **Project conventions (stack, imports, Prisma fields, server-action pattern)** — see [`docs/conventions.md`](docs/conventions.md). Read this before implementing any ticket.
 - **i18n** — see [`src/i18n/README.md`](src/i18n/README.md) for when to use flat keys vs `*-copy.ts` modules and the `labelKey` server pattern.
 - **Git workflow (trunk-based, branch prefixes, hygiene)** — see [`docs/git-workflow.md`](docs/git-workflow.md). `main` is the only long-lived branch; no `integration/*`, `develop`, `next`. Run `scripts/git-hygiene.sh` periodically.
+- **PWA (service worker, manifest, install prompts, offline fallback, cache allow-list)** — see [`docs/pwa.md`](docs/pwa.md). Required reading before touching `public/sw.js`, `src/app/manifest.ts`, or anything under `src/components/pwa/`. The SW has a strict denylist (`/api`, `/admin`, `/vendor`, `/checkout`, `/auth`) that must never be weakened.
 
 ## Concurrent-agent safety
 

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -1,0 +1,140 @@
+# Progressive Web App
+
+The marketplace ships as an installable PWA. This doc is the single source of
+truth for anyone touching [`public/sw.js`](../public/sw.js),
+[`src/app/manifest.ts`](../src/app/manifest.ts), or the
+[`src/components/pwa/`](../src/components/pwa/) components.
+
+If you change any of those files, **re-read this doc first** and keep it up
+to date in the same PR.
+
+## Architecture
+
+```
+src/app/manifest.ts                     → Next metadata API → /manifest.webmanifest
+src/app/icons/icon-*.png/route.tsx      → ImageResponse PNG icons (192, 512, maskable 512)
+src/lib/pwa/brand-icon.tsx              → shared icon renderer
+public/sw.js                            → service worker (versioned: mp-sw-vN)
+src/components/pwa/PwaRegister.tsx      → registers sw.js (production only)
+src/components/pwa/InstallButton.tsx    → Android/desktop Chrome install CTA
+src/components/pwa/IosInstallHint.tsx   → iOS Safari "Add to Home Screen" hint
+src/app/offline/page.tsx                → offline fallback shell
+```
+
+The PWA was built in incremental phases (issues #425 → #429). Each phase
+leaves the SW in a known-good state with a clear cache allow-list.
+
+## Service worker caches
+
+| Cache name       | Phase | Contents                                        | Strategy               |
+|------------------|-------|-------------------------------------------------|------------------------|
+| `mp-offline-v1`  | 2     | `/offline` only                                 | Precache on install    |
+| `mp-static-v1`   | 3     | `/_next/static/*`, `/icons/icon-*.png`, favicons, OG/twitter images | Stale-while-revalidate, LRU 60 entries |
+
+**On `activate`** the SW deletes any cache not in the current allow-list.
+That's how old versions get pruned when we bump `SW_VERSION`.
+
+## What the SW is allowed to cache
+
+- Content-addressed build output: `/_next/static/*` (includes `next/font`
+  `.woff2`)
+- Manifest icons: `/icons/icon-*.png`
+- Brand files: `/favicon.svg`, `/favicon.ico`, `/opengraph-image`,
+  `/twitter-image`
+- The precached `/offline` shell
+
+Everything else is pass-through — the SW does not call `respondWith` for it.
+
+## What the SW must NEVER cache
+
+These prefixes are on an explicit denylist checked before the allow-list:
+
+- `/api/*` — all server actions, REST endpoints, webhooks
+- `/admin/*` — admin panel
+- `/vendor/*` — vendor portal
+- `/checkout/*` — buy flow
+- `/auth/*` — NextAuth routes
+
+Navigations to these prefixes also bypass the offline fallback. If the user
+is offline on an auth or admin screen, they see the browser's native error,
+not the `/offline` shell — that would be more confusing than helpful.
+
+## Bumping the SW version
+
+1. Edit `SW_VERSION` in `public/sw.js` (e.g. `mp-sw-v3` → `mp-sw-v4`).
+2. If you add a new cache, add its name to the `allowed` Set in
+   `activate` so it survives the prune.
+3. If you remove a cache, leave the name out of `allowed` so it gets
+   purged for all existing users on next activation.
+4. Deploy. The new SW installs in the background, waits for old tabs to
+   close, then takes over (we call `skipWaiting` + `clients.claim` so
+   activation is immediate on first load).
+
+## Debugging a stuck SW on a real device
+
+1. Chrome DevTools › Application › Service Workers → "Unregister"
+2. Application › Storage → "Clear site data" (checks all boxes)
+3. Hard reload
+
+On iOS Safari:
+
+1. Settings › Safari › Advanced › Website Data → find the site → Delete
+2. If installed as a PWA, long-press the home screen icon → Delete
+
+## Install prompts
+
+| Platform              | Mechanism                                        |
+|-----------------------|--------------------------------------------------|
+| Chrome desktop        | `<InstallButton />` via `beforeinstallprompt`    |
+| Chrome/Edge Android   | `<InstallButton />` via `beforeinstallprompt`    |
+| Safari iOS            | `<IosInstallHint />` points to Share → Add to Home Screen |
+| Safari macOS          | Native "Install" in the share sheet (no UI needed) |
+
+`InstallButton` is rendered in the public `Header`, hidden on `/admin`,
+`/vendor`, `/checkout`. `IosInstallHint` is rendered in
+`src/app/(public)/layout.tsx`, i.e. only on public pages — never during a
+buy flow.
+
+## Validation playbook (manual)
+
+Run this after any change to the PWA surface.
+
+### Chrome desktop
+- [ ] `npm run build && npm start`
+- [ ] DevTools › Application › Manifest: zero errors, 3 icons visible
+- [ ] DevTools › Application › Service Workers: active, scope `/`, version matches `SW_VERSION`
+- [ ] DevTools › Application › Cache Storage: only current caches listed, contents match the allow-list
+- [ ] Lighthouse › PWA audit › "Installable": ✅
+- [ ] Lighthouse › Performance on repeat visit: ≥ first-visit score
+- [ ] Install via URL bar icon → app launches in its own window in `standalone` mode
+
+### Chrome Android (real device, not emulator)
+- [ ] "Add to Home Screen" offered in the browser menu
+- [ ] Installed app launches in `standalone`
+- [ ] Login via NextAuth works (cookies persist across launches)
+- [ ] Checkout completes (mock + real Stripe)
+- [ ] Offline mode: top-level navigations fall back to `/offline`, `/admin` and `/vendor` surface the native error
+- [ ] `<InstallButton />` disappears after install; `<IosInstallHint />` never appears
+
+### Safari iOS (real device)
+- [ ] Visit the public site → `<IosInstallHint />` appears after 3s
+- [ ] Dismiss → doesn't reappear for 14 days (check `mp.pwa.iosHint.dismissedAt` in localStorage)
+- [ ] Share → Add to Home Screen → icon uses `siteAppearance.themeColor` background
+- [ ] Launched from home screen: status bar matches `appleWebApp.statusBarStyle`
+- [ ] Login via NextAuth works in the standalone window
+- [ ] Checkout completes
+
+### Regression checks
+- [ ] `/api/*` requests never show `(ServiceWorker)` in the Network tab
+- [ ] `/admin`, `/vendor`, `/checkout`, `/auth` navigations never show `(ServiceWorker)`
+- [ ] Product prices and stock update on every load (no stale HTML served from cache)
+- [ ] Hard refresh after editing a non-hashed public asset picks up the change within one navigation (SWR)
+
+## Out of scope (for now)
+
+- Push notifications (would need VAPID keys + backend; deferred)
+- App shortcuts in the manifest (nice-to-have)
+- Web Share Target API (nice-to-have)
+- Background sync for pending cart actions (needs careful thought around auth)
+
+Open an issue labeled `pwa` if you want to pick any of these up.

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,5 +1,6 @@
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import IosInstallHint from '@/components/pwa/IosInstallHint'
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -7,6 +8,7 @@ export default async function PublicLayout({ children }: { children: React.React
       <Header />
       <main className="flex-1">{children}</main>
       <Footer />
+      <IosInstallHint />
     </>
   )
 }

--- a/src/components/pwa/IosInstallHint.tsx
+++ b/src/components/pwa/IosInstallHint.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+
+const DISMISS_KEY = 'mp.pwa.iosHint.dismissedAt'
+const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+const REVEAL_DELAY_MS = 3000
+
+function isIosSafari(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const ua = navigator.userAgent
+  const isIos = /iphone|ipad|ipod/i.test(ua)
+  // Android Chrome on iPad identifies as iPad too — check Safari presence.
+  const isSafariFamily = /safari/i.test(ua) && !/crios|fxios|edgios|opios/i.test(ua)
+  return isIos && isSafariFamily
+}
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.matchMedia('(display-mode: standalone)').matches) return true
+  const iosNav = navigator as Navigator & { standalone?: boolean }
+  return iosNav.standalone === true
+}
+
+function recentlyDismissed(): boolean {
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY)
+    if (!raw) return false
+    const ts = Number.parseInt(raw, 10)
+    if (!Number.isFinite(ts)) return false
+    return Date.now() - ts < DISMISS_TTL_MS
+  } catch {
+    return false
+  }
+}
+
+/**
+ * iOS Safari doesn't fire `beforeinstallprompt`, so the regular
+ * `<InstallButton />` never appears on iPhones. Instead we show a small
+ * dismissible banner pointing the user at the native Share → "Add to Home
+ * Screen" flow. Surfaces only on public/buyer routes; the parent decides
+ * when to mount this component.
+ */
+export default function IosInstallHint() {
+  const t = useT()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!isIosSafari()) return
+    if (isStandalone()) return
+    if (recentlyDismissed()) return
+    const id = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS)
+    return () => window.clearTimeout(id)
+  }, [])
+
+  if (!visible) return null
+
+  const onDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()))
+    } catch {
+      // ignore — private mode
+    }
+    setVisible(false)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label={t('pwa.ios.hint.title')}
+      className="fixed inset-x-3 bottom-3 z-50 mx-auto max-w-md rounded-2xl border border-emerald-200/70 bg-white/95 p-3 shadow-xl backdrop-blur-sm dark:border-emerald-500/30 dark:bg-neutral-900/95"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          aria-hidden
+          className="mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-xl bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300"
+        >
+          <IosShareGlyph />
+        </div>
+        <div className="flex-1 text-sm">
+          <p className="font-semibold text-[var(--foreground)]">
+            {t('pwa.ios.hint.title')}
+          </p>
+          <p className="mt-0.5 text-[var(--foreground-soft)]">
+            {t('pwa.ios.hint.body')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={t('pwa.ios.hint.dismiss')}
+          className="flex-none rounded-lg p-1 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function IosShareGlyph() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M12 3v12" />
+      <path d="M8 7l4-4 4 4" />
+      <path d="M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" />
+    </svg>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1164,6 +1164,9 @@ const en: Record<TranslationKeys, string> = {
 
   'pwa.install.cta': 'Install app',
   'pwa.install.tooltip': 'Launch faster from your home screen',
+  'pwa.ios.hint.title': 'Install the app on your iPhone',
+  'pwa.ios.hint.body': 'Tap the Share button and choose “Add to Home Screen”.',
+  'pwa.ios.hint.dismiss': 'Dismiss',
 }
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1162,6 +1162,9 @@ const es = {
 
   'pwa.install.cta': 'Instalar app',
   'pwa.install.tooltip': 'Accede más rápido desde tu pantalla de inicio',
+  'pwa.ios.hint.title': 'Instala la app en tu iPhone',
+  'pwa.ios.hint.body': 'Pulsa el botón Compartir y elige “Añadir a pantalla de inicio”.',
+  'pwa.ios.hint.dismiss': 'Cerrar aviso',
 } as const satisfies Record<string, string>
 
 export default es


### PR DESCRIPTION
Closes #429

Replaces #436 (stacking base deleted). Same contents.

## Summary
- \`<IosInstallHint />\` banner shown only on iPhone/iPad Safari when not already in \`standalone\` and not dismissed in the last 14 days
- 3s reveal delay so it never competes with first paint
- Excludes other iOS browsers (\`crios\`/\`fxios\`/\`edgios\`/\`opios\`) — they can't add to home screen the same way
- Mounted in \`src/app/(public)/layout.tsx\` only (never on checkout or operator surfaces)
- i18n: \`pwa.ios.hint.{title,body,dismiss}\` in es/en
- \`docs/pwa.md\` with architecture, cache allow-list + denylist, SW versioning rules, and full cross-device validation playbook
- \`AGENTS.md\` gains a pointer to \`docs/pwa.md\` so future changes to \`public/sw.js\` or \`src/app/manifest.ts\` re-read the rules

## Test plan
- [ ] iPhone Safari: hint appears after 3s on public pages
- [ ] Dismiss → hidden 14 days
- [ ] Standalone launch: no hint
- [ ] iPhone Chrome (\`CriOS\`): no hint
- [ ] Desktop/Android Chrome: no hint (has its own \`<InstallButton />\`)
- [ ] Playbook in \`docs/pwa.md\` readable end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)