### PR TITLE
feat(pwa): Web Share Target — receive product/vendor/text shares (#465)

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -60,6 +60,15 @@ export default function manifest(): MetadataRoute.Manifest {
         icons: [{ src: '/icons/shortcut-orders.png', sizes: '96x96', type: 'image/png' }],
       },
     ],
+    share_target: {
+      action: '/share-target',
+      method: 'GET',
+      params: {
+        title: 'title',
+        text: 'text',
+        url: 'url',
+      },
+    },
     screenshots: [
       {
         src: '/screenshots/home-narrow.png',

--- a/src/app/share-target/page.tsx
+++ b/src/app/share-target/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { resolveShareTarget } from '@/lib/pwa/share-target'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+interface ShareTargetPageProps {
+  searchParams: Promise<{ title?: string; text?: string; url?: string }>
+}
+
+export default async function ShareTargetPage({ searchParams }: ShareTargetPageProps) {
+  const params = await searchParams
+  const resolution = resolveShareTarget({
+    title: params.title ?? null,
+    text: params.text ?? null,
+    url: params.url ?? null,
+  })
+  redirect(resolution.redirect)
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -16,6 +16,7 @@ export type AnalyticsEventName =
   | 'pwa_launched_standalone'
   | 'pwa_ios_hint_shown'
   | 'pwa_ios_hint_dismissed'
+  | 'pwa_share_target_received'
 
 export interface AnalyticsItemInput {
   id: string

--- a/src/lib/pwa/share-target.ts
+++ b/src/lib/pwa/share-target.ts
@@ -1,0 +1,89 @@
+import { SITE_URL } from '@/lib/seo'
+
+export interface ShareTargetParams {
+  title?: string | null
+  text?: string | null
+  url?: string | null
+}
+
+export type ShareTargetResolution =
+  | { type: 'product'; redirect: string }
+  | { type: 'vendor'; redirect: string }
+  | { type: 'search'; redirect: string }
+  | { type: 'home'; redirect: string }
+
+/**
+ * Given the raw params from a Web Share Target invocation, figure out
+ * where in the app to redirect the user.
+ *
+ * Priority:
+ * 1. If `url` or `text` contains a recognizable product path → product page
+ * 2. If it contains a vendor path → vendor profile
+ * 3. If there's any non-empty text → search
+ * 4. Fallback → home
+ */
+export function resolveShareTarget(params: ShareTargetParams): ShareTargetResolution {
+  const raw = [params.url, params.text, params.title].filter(Boolean).join(' ')
+
+  // Try to extract a path from our own domain URL.
+  const ownPath = extractOwnPath(raw)
+  if (ownPath) {
+    const productMatch = ownPath.match(/^\/productos\/([\w-]+)/)
+    if (productMatch) {
+      return { type: 'product', redirect: `/productos/${productMatch[1]}?source=share-target` }
+    }
+    const vendorMatch = ownPath.match(/^\/productores\/([\w-]+)/)
+    if (vendorMatch) {
+      return { type: 'vendor', redirect: `/productores/${vendorMatch[1]}?source=share-target` }
+    }
+  }
+
+  // Fallback: use any meaningful text as a search query.
+  const query = extractSearchQuery(params)
+  if (query) {
+    return { type: 'search', redirect: `/buscar?q=${encodeURIComponent(query)}&source=share-target` }
+  }
+
+  return { type: 'home', redirect: '/?source=share-target' }
+}
+
+/**
+ * If the raw content contains a URL from our own domain, return just the
+ * pathname portion (e.g. "/productos/tomate-eco"). Returns null otherwise.
+ */
+function extractOwnPath(raw: string): string | null {
+  // Match URLs that look like our domain.
+  const siteOrigin = new URL(SITE_URL).origin
+  const urlRegex = /https?:\/\/[^\s]+/gi
+  const urls = raw.match(urlRegex)
+  if (!urls) return null
+
+  for (const candidate of urls) {
+    try {
+      const parsed = new URL(candidate)
+      if (parsed.origin === siteOrigin) {
+        return parsed.pathname
+      }
+    } catch {
+      // not a valid URL — skip
+    }
+  }
+  return null
+}
+
+/**
+ * Build a sensible search query from the share params. Strips URLs and
+ * excessive whitespace so the search page gets clean input.
+ */
+function extractSearchQuery(params: ShareTargetParams): string | null {
+  // Prefer `text`, then `title`. Skip `url` — it's already handled above.
+  const raw = (params.text ?? params.title ?? '').trim()
+  if (!raw) return null
+
+  // Strip any URLs so the search page doesn't try to search "https://..."
+  const cleaned = raw.replace(/https?:\/\/\S+/gi, '').trim()
+  if (!cleaned) return null
+
+  // Cap at 100 chars to avoid abuse.
+  return cleaned.length > 100 ? cleaned.slice(0, 100) : cleaned
+}

--- a/test/features/share-target.test.ts
+++ b/test/features/share-target.test.ts
@@ -1,0 +1,150 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveShareTarget, type ShareTargetParams } from '@/lib/pwa/share-target'
+
+// ── Product URL recognition ──────────────────────────────────────────────
+
+test('resolveShareTarget: product URL from own domain → product page', () => {
+  const result = resolveShareTarget({
+    url: 'http://localhost:3000/productos/tomate-eco',
+    text: null,
+    title: null,
+  })
+  assert.equal(result.type, 'product')
+  assert.equal(result.redirect, '/productos/tomate-eco?source=share-target')
+})
+
+test('resolveShareTarget: product URL embedded in text → product page', () => {
+  const result = resolveShareTarget({
+    url: null,
+    text: 'Mira esto http://localhost:3000/productos/queso-manchego genial!',
+    title: null,
+  })
+  assert.equal(result.type, 'product')
+  assert.equal(result.redirect, '/productos/queso-manchego?source=share-target')
+})
+
+test('resolveShareTarget: product slug with hyphens and numbers', () => {
+  const result = resolveShareTarget({
+    url: 'http://localhost:3000/productos/aceite-virgen-extra-500ml',
+    text: null,
+    title: null,
+  })
+  assert.equal(result.type, 'product')
+  assert.match(result.redirect, /\/productos\/aceite-virgen-extra-500ml/)
+})
+
+// ── Vendor URL recognition ───────────────────────────────────────────────
+
+test('resolveShareTarget: vendor URL → vendor profile', () => {
+  const result = resolveShareTarget({
+    url: 'http://localhost:3000/productores/huerta-del-sol',
+    text: null,
+    title: null,
+  })
+  assert.equal(result.type, 'vendor')
+  assert.equal(result.redirect, '/productores/huerta-del-sol?source=share-target')
+})
+
+// ── Search fallback ──────────────────────────────────────────────────────
+
+test('resolveShareTarget: plain text → search', () => {
+  const result = resolveShareTarget({
+    url: null,
+    text: 'tomates ecológicos',
+    title: null,
+  })
+  assert.equal(result.type, 'search')
+  assert.equal(result.redirect, '/buscar?q=tomates%20ecol%C3%B3gicos&source=share-target')
+})
+
+test('resolveShareTarget: title-only → search from title', () => {
+  const result = resolveShareTarget({
+    url: null,
+    text: null,
+    title: 'Frutas de temporada',
+  })
+  assert.equal(result.type, 'search')
+  assert.match(result.redirect, /\/buscar\?q=Frutas/)
+})
+
+test('resolveShareTarget: text with URLs stripped → search with clean query', () => {
+  const result = resolveShareTarget({
+    url: null,
+    text: 'Check out https://external-site.com/page — best organic food',
+    title: null,
+  })
+  assert.equal(result.type, 'search')
+  // The external URL should be stripped, leaving only the text.
+  assert.match(result.redirect, /\/buscar\?q=/)
+  assert.ok(!result.redirect.includes('external-site.com'))
+})
+
+test('resolveShareTarget: very long text → capped at 100 chars', () => {
+  const longText = 'a'.repeat(200)
+  const result = resolveShareTarget({
+    url: null,
+    text: longText,
+    title: null,
+  })
+  assert.equal(result.type, 'search')
+  // The encoded query should use a 100-char truncated string.
+  const qParam = new URL(`http://x${result.redirect}`).searchParams.get('q')
+  assert.ok(qParam !== null)
+  assert.equal(qParam!.length, 100)
+})
+
+// ── Home fallback ────────────────────────────────────────────────────────
+
+test('resolveShareTarget: empty params → home', () => {
+  const result = resolveShareTarget({ url: null, text: null, title: null })
+  assert.equal(result.type, 'home')
+  assert.equal(result.redirect, '/?source=share-target')
+})
+
+test('resolveShareTarget: only whitespace text → home', () => {
+  const result = resolveShareTarget({ url: null, text: '   ', title: null })
+  assert.equal(result.type, 'home')
+})
+
+test('resolveShareTarget: text is just a URL from another domain → home', () => {
+  const result = resolveShareTarget({
+    url: null,
+    text: 'https://external-site.com/page',
+    title: null,
+  })
+  // After stripping the external URL, text is empty → home.
+  assert.equal(result.type, 'home')
+})
+
+// ── External / unrecognized URLs ─────────────────────────────────────────
+
+test('resolveShareTarget: URL from different domain → search with remaining text', () => {
+  const result = resolveShareTarget({
+    url: 'https://other-marketplace.com/product/123',
+    text: 'Amazing organic honey',
+    title: null,
+  })
+  // The URL is not ours, so it falls through. Text has content → search.
+  assert.equal(result.type, 'search')
+  assert.match(result.redirect, /\/buscar\?q=Amazing/)
+})
+
+// ── Priority: URL > text > title ─────────────────────────────────────────
+
+test('resolveShareTarget: own product URL takes priority over text', () => {
+  const result = resolveShareTarget({
+    url: 'http://localhost:3000/productos/miel-romero',
+    text: 'searching for honey',
+    title: 'My Honey',
+  })
+  assert.equal(result.type, 'product')
+  assert.match(result.redirect, /\/productos\/miel-romero/)
+})
+
+// ── All params undefined (defensive) ─────────────────────────────────────
+
+test('resolveShareTarget: all undefined → home', () => {
+  const result = resolveShareTarget({} as ShareTargetParams)
+  assert.equal(result.type, 'home')
+})


### PR DESCRIPTION
Closes #465

## Summary
- Manifest gains `share_target` field (GET `/share-target` with `title`, `text`, `url` params)
- New route `src/app/share-target/page.tsx` (`force-dynamic`, `noindex`) resolves the shared content and redirects
- Resolution logic in `src/lib/pwa/share-target.ts`:
  1. Own-domain product URL → `/productos/<slug>?source=share-target`
  2. Own-domain vendor URL → `/productores/<slug>?source=share-target`
  3. Non-empty text (URLs stripped) → `/buscar?q=<query>&source=share-target`
  4. Fallback → `/?source=share-target`
- External URLs stripped from search queries, text capped at 100 chars
- `pwa_share_target_received` added to analytics event types

## Test plan
- [x] 14 unit tests covering all resolution paths (707/708 pass, 1 pre-existing failure)
- [x] `npm run typecheck` green
- [ ] Chrome Android installed PWA: share a product URL from Chrome → opens the product page
- [ ] Share plain text from WhatsApp → opens search with that text
- [ ] Share an external URL → falls back to search or home
- [ ] `/share-target` not indexed by crawlers (robots meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)