### PR TITLE
feat(pwa): manifest shortcuts + screenshots + stable id (#444)

### DIFF
--- a/src/app/icons/shortcut-cart.png/route.tsx
+++ b/src/app/icons/shortcut-cart.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '🛒')
+}

--- a/src/app/icons/shortcut-orders.png/route.tsx
+++ b/src/app/icons/shortcut-orders.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '📦')
+}

--- a/src/app/icons/shortcut-search.png/route.tsx
+++ b/src/app/icons/shortcut-search.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '🔍')
+}

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -4,6 +4,7 @@ import { siteAppearance } from '@/lib/brand'
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
+    id: '/',
     name: SITE_NAME,
     short_name: 'Mercado',
     description: SITE_DESCRIPTION,
@@ -34,6 +35,45 @@ export default function manifest(): MetadataRoute.Manifest {
         sizes: '512x512',
         type: 'image/png',
         purpose: 'maskable',
+      },
+    ],
+    shortcuts: [
+      {
+        name: 'Buscar productos',
+        short_name: 'Buscar',
+        description: 'Explora el catálogo del marketplace',
+        url: '/buscar?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-search.png', sizes: '96x96', type: 'image/png' }],
+      },
+      {
+        name: 'Mi carrito',
+        short_name: 'Carrito',
+        description: 'Revisa los productos en tu carrito',
+        url: '/carrito?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-cart.png', sizes: '96x96', type: 'image/png' }],
+      },
+      {
+        name: 'Mis pedidos',
+        short_name: 'Pedidos',
+        description: 'Consulta el estado de tus pedidos',
+        url: '/cuenta/pedidos?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-orders.png', sizes: '96x96', type: 'image/png' }],
+      },
+    ],
+    screenshots: [
+      {
+        src: '/screenshots/home-narrow.png',
+        sizes: '1080x1920',
+        type: 'image/png',
+        form_factor: 'narrow',
+        label: 'Catálogo en móvil',
+      },
+      {
+        src: '/screenshots/home-wide.png',
+        sizes: '1920x1080',
+        type: 'image/png',
+        form_factor: 'wide',
+        label: 'Catálogo en escritorio',
       },
     ],
   }

--- a/src/app/screenshots/home-narrow.png/route.tsx
+++ b/src/app/screenshots/home-narrow.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandScreenshot } from '@/lib/pwa/brand-screenshot'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandScreenshot('narrow')
+}

--- a/src/app/screenshots/home-wide.png/route.tsx
+++ b/src/app/screenshots/home-wide.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandScreenshot } from '@/lib/pwa/brand-screenshot'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandScreenshot('wide')
+}

--- a/src/lib/pwa/brand-icon.tsx
+++ b/src/lib/pwa/brand-icon.tsx
@@ -4,9 +4,14 @@ type IconVariant = 'any' | 'maskable'
 
 /**
  * Renders the PWA brand mark at a given pixel size. `maskable` variants get a
- * ~18% safe-area padding so the icon survives OS shape masking.
+ * ~18% safe-area padding so the icon survives OS shape masking. `glyph` can
+ * override the default brand emoji for shortcut icons (🔍 / 🛒 / 📦).
  */
-export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
+export function renderBrandIcon(
+  size: number,
+  variant: IconVariant = 'any',
+  glyph = '🌿'
+) {
   const padding = variant === 'maskable' ? size * 0.18 : size * 0.1
   const inner = size - padding * 2
   const radius = variant === 'maskable' ? 0 : size * 0.22
@@ -38,7 +43,7 @@ export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
             lineHeight: 1,
           }}
         >
-          🌿
+          {glyph}
         </div>
       </div>
     ),

--- a/src/lib/pwa/brand-screenshot.tsx
+++ b/src/lib/pwa/brand-screenshot.tsx
@@ -1,0 +1,112 @@
+import { ImageResponse } from 'next/og'
+import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants'
+
+type Orientation = 'narrow' | 'wide'
+
+const DIMENSIONS: Record<Orientation, { width: number; height: number }> = {
+  narrow: { width: 1080, height: 1920 },
+  wide: { width: 1920, height: 1080 },
+}
+
+/**
+ * Renders a deterministic marketing-style screenshot of the app for the
+ * `screenshots` array in `manifest.ts`. Keeps contents synthetic so the
+ * output doesn't depend on seed data or database state.
+ */
+export function renderBrandScreenshot(orientation: Orientation) {
+  const { width, height } = DIMENSIONS[orientation]
+  const isWide = orientation === 'wide'
+
+  const cards = [
+    { emoji: '🥬', label: 'Verduras' },
+    { emoji: '🍎', label: 'Frutas' },
+    { emoji: '🧀', label: 'Lácteos' },
+    { emoji: '🍯', label: 'Miel' },
+  ]
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'linear-gradient(160deg, #052e16 0%, #065f46 50%, #0f766e 100%)',
+          color: '#f8fafc',
+          fontFamily: 'system-ui, sans-serif',
+          padding: isWide ? 96 : 72,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              borderRadius: 20,
+              background: 'rgba(255,255,255,0.16)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 52,
+            }}
+          >
+            🌿
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ fontSize: 44, fontWeight: 800, lineHeight: 1.05 }}>{SITE_NAME}</div>
+            <div style={{ fontSize: 24, opacity: 0.85 }}>Compra directo al productor</div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: isWide ? 72 : 96,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            maxWidth: isWide ? 1200 : 900,
+          }}
+        >
+          <div style={{ fontSize: isWide ? 96 : 84, fontWeight: 900, lineHeight: 1.0 }}>
+            Alimentos locales, productores verificados.
+          </div>
+          <div style={{ fontSize: isWide ? 36 : 34, lineHeight: 1.3, color: 'rgba(236,253,245,0.88)' }}>
+            {SITE_DESCRIPTION}
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 'auto',
+            display: 'flex',
+            gap: isWide ? 32 : 24,
+            flexWrap: 'wrap',
+          }}
+        >
+          {cards.map((c) => (
+            <div
+              key={c.label}
+              style={{
+                flex: '1 1 0',
+                minWidth: isWide ? 260 : 200,
+                background: 'rgba(255,255,255,0.08)',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: 28,
+                padding: isWide ? 36 : 28,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 12,
+              }}
+            >
+              <div style={{ fontSize: isWide ? 72 : 64 }}>{c.emoji}</div>
+              <div style={{ fontSize: isWide ? 32 : 28, fontWeight: 700 }}>{c.label}</div>
+              <div style={{ fontSize: isWide ? 22 : 20, opacity: 0.78 }}>Del campo · Km 0</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { width, height }
+  )
+}


### PR DESCRIPTION
Closes #444

## Summary
- Three \`shortcuts\` entries for Buscar / Carrito / Mis pedidos, each with a dedicated 96x96 icon rendered via \`ImageResponse\` (emoji-per-shortcut)
- Two \`screenshots\` entries rendered deterministically: \`home-narrow.png\` (1080x1920) and \`home-wide.png\` (1920x1080) — activates Chrome's rich install card on Android
- \`id: '/'\` so \`start_url='/?source=pwa'\` and future variants share a single PWA identity
- Shortcut URLs add \`?source=pwa-shortcut\` so analytics can distinguish quick-action launches from the generic \`source=pwa\` start_url
- New helper \`renderBrandScreenshot()\` mirrors \`renderBrandIcon()\` and lives under \`src/lib/pwa/\`

## Why deterministic ImageResponse screenshots
Real app screenshots would pin us to the current seed state and break the moment the homepage UI moves. A synthetic marketing composition stays valid indefinitely and costs zero binaries.

## Test plan
- [ ] \`npm run typecheck\` + \`build\` green ✅ (verified locally)
- [ ] DevTools › Application › Manifest: shortcuts + screenshots listed with no errors
- [ ] \`GET /icons/shortcut-search.png\`, \`shortcut-cart.png\`, \`shortcut-orders.png\` return 200 + PNG
- [ ] \`GET /screenshots/home-narrow.png\`, \`home-wide.png\` return 200 + PNG
- [ ] Chrome Android install prompt shows the rich card with the narrow screenshot
- [ ] Long-press on installed icon (Android) shows the 3 shortcuts
- [ ] Shortcut launches land on \`/buscar\`, \`/carrito\`, \`/cuenta/pedidos\` with \`?source=pwa-shortcut\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)