### PR TITLE
feat(pwa): app badge for buyer + vendor pending counts (#447)

### DIFF
--- a/src/app/(buyer)/layout.tsx
+++ b/src/app/(buyer)/layout.tsx
@@ -1,12 +1,23 @@
 import { auth } from '@/lib/auth'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import AppBadgeSync from '@/components/pwa/AppBadgeSync'
+import { getPendingReviewsCount } from '@/domains/reviews/pending'
 
 export default async function BuyerLayout({ children }: { children: React.ReactNode }) {
   const session = await auth()
+
+  // Feed the installed-app badge with the number of delivered lines the
+  // buyer still has to review. Cheap: reuses the existing helper already
+  // called by the buyer dashboard, so we don't add a new N+1 query.
+  const badgeCount = session?.user?.id
+    ? await getPendingReviewsCount(session.user.id).catch(() => undefined)
+    : undefined
+
   return (
     <>
       <Header user={session?.user} />
+      <AppBadgeSync count={badgeCount} />
       <main className="flex-1">{children}</main>
       <Footer />
     </>

--- a/src/app/(vendor)/layout.tsx
+++ b/src/app/(vendor)/layout.tsx
@@ -3,6 +3,7 @@ import { VendorSidebar } from '@/components/vendor/VendorSidebar'
 import { VendorHeader } from '@/components/vendor/VendorHeader'
 import { SidebarProvider } from '@/components/layout/SidebarProvider'
 import { ImpersonationBanner } from '@/components/vendor/ImpersonationBanner'
+import AppBadgeSync from '@/components/pwa/AppBadgeSync'
 import { db } from '@/lib/db'
 import { requireVendor } from '@/lib/auth-guard'
 import { getAvailablePortals } from '@/lib/portals'
@@ -13,8 +14,20 @@ export default async function VendorLayout({ children }: { children: React.React
 
   const vendor = await db.vendor.findUnique({
     where: { userId: session.user.id },
-    select: { displayName: true, status: true, slug: true },
+    select: { id: true, displayName: true, status: true, slug: true },
   })
+
+  // Count fulfillments that still need vendor action (same 'active' filter
+  // used by `getMyFulfillments`). Feeds the installed-app icon badge so a
+  // vendor sees pending work even when the app window is in the background.
+  const pendingFulfillments = vendor
+    ? await db.vendorFulfillment.count({
+        where: {
+          vendorId: vendor.id,
+          status: { in: ['PENDING', 'CONFIRMED', 'PREPARING', 'READY'] },
+        },
+      })
+    : 0
 
   const portals = getAvailablePortals(session.user.role)
 
@@ -39,6 +52,7 @@ export default async function VendorLayout({ children }: { children: React.React
             />
           )}
           <VendorHeader user={session.user} vendor={vendor} portals={portals} />
+          <AppBadgeSync count={pendingFulfillments} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/components/pwa/AppBadgeSync.tsx
+++ b/src/components/pwa/AppBadgeSync.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useAppBadge } from '@/lib/pwa/use-app-badge'
+
+interface AppBadgeSyncProps {
+  count: number | undefined
+}
+
+/**
+ * Server-friendly wrapper that lets a server component hand a count to
+ * the client-only `useAppBadge` hook without marking the whole layout as
+ * client. Renders nothing.
+ */
+export default function AppBadgeSync({ count }: AppBadgeSyncProps) {
+  useAppBadge(count)
+  return null
+}

--- a/src/lib/pwa/use-app-badge.ts
+++ b/src/lib/pwa/use-app-badge.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect } from 'react'
+
+type BadgeFn = (count?: number) => Promise<void>
+
+/**
+ * Applies a numeric badge to the installed app icon via the Badging API.
+ * Silent no-op on platforms that don't support it (Safari iOS, Firefox,
+ * Chrome on Linux, server). Clears the badge on unmount so stale numbers
+ * don't linger after the user signs out or navigates away from the
+ * dashboard that owns the count.
+ */
+export function useAppBadge(count: number | undefined) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const nav = navigator as unknown as {
+      setAppBadge?: BadgeFn
+      clearAppBadge?: () => Promise<void>
+    }
+    if (typeof nav.setAppBadge !== 'function') return
+
+    const apply = async () => {
+      try {
+        if (!count || count <= 0) {
+          await nav.clearAppBadge?.()
+        } else {
+          await nav.setAppBadge?.(count)
+        }
+      } catch {
+        // Badging API rejects on some OS permission states — we treat
+        // every failure as "not supported right now" and move on.
+      }
+    }
+
+    void apply()
+
+    return () => {
+      try {
+        void nav.clearAppBadge?.()
+      } catch {
+        // ignore
+      }
+    }
+  }, [count])
+}


### PR DESCRIPTION
Closes #447. Replaces #454.

`useAppBadge(count)` hook + `<AppBadgeSync />` wrapper. Buyer layout: pending reviews via existing `getPendingReviewsCount`. Vendor layout: `db.vendorFulfillment.count` for active statuses. Silent no-op on unsupported platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)