### PR TITLE
feat(pwa): update-available toast with skip-waiting handshake (#445)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { SessionProvider } from '@/components/SessionProvider'
 import { LanguageProvider } from '@/i18n'
 import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
+import UpdateToast from '@/components/pwa/UpdateToast'
 
 const geist = Geist({
   variable: '--font-geist-sans',
@@ -87,6 +88,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <AnalyticsProvider />
               </Suspense>
               <PwaRegister />
+              <UpdateToast />
               {children}
             </LanguageProvider>
           </ThemeProvider>

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -3,8 +3,9 @@
 import { useEffect } from 'react'
 
 /**
- * Registers the service worker and captures the `beforeinstallprompt` event
- * so UI elsewhere can trigger the install prompt later.
+ * Registers the service worker, captures the `beforeinstallprompt` event
+ * so UI elsewhere can trigger the install prompt later, and wires the
+ * update-available flow that powers `<UpdateToast />`.
  *
  * Keep this component tiny and side-effect-only: it must not render any DOM
  * and must never break SSR — all browser APIs are touched inside useEffect.
@@ -15,9 +16,45 @@ export default function PwaRegister() {
     if (process.env.NODE_ENV !== 'production') return
     if (!('serviceWorker' in navigator)) return
 
+    // Track whether a controllerchange reload has already fired so we
+    // never reload twice in a row from a single SKIP_WAITING round-trip.
+    let reloadedForUpdate = false
+
+    const notifyUpdate = (registration: ServiceWorkerRegistration) => {
+      ;(
+        window as unknown as { __pwaWaitingRegistration?: ServiceWorkerRegistration }
+      ).__pwaWaitingRegistration = registration
+      window.dispatchEvent(new CustomEvent('pwa:updateready'))
+    }
+
+    const watchRegistration = (registration: ServiceWorkerRegistration) => {
+      // If a new SW is already waiting by the time we register, surface it.
+      if (registration.waiting && navigator.serviceWorker.controller) {
+        notifyUpdate(registration)
+      }
+
+      registration.addEventListener('updatefound', () => {
+        const installing = registration.installing
+        if (!installing) return
+        installing.addEventListener('statechange', () => {
+          if (
+            installing.state === 'installed' &&
+            navigator.serviceWorker.controller
+          ) {
+            // An existing controller means this is an upgrade, not a
+            // first install — time to offer the update to the user.
+            notifyUpdate(registration)
+          }
+        })
+      })
+    }
+
     const register = () => {
       navigator.serviceWorker
         .register('/sw.js', { scope: '/' })
+        .then((registration) => {
+          watchRegistration(registration)
+        })
         .catch((err) => {
           // Swallow — SW registration failure must never break the app.
           // Lighthouse will still flag it, which is what we want.
@@ -29,6 +66,13 @@ export default function PwaRegister() {
     // requests on the first paint.
     if (document.readyState === 'complete') register()
     else window.addEventListener('load', register, { once: true })
+
+    const onControllerChange = () => {
+      if (reloadedForUpdate) return
+      reloadedForUpdate = true
+      window.location.reload()
+    }
+    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange)
 
     const onBeforeInstallPrompt = (e: Event) => {
       // Prevent Chrome's mini-infobar so we can decide when to prompt.
@@ -51,6 +95,10 @@ export default function PwaRegister() {
     return () => {
       window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
       window.removeEventListener('appinstalled', onAppInstalled)
+      navigator.serviceWorker.removeEventListener(
+        'controllerchange',
+        onControllerChange
+      )
     }
   }, [])
 

--- a/src/components/pwa/UpdateToast.tsx
+++ b/src/components/pwa/UpdateToast.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+
+/**
+ * Listens for the `pwa:updateready` event that `<PwaRegister />` emits when
+ * a new service worker reaches `installed` with a controlling worker still
+ * active. Offers the user an "Update now" action that posts SKIP_WAITING to
+ * the waiting worker; the register's `controllerchange` handler then
+ * triggers a single reload.
+ */
+export default function UpdateToast() {
+  const t = useT()
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(
+    null
+  )
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const handler = () => {
+      const reg =
+        (
+          window as unknown as {
+            __pwaWaitingRegistration?: ServiceWorkerRegistration
+          }
+        ).__pwaWaitingRegistration ?? null
+      if (!reg) return
+      setRegistration(reg)
+      setDismissed(false)
+    }
+
+    window.addEventListener('pwa:updateready', handler)
+    return () => window.removeEventListener('pwa:updateready', handler)
+  }, [])
+
+  if (!registration || dismissed) return null
+
+  const onUpdate = () => {
+    const waiting = registration.waiting
+    if (!waiting) {
+      // No waiting worker — nothing to do. Hide the toast.
+      setDismissed(true)
+      return
+    }
+    waiting.postMessage('SKIP_WAITING')
+    // The `controllerchange` listener in PwaRegister will trigger the reload
+    // once the new worker takes over. We just hide the toast meanwhile.
+    setDismissed(true)
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-[60] mx-auto max-w-sm rounded-2xl border border-emerald-200/70 bg-white/95 p-3 shadow-xl backdrop-blur-sm dark:border-emerald-500/30 dark:bg-neutral-900/95"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          aria-hidden
+          className="mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-xl bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300"
+        >
+          <ArrowPathIcon className="h-5 w-5" />
+        </div>
+        <div className="flex-1 text-sm">
+          <p className="font-semibold text-[var(--foreground)]">
+            {t('pwa.update.title')}
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onUpdate}
+              className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+            >
+              {t('pwa.update.cta')}
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label={t('pwa.update.dismiss')}
+          className="flex-none rounded-lg p-1 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1212,6 +1212,9 @@ const en: Record<TranslationKeys, string> = {
   'pwa.ios.hint.title': 'Install the app on your iPhone',
   'pwa.ios.hint.body': 'Tap the Share button and choose “Add to Home Screen”.',
   'pwa.ios.hint.dismiss': 'Dismiss',
+  'pwa.update.title': 'New version available',
+  'pwa.update.cta': 'Update now',
+  'pwa.update.dismiss': 'Close',
 }
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1210,6 +1210,9 @@ const es = {
   'pwa.ios.hint.title': 'Instala la app en tu iPhone',
   'pwa.ios.hint.body': 'Pulsa el botón Compartir y elige “Añadir a pantalla de inicio”.',
   'pwa.ios.hint.dismiss': 'Cerrar aviso',
+  'pwa.update.title': 'Nueva versión disponible',
+  'pwa.update.cta': 'Actualizar ahora',
+  'pwa.update.dismiss': 'Cerrar',
 } as const satisfies Record<string, string>
 
 export default es


### PR DESCRIPTION
Closes #445. Replaces #451 (stacking base deleted).

## Summary
- \`PwaRegister\` now watches \`registration.updatefound\` and fires \`pwa:updateready\` once the new worker reaches \`installed\` AND a controller already exists (first installs are suppressed)
- \`<UpdateToast />\` client component offers "Update now" that posts \`SKIP_WAITING\`
- Single-shot \`controllerchange\` listener triggers exactly one reload
- Mounted globally in \`src/app/layout.tsx\`
- i18n \`pwa.update.{title,cta,dismiss}\` in es/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)