### PR TITLE
feat(webhooks): add WebhookDelivery model + migration

### DIFF
--- a/prisma/migrations/20260415180000_webhook_delivery/migration.sql
+++ b/prisma/migrations/20260415180000_webhook_delivery/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL DEFAULT 'stripe',
+    "eventId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "providerRef" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'received',
+    "errorMessage" TEXT,
+    "payloadHash" TEXT,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "processedAt" TIMESTAMP(3),
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookDelivery_provider_eventId_key" ON "WebhookDelivery"("provider", "eventId");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_provider_eventType_receivedAt_idx" ON "WebhookDelivery"("provider", "eventType", "receivedAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_status_receivedAt_idx" ON "WebhookDelivery"("status", "receivedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -638,6 +638,35 @@ model OrderEvent {
   @@index([orderId])
 }
 
+/// First-class delivery bookkeeping for webhook events. Lets the
+/// stripe webhook handler dedupe by `(provider, eventId)` via a real
+/// unique constraint instead of a JSON-path lookup against
+/// `OrderEvent.payload`. Created (insert + unique violation = duplicate)
+/// in the route handler before any business state mutation; updated to
+/// `processed` / `failed` after the handler returns. Replaces the
+/// dedupe responsibility of `OrderEvent` while leaving its
+/// business-event responsibility intact.
+///
+/// `payloadHash` is sha256(raw body), useful for forensic comparisons
+/// without storing the full payload (which can carry PII or card
+/// metadata depending on the provider).
+model WebhookDelivery {
+  id           String    @id @default(cuid())
+  provider     String    @default("stripe")
+  eventId      String
+  eventType    String
+  providerRef  String?
+  status       String    @default("received")
+  errorMessage String?
+  payloadHash  String?
+  receivedAt   DateTime  @default(now())
+  processedAt  DateTime?
+
+  @@unique([provider, eventId])
+  @@index([provider, eventType, receivedAt])
+  @@index([status, receivedAt])
+}
+
 /// Dead-letter queue for webhook events that could not be reconciled to an
 /// existing order/payment (e.g. Stripe sent a payment_intent.succeeded for a
 /// providerRef we have no Payment row for). An operator can query the

--- a/test/integration/webhook-delivery-model.test.ts
+++ b/test/integration/webhook-delivery-model.test.ts
@@ -1,0 +1,85 @@
+import test, { beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { db } from '@/lib/db'
+import { resetIntegrationDatabase } from './helpers'
+
+/**
+ * Issue #407: WebhookDelivery model.
+ *
+ * This PR only ADDS the model + migration — the route handler swap to
+ * use it for dedupe is sub-issue #408 in a separate PR. The tests here
+ * just pin the schema contract:
+ *
+ * 1. The unique constraint on (provider, eventId) actually fires.
+ * 2. The default values land as expected.
+ * 3. Independent eventIds across providers do not collide.
+ *
+ * Once #408 swaps the route, additional tests will exercise the
+ * insert-then-update lifecycle.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+test('WebhookDelivery enforces UNIQUE (provider, eventId) — duplicate insert fails with P2002', async () => {
+  await db.webhookDelivery.create({
+    data: {
+      provider: 'stripe',
+      eventId: 'evt_dedupe_1',
+      eventType: 'payment_intent.succeeded',
+    },
+  })
+
+  await assert.rejects(
+    () =>
+      db.webhookDelivery.create({
+        data: {
+          provider: 'stripe',
+          eventId: 'evt_dedupe_1',
+          eventType: 'payment_intent.succeeded',
+        },
+      }),
+    (err: unknown) => {
+      // Prisma surfaces this as P2002 (unique constraint violation).
+      const message = err instanceof Error ? err.message : String(err)
+      return /P2002|Unique constraint/i.test(message)
+    },
+  )
+})
+
+test('WebhookDelivery sets defaults: status=received, receivedAt now, processedAt null', async () => {
+  const row = await db.webhookDelivery.create({
+    data: {
+      provider: 'stripe',
+      eventId: 'evt_defaults_1',
+      eventType: 'invoice.paid',
+    },
+  })
+  assert.equal(row.status, 'received')
+  assert.equal(row.processedAt, null)
+  assert.ok(row.receivedAt instanceof Date)
+  // received within the last 60s — generous to keep this test stable
+  // on slow CI.
+  assert.ok(Date.now() - row.receivedAt.getTime() < 60_000)
+})
+
+test('the same eventId on a different provider does NOT collide', async () => {
+  await db.webhookDelivery.create({
+    data: {
+      provider: 'stripe',
+      eventId: 'evt_shared_id',
+      eventType: 'payment_intent.succeeded',
+    },
+  })
+  // sendcloud might one day reuse the same id space; the unique is
+  // intentionally scoped per provider so this must succeed.
+  const sendcloud = await db.webhookDelivery.create({
+    data: {
+      provider: 'sendcloud',
+      eventId: 'evt_shared_id',
+      eventType: 'parcel_status_changed',
+    },
+  })
+  assert.equal(sendcloud.provider, 'sendcloud')
+})


### PR DESCRIPTION
## Summary

Closes #407. Adds a first-class `WebhookDelivery` model + migration so the stripe webhook handler can dedupe by `(provider, eventId)` via a real `UNIQUE` constraint instead of a JSON-path lookup against `OrderEvent.payload`. **Schema-only** — the route swap is sub-issue #408 in a separate PR so this can land independently.

## Why split

- `#407` (this PR): schema + migration + contract tests. Pure additive. Zero behaviour change at runtime.
- `#408` (next): swap [src/app/api/webhooks/stripe/route.ts](src/app/api/webhooks/stripe/route.ts) to use `WebhookDelivery` for dedupe instead of `OrderEvent.payload.eventId`.
- `#409`: cleanup tech-debt — document `OrderEvent` (business events) vs `WebhookDelivery` (delivery bookkeeping) separation.

Splitting keeps the diff small and lets ops review the migration in isolation before touching the live webhook code.

## Schema

```prisma
model WebhookDelivery {
  id           String    @id @default(cuid())
  provider     String    @default("stripe")
  eventId      String
  eventType    String
  providerRef  String?
  status       String    @default("received") // received|processed|failed|ignored
  errorMessage String?
  payloadHash  String?  // sha256(raw body), forensic only
  receivedAt   DateTime  @default(now())
  processedAt  DateTime?

  @@unique([provider, eventId])
  @@index([provider, eventType, receivedAt])
  @@index([status, receivedAt])
}
```

`payloadHash` is reserved for forensic comparisons without storing the full payload (Stripe payloads can carry card metadata). Not populated by this PR — `#408` will fill it.

## Migration

[prisma/migrations/20260415180000_webhook_delivery/migration.sql](prisma/migrations/20260415180000_webhook_delivery/migration.sql) — additive `CREATE TABLE` only, no backfill, no FK to existing tables. Safe to apply on a busy DB.

## What this PR does NOT do

- It does **not** modify the route handler. Dedupe still uses `OrderEvent.payload.eventId` until #408 lands.
- It does **not** touch `WebhookDeadLetter` — that's a different concern (events that arrived but couldn't be reconciled to a Payment row) and stays in place.
- It does **not** change subscription/invoice ordering — that's #417's watermark approach, which is complementary to this dedupe table.

## Tests

[test/integration/webhook-delivery-model.test.ts](test/integration/webhook-delivery-model.test.ts) — 3 tests, all green:

- `UNIQUE (provider, eventId)` fires on duplicate insert (P2002)
- defaults: `status='received'`, `processedAt=null`, `receivedAt` populated by the DB
- same `eventId` on a different `provider` does **not** collide

## Test plan

- [x] `npx prisma migrate deploy` — applies cleanly to a fresh DB
- [x] `npx tsc --noEmit -p tsconfig.app.json` — passes
- [x] `npx tsc --noEmit -p tsconfig.test.json` — passes
- [x] `npx tsx --test test/integration/webhook-delivery-model.test.ts` — 3/3 pass
- [ ] Full CI on PR

## Risk / rollback

Trivial. Additive schema only — nothing reads or writes the new table at runtime yet. Rollback: revert the PR; the table can stay empty (no FKs) or be dropped manually.

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)