### PR TITLE
feat(pwa): install funnel analytics + standalone launch tracking (#448)

### DIFF
--- a/src/components/pwa/InstallButton.tsx
+++ b/src/components/pwa/InstallButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline'
 import { useT } from '@/i18n'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 /**
  * Minimum Chromium `beforeinstallprompt` event shape — not exported by
@@ -84,9 +85,13 @@ export default function InstallButton() {
 
   const onClick = async () => {
     try {
+      trackPwaEvent('pwa_install_prompted')
       await prompt.prompt()
       const { outcome } = await prompt.userChoice
-      if (outcome === 'dismissed') {
+      if (outcome === 'accepted') {
+        trackPwaEvent('pwa_install_accepted')
+      } else {
+        trackPwaEvent('pwa_install_dismissed')
         try {
           localStorage.setItem(DISMISS_KEY, String(Date.now()))
         } catch {

--- a/src/components/pwa/IosInstallHint.tsx
+++ b/src/components/pwa/IosInstallHint.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { useT } from '@/i18n'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 const DISMISS_KEY = 'mp.pwa.iosHint.dismissedAt'
 const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
@@ -51,7 +52,10 @@ export default function IosInstallHint() {
     if (!isIosSafari()) return
     if (isStandalone()) return
     if (recentlyDismissed()) return
-    const id = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS)
+    const id = window.setTimeout(() => {
+      setVisible(true)
+      trackPwaEvent('pwa_ios_hint_shown')
+    }, REVEAL_DELAY_MS)
     return () => window.clearTimeout(id)
   }, [])
 
@@ -64,6 +68,7 @@ export default function IosInstallHint() {
       // ignore — private mode
     }
     setVisible(false)
+    trackPwaEvent('pwa_ios_hint_dismissed')
   }
 
   return (

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { trackPwaEvent } from '@/lib/pwa/track'
 
 /**
  * Registers the service worker, captures the `beforeinstallprompt` event
@@ -15,6 +16,18 @@ export default function PwaRegister() {
     if (typeof window === 'undefined') return
     if (process.env.NODE_ENV !== 'production') return
     if (!('serviceWorker' in navigator)) return
+
+    // One-shot: if this session launched in standalone display mode, emit a
+    // funnel event so analytics can count installed launches separately
+    // from web sessions. iOS Safari exposes the flag on navigator instead
+    // of matchMedia.
+    const iosNav = navigator as Navigator & { standalone?: boolean }
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      iosNav.standalone === true
+    if (isStandalone) {
+      trackPwaEvent('pwa_launched_standalone')
+    }
 
     // Track whether a controllerchange reload has already fired so we
     // never reload twice in a row from a single SKIP_WAITING round-trip.
@@ -82,11 +95,13 @@ export default function PwaRegister() {
       // non-standard global type into the app.
       ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = e
       window.dispatchEvent(new CustomEvent('pwa:installable'))
+      trackPwaEvent('pwa_installable')
     }
 
     const onAppInstalled = () => {
       ;(window as unknown as { __pwaInstallPrompt?: Event }).__pwaInstallPrompt = undefined
       window.dispatchEvent(new CustomEvent('pwa:installed'))
+      trackPwaEvent('pwa_installed')
     }
 
     window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,6 +8,14 @@ export type AnalyticsEventName =
   | 'contact_submit'
   | 'sign_up'
   | 'add_to_favorites'
+  | 'pwa_installable'
+  | 'pwa_install_prompted'
+  | 'pwa_install_accepted'
+  | 'pwa_install_dismissed'
+  | 'pwa_installed'
+  | 'pwa_launched_standalone'
+  | 'pwa_ios_hint_shown'
+  | 'pwa_ios_hint_dismissed'
 
 export interface AnalyticsItemInput {
   id: string

--- a/src/lib/pwa/track.ts
+++ b/src/lib/pwa/track.ts
@@ -1,0 +1,31 @@
+import { trackAnalyticsEvent, type AnalyticsEventName } from '@/lib/analytics'
+
+type PwaEventName = Extract<AnalyticsEventName, `pwa_${string}`>
+
+type Platform = 'android' | 'ios' | 'desktop' | 'unknown'
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'unknown'
+  const ua = navigator.userAgent
+  if (/android/i.test(ua)) return 'android'
+  if (/iphone|ipad|ipod/i.test(ua)) return 'ios'
+  if (/windows|mac|linux|cros/i.test(ua)) return 'desktop'
+  return 'unknown'
+}
+
+/**
+ * Thin wrapper around `trackAnalyticsEvent` that tags every PWA funnel
+ * event with the detected platform family and the current pathname.
+ * Safe to call during render — it is a no-op on the server.
+ */
+export function trackPwaEvent(
+  event: PwaEventName,
+  extra: Record<string, unknown> = {}
+) {
+  if (typeof window === 'undefined') return
+  trackAnalyticsEvent(event, {
+    ua: detectPlatform(),
+    source_url: window.location.pathname,
+    ...extra,
+  })
+}


### PR DESCRIPTION
Closes #448. Replaces #455.

8 new `pwa_*` events in `AnalyticsEventName`. `trackPwaEvent` helper tags with platform + pathname. Wired into PwaRegister, InstallButton, IosInstallHint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)