### PR TITLE
feat(pwa): update-available toast with skip-waiting handshake (#445)

### DIFF
--- a/src/app/icons/shortcut-cart.png/route.tsx
+++ b/src/app/icons/shortcut-cart.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '🛒')
+}

--- a/src/app/icons/shortcut-orders.png/route.tsx
+++ b/src/app/icons/shortcut-orders.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '📦')
+}

--- a/src/app/icons/shortcut-search.png/route.tsx
+++ b/src/app/icons/shortcut-search.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandIcon } from '@/lib/pwa/brand-icon'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandIcon(96, 'any', '🔍')
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { SessionProvider } from '@/components/SessionProvider'
 import { LanguageProvider } from '@/i18n'
 import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
+import UpdateToast from '@/components/pwa/UpdateToast'
 
 const geist = Geist({
   variable: '--font-geist-sans',
@@ -87,6 +88,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <AnalyticsProvider />
               </Suspense>
               <PwaRegister />
+              <UpdateToast />
               {children}
             </LanguageProvider>
           </ThemeProvider>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -4,6 +4,7 @@ import { siteAppearance } from '@/lib/brand'
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
+    id: '/',
     name: SITE_NAME,
     short_name: 'Mercado',
     description: SITE_DESCRIPTION,
@@ -34,6 +35,45 @@ export default function manifest(): MetadataRoute.Manifest {
         sizes: '512x512',
         type: 'image/png',
         purpose: 'maskable',
+      },
+    ],
+    shortcuts: [
+      {
+        name: 'Buscar productos',
+        short_name: 'Buscar',
+        description: 'Explora el catálogo del marketplace',
+        url: '/buscar?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-search.png', sizes: '96x96', type: 'image/png' }],
+      },
+      {
+        name: 'Mi carrito',
+        short_name: 'Carrito',
+        description: 'Revisa los productos en tu carrito',
+        url: '/carrito?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-cart.png', sizes: '96x96', type: 'image/png' }],
+      },
+      {
+        name: 'Mis pedidos',
+        short_name: 'Pedidos',
+        description: 'Consulta el estado de tus pedidos',
+        url: '/cuenta/pedidos?source=pwa-shortcut',
+        icons: [{ src: '/icons/shortcut-orders.png', sizes: '96x96', type: 'image/png' }],
+      },
+    ],
+    screenshots: [
+      {
+        src: '/screenshots/home-narrow.png',
+        sizes: '1080x1920',
+        type: 'image/png',
+        form_factor: 'narrow',
+        label: 'Catálogo en móvil',
+      },
+      {
+        src: '/screenshots/home-wide.png',
+        sizes: '1920x1080',
+        type: 'image/png',
+        form_factor: 'wide',
+        label: 'Catálogo en escritorio',
       },
     ],
   }

--- a/src/app/screenshots/home-narrow.png/route.tsx
+++ b/src/app/screenshots/home-narrow.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandScreenshot } from '@/lib/pwa/brand-screenshot'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandScreenshot('narrow')
+}

--- a/src/app/screenshots/home-wide.png/route.tsx
+++ b/src/app/screenshots/home-wide.png/route.tsx
@@ -1,0 +1,8 @@
+import { renderBrandScreenshot } from '@/lib/pwa/brand-screenshot'
+
+export const dynamic = 'force-static'
+export const revalidate = false
+
+export function GET() {
+  return renderBrandScreenshot('wide')
+}

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -3,8 +3,9 @@
 import { useEffect } from 'react'
 
 /**
- * Registers the service worker and captures the `beforeinstallprompt` event
- * so UI elsewhere can trigger the install prompt later.
+ * Registers the service worker, captures the `beforeinstallprompt` event
+ * so UI elsewhere can trigger the install prompt later, and wires the
+ * update-available flow that powers `<UpdateToast />`.
  *
  * Keep this component tiny and side-effect-only: it must not render any DOM
  * and must never break SSR — all browser APIs are touched inside useEffect.
@@ -15,9 +16,45 @@ export default function PwaRegister() {
     if (process.env.NODE_ENV !== 'production') return
     if (!('serviceWorker' in navigator)) return
 
+    // Track whether a controllerchange reload has already fired so we
+    // never reload twice in a row from a single SKIP_WAITING round-trip.
+    let reloadedForUpdate = false
+
+    const notifyUpdate = (registration: ServiceWorkerRegistration) => {
+      ;(
+        window as unknown as { __pwaWaitingRegistration?: ServiceWorkerRegistration }
+      ).__pwaWaitingRegistration = registration
+      window.dispatchEvent(new CustomEvent('pwa:updateready'))
+    }
+
+    const watchRegistration = (registration: ServiceWorkerRegistration) => {
+      // If a new SW is already waiting by the time we register, surface it.
+      if (registration.waiting && navigator.serviceWorker.controller) {
+        notifyUpdate(registration)
+      }
+
+      registration.addEventListener('updatefound', () => {
+        const installing = registration.installing
+        if (!installing) return
+        installing.addEventListener('statechange', () => {
+          if (
+            installing.state === 'installed' &&
+            navigator.serviceWorker.controller
+          ) {
+            // An existing controller means this is an upgrade, not a
+            // first install — time to offer the update to the user.
+            notifyUpdate(registration)
+          }
+        })
+      })
+    }
+
     const register = () => {
       navigator.serviceWorker
         .register('/sw.js', { scope: '/' })
+        .then((registration) => {
+          watchRegistration(registration)
+        })
         .catch((err) => {
           // Swallow — SW registration failure must never break the app.
           // Lighthouse will still flag it, which is what we want.
@@ -29,6 +66,13 @@ export default function PwaRegister() {
     // requests on the first paint.
     if (document.readyState === 'complete') register()
     else window.addEventListener('load', register, { once: true })
+
+    const onControllerChange = () => {
+      if (reloadedForUpdate) return
+      reloadedForUpdate = true
+      window.location.reload()
+    }
+    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange)
 
     const onBeforeInstallPrompt = (e: Event) => {
       // Prevent Chrome's mini-infobar so we can decide when to prompt.
@@ -51,6 +95,10 @@ export default function PwaRegister() {
     return () => {
       window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
       window.removeEventListener('appinstalled', onAppInstalled)
+      navigator.serviceWorker.removeEventListener(
+        'controllerchange',
+        onControllerChange
+      )
     }
   }, [])
 

--- a/src/components/pwa/UpdateToast.tsx
+++ b/src/components/pwa/UpdateToast.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+
+/**
+ * Listens for the `pwa:updateready` event that `<PwaRegister />` emits when
+ * a new service worker reaches `installed` with a controlling worker still
+ * active. Offers the user an "Update now" action that posts SKIP_WAITING to
+ * the waiting worker; the register's `controllerchange` handler then
+ * triggers a single reload.
+ */
+export default function UpdateToast() {
+  const t = useT()
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(
+    null
+  )
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const handler = () => {
+      const reg =
+        (
+          window as unknown as {
+            __pwaWaitingRegistration?: ServiceWorkerRegistration
+          }
+        ).__pwaWaitingRegistration ?? null
+      if (!reg) return
+      setRegistration(reg)
+      setDismissed(false)
+    }
+
+    window.addEventListener('pwa:updateready', handler)
+    return () => window.removeEventListener('pwa:updateready', handler)
+  }, [])
+
+  if (!registration || dismissed) return null
+
+  const onUpdate = () => {
+    const waiting = registration.waiting
+    if (!waiting) {
+      // No waiting worker — nothing to do. Hide the toast.
+      setDismissed(true)
+      return
+    }
+    waiting.postMessage('SKIP_WAITING')
+    // The `controllerchange` listener in PwaRegister will trigger the reload
+    // once the new worker takes over. We just hide the toast meanwhile.
+    setDismissed(true)
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-[60] mx-auto max-w-sm rounded-2xl border border-emerald-200/70 bg-white/95 p-3 shadow-xl backdrop-blur-sm dark:border-emerald-500/30 dark:bg-neutral-900/95"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          aria-hidden
+          className="mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-xl bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300"
+        >
+          <ArrowPathIcon className="h-5 w-5" />
+        </div>
+        <div className="flex-1 text-sm">
+          <p className="font-semibold text-[var(--foreground)]">
+            {t('pwa.update.title')}
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onUpdate}
+              className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+            >
+              {t('pwa.update.cta')}
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label={t('pwa.update.dismiss')}
+          className="flex-none rounded-lg p-1 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1167,6 +1167,9 @@ const en: Record<TranslationKeys, string> = {
   'pwa.ios.hint.title': 'Install the app on your iPhone',
   'pwa.ios.hint.body': 'Tap the Share button and choose “Add to Home Screen”.',
   'pwa.ios.hint.dismiss': 'Dismiss',
+  'pwa.update.title': 'New version available',
+  'pwa.update.cta': 'Update now',
+  'pwa.update.dismiss': 'Close',
 }
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1165,6 +1165,9 @@ const es = {
   'pwa.ios.hint.title': 'Instala la app en tu iPhone',
   'pwa.ios.hint.body': 'Pulsa el botón Compartir y elige “Añadir a pantalla de inicio”.',
   'pwa.ios.hint.dismiss': 'Cerrar aviso',
+  'pwa.update.title': 'Nueva versión disponible',
+  'pwa.update.cta': 'Actualizar ahora',
+  'pwa.update.dismiss': 'Cerrar',
 } as const satisfies Record<string, string>
 
 export default es

--- a/src/lib/pwa/brand-icon.tsx
+++ b/src/lib/pwa/brand-icon.tsx
@@ -4,9 +4,14 @@ type IconVariant = 'any' | 'maskable'
 
 /**
  * Renders the PWA brand mark at a given pixel size. `maskable` variants get a
- * ~18% safe-area padding so the icon survives OS shape masking.
+ * ~18% safe-area padding so the icon survives OS shape masking. `glyph` can
+ * override the default brand emoji for shortcut icons (🔍 / 🛒 / 📦).
  */
-export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
+export function renderBrandIcon(
+  size: number,
+  variant: IconVariant = 'any',
+  glyph = '🌿'
+) {
   const padding = variant === 'maskable' ? size * 0.18 : size * 0.1
   const inner = size - padding * 2
   const radius = variant === 'maskable' ? 0 : size * 0.22
@@ -38,7 +43,7 @@ export function renderBrandIcon(size: number, variant: IconVariant = 'any') {
             lineHeight: 1,
           }}
         >
-          🌿
+          {glyph}
         </div>
       </div>
     ),

--- a/src/lib/pwa/brand-screenshot.tsx
+++ b/src/lib/pwa/brand-screenshot.tsx
@@ -1,0 +1,112 @@
+import { ImageResponse } from 'next/og'
+import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants'
+
+type Orientation = 'narrow' | 'wide'
+
+const DIMENSIONS: Record<Orientation, { width: number; height: number }> = {
+  narrow: { width: 1080, height: 1920 },
+  wide: { width: 1920, height: 1080 },
+}
+
+/**
+ * Renders a deterministic marketing-style screenshot of the app for the
+ * `screenshots` array in `manifest.ts`. Keeps contents synthetic so the
+ * output doesn't depend on seed data or database state.
+ */
+export function renderBrandScreenshot(orientation: Orientation) {
+  const { width, height } = DIMENSIONS[orientation]
+  const isWide = orientation === 'wide'
+
+  const cards = [
+    { emoji: '🥬', label: 'Verduras' },
+    { emoji: '🍎', label: 'Frutas' },
+    { emoji: '🧀', label: 'Lácteos' },
+    { emoji: '🍯', label: 'Miel' },
+  ]
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          background: 'linear-gradient(160deg, #052e16 0%, #065f46 50%, #0f766e 100%)',
+          color: '#f8fafc',
+          fontFamily: 'system-ui, sans-serif',
+          padding: isWide ? 96 : 72,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              borderRadius: 20,
+              background: 'rgba(255,255,255,0.16)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 52,
+            }}
+          >
+            🌿
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ fontSize: 44, fontWeight: 800, lineHeight: 1.05 }}>{SITE_NAME}</div>
+            <div style={{ fontSize: 24, opacity: 0.85 }}>Compra directo al productor</div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: isWide ? 72 : 96,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            maxWidth: isWide ? 1200 : 900,
+          }}
+        >
+          <div style={{ fontSize: isWide ? 96 : 84, fontWeight: 900, lineHeight: 1.0 }}>
+            Alimentos locales, productores verificados.
+          </div>
+          <div style={{ fontSize: isWide ? 36 : 34, lineHeight: 1.3, color: 'rgba(236,253,245,0.88)' }}>
+            {SITE_DESCRIPTION}
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 'auto',
+            display: 'flex',
+            gap: isWide ? 32 : 24,
+            flexWrap: 'wrap',
+          }}
+        >
+          {cards.map((c) => (
+            <div
+              key={c.label}
+              style={{
+                flex: '1 1 0',
+                minWidth: isWide ? 260 : 200,
+                background: 'rgba(255,255,255,0.08)',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: 28,
+                padding: isWide ? 36 : 28,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 12,
+              }}
+            >
+              <div style={{ fontSize: isWide ? 72 : 64 }}>{c.emoji}</div>
+              <div style={{ fontSize: isWide ? 32 : 28, fontWeight: 700 }}>{c.label}</div>
+              <div style={{ fontSize: isWide ? 22 : 20, opacity: 0.78 }}>Del campo · Km 0</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { width, height }
+  )
+}


### PR DESCRIPTION
Closes #445

Stacked on #450.

## Summary
- \`PwaRegister\` now watches \`registration.updatefound\` and fires \`pwa:updateready\` once the new worker reaches \`installed\` AND a controller already exists (first installs are suppressed)
- New \`<UpdateToast />\` client component subscribes to \`pwa:updateready\` and offers an "Update now" button that posts \`SKIP_WAITING\` to the waiting worker
- A single-shot \`controllerchange\` listener in \`PwaRegister\` handles the subsequent reload — we never reload twice for the same upgrade
- Toast is mounted once globally in \`src/app/layout.tsx\` (not only on public routes) so admin and vendor users see updates too
- i18n: \`pwa.update.{title,cta,dismiss}\` in es/en
- \`SKIP_WAITING\` handshake already exists in \`public/sw.js\` since #425 — this PR just wires it end-to-end

## Why suppress on first install?
When a brand-new visitor registers the SW for the first time, \`controller\` is \`null\` and the worker goes straight to \`activated\`. That's not an "update" — it's the very first install — so showing a toast there would be noise.

## Test plan
- [ ] First visit from a fresh browser: no toast
- [ ] Deploy a new \`sw.js\` (bump \`SW_VERSION\`) → existing tab shows toast within a few seconds
- [ ] Click "Update now" → single reload → new SW version visible in DevTools
- [ ] Dismiss → toast hidden until next update
- [ ] Checkout / auth / dashboards all unaffected (SW is still pass-through for protected prefixes)
- [ ] No double reloads even when clicking "Update" twice quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)