### PR TITLE
feat(pwa): install funnel analytics + standalone launch tracking (#448)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,123 @@
+name: Lighthouse PWA
+
+on:
+  pull_request:
+    paths:
+      - 'src/app/manifest.ts'
+      - 'public/sw.js'
+      - 'src/components/pwa/**'
+      - 'src/app/icons/**'
+      - 'src/app/screenshots/**'
+      - 'src/app/offline/**'
+      - 'src/app/layout.tsx'
+      - 'src/lib/pwa/**'
+      - '.lighthouserc.json'
+      - '.github/workflows/lighthouse.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATABASE_URL: postgresql://mp_user:mp_pass@localhost:5432/marketplace_test
+  DATABASE_URL_TEST: postgresql://mp_user:mp_pass@localhost:5432/marketplace_test
+  AUTH_SECRET: ci-secret-please-change
+  NEXT_PUBLIC_APP_URL: http://localhost:3000
+  PAYMENT_PROVIDER: mock
+  # Make sure PwaRegister actually registers the SW. Our client gates on
+  # NODE_ENV === 'production' to avoid fighting HMR in `next dev`.
+  NODE_ENV: production
+
+jobs:
+  lighthouse:
+    name: Lighthouse PWA audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: marketplace_test
+          POSTGRES_USER: mp_user
+          POSTGRES_PASSWORD: mp_pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U mp_user -d marketplace_test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-deps
+
+      - name: Apply migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL_TEST }}
+
+      - name: Create .env for seed script
+        run: |
+          echo "DATABASE_URL=$DATABASE_URL_TEST" > .env
+          echo "AUTH_SECRET=$AUTH_SECRET" >> .env
+          echo "NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL" >> .env
+          echo "PAYMENT_PROVIDER=$PAYMENT_PROVIDER" >> .env
+
+      - name: Seed database
+        run: npm run db:seed
+
+      - name: Build (production)
+        run: npm run build
+
+      - name: Start next (background)
+        run: |
+          nohup npx next start -p 3000 > .lighthouse-server.log 2>&1 &
+          echo $! > .lighthouse-server.pid
+
+      - name: Wait for server ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:3000/ -o /dev/null; then
+              echo "Server ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server did not become ready in 60s"
+          tail -n 100 .lighthouse-server.log || true
+          exit 1
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.14.x autorun --config=./.lighthouserc.json
+
+      - name: Stop next
+        if: always()
+        run: |
+          if [ -f .lighthouse-server.pid ]; then
+            kill "$(cat .lighthouse-server.pid)" || true
+          fi
+
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: lighthouse-report-${{ github.sha }}
+          path: .lighthouseci
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: lighthouse-server-log-${{ github.sha }}
+          path: .lighthouse-server.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,35 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/offline"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "preset": "desktop",
+        "onlyCategories": ["pwa", "performance", "best-practices", "accessibility"],
+        "skipAudits": ["uses-http2", "canonical"],
+        "chromeFlags": "--no-sandbox --headless=new"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "installable-manifest": "error",
+        "service-worker": "error",
+        "viewport": "error",
+        "content-width": "error",
+        "themed-omnibox": "error",
+        "maskable-icon": "warn",
+        "apple-touch-icon": "warn",
+        "categories:performance": ["warn", { "minScore": 0.75 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": ".lighthouseci"
+    }
+  }
+}

--- a/src/app/(buyer)/layout.tsx
+++ b/src/app/(buyer)/layout.tsx
@@ -1,12 +1,23 @@
 import { auth } from '@/lib/auth'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import AppBadgeSync from '@/components/pwa/AppBadgeSync'
+import { getPendingReviewsCount } from '@/domains/reviews/pending'
 
 export default async function BuyerLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
+
+  // Feed the installed-app badge with the number of delivered lines the
+  // buyer still has to review. Cheap: reuses the existing helper already
+  // called by the buyer dashboard, so we don't add a new N+1 query.
+  const badgeCount = session?.user?.id
+    ? await getPendingReviewsCount(session.user.id).catch(() => undefined)
+    : undefined
+
   return (
     <>
       <Header user={session?.user} />
+      <AppBadgeSync count={badgeCount} />
       <main className="flex-1">{children}</main>
       <Footer />
     </>

--- a/src/app/(vendor)/layout.tsx
+++ b/src/app/(vendor)/layout.tsx
@@ -3,6 +3,7 @@ import { VendorSidebar } from '@/components/vendor/VendorSidebar'
 import { VendorHeader } from '@/components/vendor/VendorHeader'
 import { SidebarProvider } from '@/components/layout/SidebarProvider'
 import { ImpersonationBanner } from '@/components/vendor/ImpersonationBanner'
+import AppBadgeSync from '@/components/pwa/AppBadgeSync'
 import { db } from '@/lib/db'
 import { requireVendor } from '@/lib/auth-guard'
 import { getAvailablePortals } from '@/lib/portals'
@@ -13,8 +14,20 @@ export default async function VendorLayout({ children }: { children: React.React
 
   const vendor = await db.vendor.findUnique({
     where: { userId: session.user.id },
-    select: { displayName: true, status: true, slug: true },
+    select: { id: true, displayName: true, status: true, slug: true },
   })
+
+  // Count fulfillments that still need vendor action (same 'active' filter
+  // used by `getMyFulfillments`). Feeds the installed-app icon badge so a
+  // vendor sees pending work even when the app window is in the background.
+  const pendingFulfillments = vendor
+    ? await db.vendorFulfillment.count({
+        where: {
+          vendorId: vendor.id,
+          status: { in: ['PENDING', 'CONFIRMED', 'PREPARING', 'READY'] },
+        },
+      })
+    : 0
 
   const portals = getAvailablePortals(session.user.role)
 
@@ -39,6 +52,7 @@ export default async function VendorLayout({ children }: { children: React.React
             />
           )}
           <VendorHeader user={session.user} vendor={vendor} portals={portals} />
+          <AppBadgeSync count={pendingFulfillments} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/components/pwa/AppBadgeSync.tsx
+++ b/src/components/pwa/AppBadgeSync.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useAppBadge } from '@/lib/pwa/use-app-badge'
+
+interface AppBadgeSyncProps {
+  count: number | undefined
+}
+
+/**
+ * Server-friendly wrapper that lets a server component hand a count to
+ * the client-only `useAppBadge` hook without marking the whole layout as
+ * client. Renders nothing.
+ */
+export default function AppBadgeSync({ count }: AppBadgeSyncProps) {
+  useAppBadge(count)
+  return null
+}

--- a/src/components/pwa/InstallButton.tsx
+++ b/src/components/pwa/InstallButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
 import { useT } from '@/i18n'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 /**
  * Minimum Chromium `beforeinstallprompt` event shape — not exported by
@@ -84,9 +85,13 @@ export default function InstallButton() {
 
   const onClick = async () => {
     try {
+      trackPwaEvent('pwa_install_prompted')
       await prompt.prompt()
       const { outcome } = await prompt.userChoice
-      if (outcome === 'dismissed') {
+      if (outcome === 'accepted') {
+        trackPwaEvent('pwa_install_accepted')
+      } else {
+        trackPwaEvent('pwa_install_dismissed')
         try {
           localStorage.setItem(DISMISS_KEY, String(Date.now()))
         } catch {

--- a/src/components/pwa/IosInstallHint.tsx
+++ b/src/components/pwa/IosInstallHint.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { useT } from '@/i18n'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 const DISMISS_KEY = 'mp.pwa.iosHint.dismissedAt'
 const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
@@ -51,7 +52,10 @@ export default function IosInstallHint() {
     if (!isIosSafari()) return
     if (isStandalone()) return
     if (recentlyDismissed()) return
-    const id = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS)
+    const id = window.setTimeout(() => {
+      setVisible(true)
+      trackPwaEvent('pwa_ios_hint_shown')
+    }, REVEAL_DELAY_MS)
     return () => window.clearTimeout(id)
   }, [])
 
@@ -64,6 +68,7 @@ export default function IosInstallHint() {
       // ignore — private mode
     }
     setVisible(false)
+    trackPwaEvent('pwa_ios_hint_dismissed')
   }
 
   return (

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 /**
  * Registers the service worker, captures the `beforeinstallprompt` event
@@ -15,6 +16,18 @@ export default function PwaRegister() {
     if (typeof window === 'undefined') return
     if (process.env.NODE_ENV !== 'production') return
     if (!('serviceWorker' in navigator)) return
+
+    // One-shot: if this session launched in standalone display mode, emit a
+    // funnel event so analytics can count installed launches separately
+    // from web sessions. iOS Safari exposes the flag on navigator instead
+    // of matchMedia.
+    const iosNav = navigator as Navigator & { standalone?: boolean }
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      iosNav.standalone === true
+    if (isStandalone) {
+      trackPwaEvent('pwa_launched_standalone')
+    }
 
     // Track whether a controllerchange reload has already fired so we
     // never reload twice in a row from a single SKIP_WAITING round-trip.
@@ -82,11 +95,13 @@ export default function PwaRegister() {
       // non-standard global type into the app.
       ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = e
       window.dispatchEvent(new CustomEvent('pwa:installable'))
+      trackPwaEvent('pwa_installable')
     }
 
     const onAppInstalled = () => {
       ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = undefined
       window.dispatchEvent(new CustomEvent('pwa:installed'))
+      trackPwaEvent('pwa_installed')
     }
 
     window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,6 +8,14 @@ export type AnalyticsEventName =
   | 'contact_submit'
   | 'sign_up'
   | 'add_to_favorites'
+  | 'pwa_installable'
+  | 'pwa_install_prompted'
+  | 'pwa_install_accepted'
+  | 'pwa_install_dismissed'
+  | 'pwa_installed'
+  | 'pwa_launched_standalone'
+  | 'pwa_ios_hint_shown'
+  | 'pwa_ios_hint_dismissed'
 
 export interface AnalyticsItemInput {
   id: string

--- a/src/lib/pwa/track.ts
+++ b/src/lib/pwa/track.ts
@@ -1,0 +1,31 @@
+import { trackAnalyticsEvent, type AnalyticsEventName } from '@/lib/analytics'
+
+type PwaEventName = Extract<AnalyticsEventName, `pwa_${string}`>
+
+type Platform = 'android' | 'ios' | 'desktop' | 'unknown'
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const ua = navigator.userAgent
+  if (/android/i.test(ua)) return 'android'
+  if (/iphone|ipad|ipod/i.test(ua)) return 'ios'
+  if (/windows|mac|linux|cros/i.test(ua)) return 'desktop'
+  return 'unknown'
+}
+
+/**
+ * Thin wrapper around `trackAnalyticsEvent` that tags every PWA funnel
+ * event with the detected platform family and the current pathname.
+ * Safe to call during render — it is a no-op on the server.
+ */
+export function trackPwaEvent(
+  event: PwaEventName,
+  extra: Record<string, unknown> = {}
+) {
+  if (typeof window === 'undefined') return
+  trackAnalyticsEvent(event, {
+    ua: detectPlatform(),
+    source_url: window.location.pathname,
+    ...extra,
+  })
+}

--- a/src/lib/pwa/use-app-badge.ts
+++ b/src/lib/pwa/use-app-badge.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type BadgeFn = (count?: number) => Promise<void>
+
+/**
+ * Applies a numeric badge to the installed app icon via the Badging API.
+ * Silent no-op on platforms that don't support it (Safari iOS, Firefox,
+ * Chrome on Linux, server). Clears the badge on unmount so stale numbers
+ * don't linger after the user signs out or navigates away from the
+ * dashboard that owns the count.
+ */
+export function useAppBadge(count: number | undefined) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const nav = navigator as unknown as {
+      setAppBadge?: BadgeFn
+      clearAppBadge?: () => Promise<void>
+    }
+    if (typeof nav.setAppBadge !== 'function') return
+
+    const apply = async () => {
+      try {
+        if (!count || count <= 0) {
+          await nav.clearAppBadge?.()
+        } else {
+          await nav.setAppBadge?.(count)
+        }
+      } catch {
+        // Badging API rejects on some OS permission states — we treat
+        // every failure as "not supported right now" and move on.
+      }
+    }
+
+    void apply()
+
+    return () => {
+      try {
+        void nav.clearAppBadge?.()
+      } catch {
+        // ignore
+      }
+    }
+  }, [count])
+}


### PR DESCRIPTION
Closes #448

Stacked on #454.

## Summary
- Extends \`AnalyticsEventName\` in \`src/lib/analytics.ts\` with 8 new events:
  \`pwa_installable\`, \`pwa_install_prompted\`, \`pwa_install_accepted\`, \`pwa_install_dismissed\`, \`pwa_installed\`, \`pwa_launched_standalone\`, \`pwa_ios_hint_shown\`, \`pwa_ios_hint_dismissed\`
- New helper \`src/lib/pwa/track.ts\` wraps \`trackAnalyticsEvent\` and tags every event with a detected platform (\`android\`/\`ios\`/\`desktop\`/\`unknown\`) and the current \`source_url\` (pathname)
- \`PwaRegister\` now:
  - Emits \`pwa_launched_standalone\` on first render if the session is running as an installed app (checks \`display-mode: standalone\` and iOS \`navigator.standalone\`)
  - Emits \`pwa_installable\` when it captures \`beforeinstallprompt\`
  - Emits \`pwa_installed\` on \`appinstalled\`
- \`InstallButton\` emits \`pwa_install_prompted\` on click, and \`pwa_install_accepted\` / \`pwa_install_dismissed\` based on \`userChoice.outcome\`
- \`IosInstallHint\` emits \`pwa_ios_hint_shown\` when the banner reveals and \`pwa_ios_hint_dismissed\` on dismiss
- Existing analytics stack (\`dataLayer\`, \`gtag\`, \`marketplace:analytics\` custom event) is reused — no new dependencies, no SSR access

## Test plan
- [ ] Chrome desktop fresh profile → home → install → ver secuencia \`installable\` → \`prompted\` → \`accepted\` → \`installed\` en DevTools DataLayer
- [ ] Descartar el prompt → ver \`dismissed\` en lugar de \`accepted\`
- [ ] Lanzar la app instalada → ver \`launched_standalone\` una sola vez por sesión
- [ ] Safari iOS → \`ios_hint_shown\` tras 3s, \`ios_hint_dismissed\` al cerrar
- [ ] SSR limpio (no eventos desde servidor, no errores)
- [ ] Cada evento tiene \`ua\` y \`source_url\` en el payload

## Out of scope

- Dashboard / report building on top of these events — producto lo pilota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)