### PR TITLE
feat(pwa): push notifications — VAPID config, model, SW handlers, opt-in UI (#463)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,14 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 # SENDCLOUD_BASE_URL="https://panel.sendcloud.sc/api/v2"  # optional override
 
 # ===========================
+# PUSH NOTIFICATIONS (optional)
+# ===========================
+# Generate VAPID keys with: npx web-push generate-vapid-keys
+# Required only when you want browser push. Leave blank to disable.
+# NEXT_PUBLIC_VAPID_PUBLIC_KEY="BL..."
+# VAPID_PRIVATE_KEY="..."
+
+# ===========================
 # ADMIN HOST ISOLATION (optional)
 # ===========================
 # Serve /admin/** on a dedicated host so an admin session cookie cannot

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "resend": "^6.10.0",
         "stripe": "^22.0.1",
         "tailwind-merge": "^3.5.0",
+        "web-push": "^3.6.7",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -45,6 +46,7 @@
         "@types/node": "^20.19.39",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "c8": "^11.0.0",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
@@ -2639,6 +2641,16 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -2680,6 +2692,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2739,6 +2760,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/atomically": {
@@ -2815,6 +2848,12 @@
       "integrity": "sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==",
       "license": "MIT"
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2826,6 +2865,12 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -3458,6 +3503,15 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/effect": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
@@ -3896,11 +3950,33 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -3927,6 +4003,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -4080,6 +4162,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kleur": {
@@ -4509,6 +4612,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -6156,6 +6265,26 @@
         "node": ">= 4"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6731,6 +6860,25 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "resend": "^6.10.0",
     "stripe": "^22.0.1",
     "tailwind-merge": "^3.5.0",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
@@ -62,6 +63,7 @@
     "@types/node": "^20.19.39",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "c8": "^11.0.0",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",

--- a/prisma/migrations/20260416080000_push_subscriptions/migration.sql
+++ b/prisma/migrations/20260416080000_push_subscriptions/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+
+-- AddForeignKey
+ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,6 +205,7 @@ model User {
   reviews                 Review[]
   favorites               Favorite[]
   subscriptions           Subscription[]
+  pushSubscriptions       PushSubscription[]
   emailVerificationTokens EmailVerificationToken[]
   passwordResetTokens     PasswordResetToken[]
 
@@ -1028,6 +1029,23 @@ model PasswordResetToken {
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+// ─── Push Notifications ──────────────────────────────────────────────────────
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  endpoint  String   @unique
+  p256dh    String   @db.Text
+  auth      String   @db.Text
+  userAgent String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -169,4 +169,52 @@ self.addEventListener('message', (event) => {
   if (event.data === 'SKIP_WAITING') self.skipWaiting()
 })
 
+// ── Push Notifications ───────────────────────────────────────────────────
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return
+
+  let payload
+  try {
+    payload = event.data.json()
+  } catch {
+    return
+  }
+
+  const title = payload.title || 'Mercado Productor'
+  const options = {
+    body: payload.body || '',
+    icon: payload.icon || '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: payload.tag || 'mp-default',
+    data: { url: payload.url || '/' },
+    // Vibrate on Android: short-long-short pattern for notifications.
+    vibrate: [100, 50, 100],
+  }
+
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const targetUrl = event.notification.data?.url || '/'
+  const fullUrl = new URL(targetUrl, self.location.origin).href
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        // If a tab with the target URL is already open, focus it.
+        for (const client of windowClients) {
+          if (client.url === fullUrl && 'focus' in client) {
+            return client.focus()
+          }
+        }
+        // Otherwise, open a new tab/window.
+        return self.clients.openWindow(fullUrl)
+      })
+  )
+})
+
 self.__SW_VERSION = SW_VERSION

--- a/src/components/pwa/PushOptIn.tsx
+++ b/src/components/pwa/PushOptIn.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BellIcon, BellSlashIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+import {
+  requestPushSubscription,
+  getPushSubscriptionState,
+  unsubscribePushBrowser,
+} from '@/lib/pwa/push-client'
+import { subscribeToPush, unsubscribeFromPush } from '@/domains/push-notifications/actions'
+
+type PushState = 'loading' | 'unsupported' | 'denied' | 'prompt' | 'subscribed' | 'unsubscribed'
+
+/**
+ * Renders a push notification opt-in / opt-out button. Hidden when push
+ * is not supported or when VAPID keys are not configured. Safe to mount
+ * anywhere — all browser APIs are gated behind feature detection.
+ */
+export default function PushOptIn() {
+  const t = useT()
+  const [state, setState] = useState<PushState>('loading')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    getPushSubscriptionState().then(setState)
+  }, [])
+
+  // Don't show anything until we know the state, and hide on unsupported
+  // or permission-denied (nothing we can do).
+  if (state === 'loading' || state === 'unsupported' || state === 'denied') {
+    return null
+  }
+
+  const isSubscribed = state === 'subscribed'
+
+  const handleToggle = async () => {
+    if (busy) return
+    setBusy(true)
+
+    try {
+      if (isSubscribed) {
+        const endpoint = await unsubscribePushBrowser()
+        if (endpoint) await unsubscribeFromPush(endpoint)
+        setState('unsubscribed')
+      } else {
+        const keys = await requestPushSubscription()
+        if (!keys) {
+          // User denied or browser blocked.
+          const newState = await getPushSubscriptionState()
+          setState(newState)
+          return
+        }
+        await subscribeToPush(keys)
+        setState('subscribed')
+      }
+    } catch {
+      // Swallow — push is nice-to-have, must never break the app.
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      disabled={busy}
+      title={isSubscribed ? t('pwa.push.disable') : t('pwa.push.enable')}
+      aria-label={isSubscribed ? t('pwa.push.disable') : t('pwa.push.enable')}
+      className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium text-[var(--foreground-soft)] transition-colors hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] disabled:opacity-50"
+    >
+      {isSubscribed ? (
+        <BellSlashIcon className="h-4.5 w-4.5" aria-hidden />
+      ) : (
+        <BellIcon className="h-4.5 w-4.5" aria-hidden />
+      )}
+      <span className="hidden md:inline">
+        {isSubscribed ? t('pwa.push.disable') : t('pwa.push.enable')}
+      </span>
+    </button>
+  )
+}

--- a/src/domains/push-notifications/actions.ts
+++ b/src/domains/push-notifications/actions.ts
@@ -1,0 +1,63 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { isPushEnabled } from '@/lib/pwa/push-config'
+
+const subscribeSchema = z.object({
+  endpoint: z.string().url(),
+  p256dh: z.string().min(1),
+  auth: z.string().min(1),
+  userAgent: z.string().max(500).optional(),
+})
+
+export type PushSubscriptionInput = z.infer<typeof subscribeSchema>
+
+/**
+ * Upserts a push subscription for the current user. If the same endpoint
+ * already exists (e.g. the user re-subscribed on the same browser), the
+ * keys are updated in place.
+ */
+export async function subscribeToPush(input: PushSubscriptionInput) {
+  if (!isPushEnabled) {
+    throw new Error('Push notifications are not configured on this instance.')
+  }
+
+  const session = await getActionSession()
+  if (!session?.user) throw new Error('Unauthorized')
+
+  const data = subscribeSchema.parse(input)
+
+  await db.pushSubscription.upsert({
+    where: { endpoint: data.endpoint },
+    create: {
+      userId: session.user.id,
+      endpoint: data.endpoint,
+      p256dh: data.p256dh,
+      auth: data.auth,
+      userAgent: data.userAgent,
+    },
+    update: {
+      p256dh: data.p256dh,
+      auth: data.auth,
+      userAgent: data.userAgent,
+    },
+  })
+}
+
+/**
+ * Removes a push subscription by endpoint. Allows the user to unsubscribe
+ * from a specific browser/device.
+ */
+export async function unsubscribeFromPush(endpoint: string) {
+  const session = await getActionSession()
+  if (!session?.user) throw new Error('Unauthorized')
+
+  await db.pushSubscription.deleteMany({
+    where: {
+      endpoint,
+      userId: session.user.id, // ensure users can only delete their own
+    },
+  })
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1222,6 +1222,8 @@ const en: Record<TranslationKeys, string> = {
   'pwa.update.title': 'New version available',
   'pwa.update.cta': 'Update now',
   'pwa.update.dismiss': 'Close',
+  'pwa.push.enable': 'Enable notifications',
+  'pwa.push.disable': 'Disable notifications',
 }
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1220,6 +1220,8 @@ const es = {
   'pwa.update.title': 'Nueva versión disponible',
   'pwa.update.cta': 'Actualizar ahora',
   'pwa.update.dismiss': 'Cerrar',
+  'pwa.push.enable': 'Activar notificaciones',
+  'pwa.push.disable': 'Desactivar notificaciones',
 } as const satisfies Record<string, string>
 
 export default es

--- a/src/lib/pwa/push-client.ts
+++ b/src/lib/pwa/push-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Client-side helpers for Web Push. These run in the browser only and
+ * communicate with the SW + server actions to manage the subscription lifecycle.
+ */
+
+/**
+ * Converts a base64-encoded VAPID public key to a Uint8Array suitable for
+ * the `applicationServerKey` option of `pushManager.subscribe()`.
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+export interface PushSubscriptionKeys {
+  endpoint: string
+  p256dh: string
+  auth: string
+  userAgent: string
+}
+
+/**
+ * Requests notification permission, subscribes the SW to push, and returns
+ * the subscription keys the server needs. Returns `null` if the user
+ * declines or the browser doesn't support push.
+ */
+export async function requestPushSubscription(): Promise<PushSubscriptionKeys | null> {
+  if (typeof window === 'undefined') return null
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return null
+
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  if (!vapidPublicKey) return null
+
+  const permission = await Notification.requestPermission()
+  if (permission !== 'granted') return null
+
+  const registration = await navigator.serviceWorker.ready
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as BufferSource,
+  })
+
+  const json = subscription.toJSON()
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) return null
+
+  return {
+    endpoint: json.endpoint,
+    p256dh: json.keys.p256dh,
+    auth: json.keys.auth,
+    userAgent: navigator.userAgent,
+  }
+}
+
+/**
+ * Returns the current push subscription state without prompting the user.
+ */
+export async function getPushSubscriptionState(): Promise<
+  'unsupported' | 'denied' | 'prompt' | 'subscribed' | 'unsubscribed'
+> {
+  if (typeof window === 'undefined') return 'unsupported'
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return 'unsupported'
+  if (!process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY) return 'unsupported'
+
+  const permission = Notification.permission
+  if (permission === 'denied') return 'denied'
+
+  const registration = await navigator.serviceWorker.ready
+  const existing = await registration.pushManager.getSubscription()
+  if (existing) return 'subscribed'
+
+  return permission === 'default' ? 'prompt' : 'unsubscribed'
+}
+
+/**
+ * Unsubscribes from push at the browser level and returns the endpoint
+ * that was removed (so the caller can also tell the server).
+ */
+export async function unsubscribePushBrowser(): Promise<string | null> {
+  if (typeof window === 'undefined') return null
+  if (!('serviceWorker' in navigator)) return null
+
+  const registration = await navigator.serviceWorker.ready
+  const subscription = await registration.pushManager.getSubscription()
+  if (!subscription) return null
+
+  const endpoint = subscription.endpoint
+  await subscription.unsubscribe()
+  return endpoint
+}

--- a/src/lib/pwa/push-config.ts
+++ b/src/lib/pwa/push-config.ts
@@ -10,7 +10,7 @@ export interface VapidConfig {
   subject: string
 }
 
-function loadVapidConfig(): VapidConfig | null {
+export function loadVapidConfig(): VapidConfig | null {
   const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
   const privateKey = process.env.VAPID_PRIVATE_KEY
   if (!publicKey || !privateKey) return null

--- a/src/lib/pwa/push-config.ts
+++ b/src/lib/pwa/push-config.ts
@@ -1,0 +1,27 @@
+/**
+ * VAPID configuration for Web Push. All values are read from env at import
+ * time. The module exports `null` when push is not configured so callers
+ * can feature-gate without try/catch.
+ */
+
+export interface VapidConfig {
+  publicKey: string
+  privateKey: string
+  subject: string
+}
+
+function loadVapidConfig(): VapidConfig | null {
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const privateKey = process.env.VAPID_PRIVATE_KEY
+  if (!publicKey || !privateKey) return null
+  return {
+    publicKey,
+    privateKey,
+    subject: process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000',
+  }
+}
+
+export const vapidConfig = loadVapidConfig()
+
+/** True when VAPID keys are configured and push can be used. */
+export const isPushEnabled = vapidConfig !== null

--- a/src/lib/pwa/push-send.ts
+++ b/src/lib/pwa/push-send.ts
@@ -1,0 +1,77 @@
+import { db } from '@/lib/db'
+import { vapidConfig } from './push-config'
+
+export interface PushPayload {
+  title: string
+  body: string
+  url?: string
+  icon?: string
+  tag?: string
+}
+
+/**
+ * Sends a push notification to all subscriptions for the given user.
+ * Silently removes subscriptions that return 404/410 (unsubscribed or
+ * expired). Returns the number of successful deliveries.
+ *
+ * Degrades to a no-op when VAPID is not configured.
+ */
+export async function sendPushToUser(
+  userId: string,
+  payload: PushPayload
+): Promise<number> {
+  if (!vapidConfig) return 0
+
+  const subscriptions = await db.pushSubscription.findMany({
+    where: { userId },
+    select: { id: true, endpoint: true, p256dh: true, auth: true },
+  })
+
+  if (subscriptions.length === 0) return 0
+
+  // Dynamic import so the module is only loaded when push is actually used.
+  // This keeps the cold-start cost off pages that don't send notifications.
+  const webpush = await import('web-push')
+  webpush.setVapidDetails(
+    vapidConfig.subject,
+    vapidConfig.publicKey,
+    vapidConfig.privateKey
+  )
+
+  const body = JSON.stringify(payload)
+  let sent = 0
+  const staleIds: string[] = []
+
+  await Promise.allSettled(
+    subscriptions.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: sub.endpoint,
+            keys: { p256dh: sub.p256dh, auth: sub.auth },
+          },
+          body,
+          { TTL: 60 * 60 } // 1 hour
+        )
+        sent += 1
+      } catch (err: unknown) {
+        const status = (err as { statusCode?: number }).statusCode
+        if (status === 404 || status === 410) {
+          // Subscription is gone — mark for deletion.
+          staleIds.push(sub.id)
+        }
+        // 429 / 5xx: transient — we just skip this delivery. A retry
+        // mechanism can be added later without changing this interface.
+      }
+    })
+  )
+
+  // Clean up stale subscriptions in a single batch.
+  if (staleIds.length > 0) {
+    await db.pushSubscription.deleteMany({
+      where: { id: { in: staleIds } },
+    })
+  }
+
+  return sent
+}

--- a/test/features/push-config.test.ts
+++ b/test/features/push-config.test.ts
@@ -1,38 +1,76 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { loadVapidConfig } from '@/lib/pwa/push-config'
 
-test('push-config: isPushEnabled is false when VAPID keys are absent', async () => {
-  // Clear env to simulate unconfigured state.
+test('loadVapidConfig: returns null when VAPID keys are absent', () => {
   const savedPublic = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
   const savedPrivate = process.env.VAPID_PRIVATE_KEY
   delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
   delete process.env.VAPID_PRIVATE_KEY
 
-  // Re-import to get fresh module evaluation.
-  // Node caches modules, so we use a query-string trick to bust the cache.
-  const mod = await import(`@/lib/pwa/push-config?t=${Date.now()}`)
-  assert.equal(mod.isPushEnabled, false)
-  assert.equal(mod.vapidConfig, null)
+  const result = loadVapidConfig()
+  assert.equal(result, null)
 
   // Restore.
   if (savedPublic) process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = savedPublic
   if (savedPrivate) process.env.VAPID_PRIVATE_KEY = savedPrivate
 })
 
-test('push-config: exports VapidConfig type structure', async () => {
-  // Set fake keys.
+test('loadVapidConfig: returns config when both keys are set', () => {
+  const savedPublic = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const savedPrivate = process.env.VAPID_PRIVATE_KEY
+  const savedUrl = process.env.NEXT_PUBLIC_APP_URL
+
   process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'BFakePublicKey123'
   process.env.VAPID_PRIVATE_KEY = 'FakePrivateKey456'
   process.env.NEXT_PUBLIC_APP_URL = 'https://test.example.com'
 
-  const mod = await import(`@/lib/pwa/push-config?t=${Date.now() + 1}`)
-  assert.equal(mod.isPushEnabled, true)
-  assert.ok(mod.vapidConfig !== null)
-  assert.equal(mod.vapidConfig!.publicKey, 'BFakePublicKey123')
-  assert.equal(mod.vapidConfig!.privateKey, 'FakePrivateKey456')
-  assert.equal(mod.vapidConfig!.subject, 'https://test.example.com')
+  const result = loadVapidConfig()
+  assert.ok(result !== null)
+  assert.equal(result!.publicKey, 'BFakePublicKey123')
+  assert.equal(result!.privateKey, 'FakePrivateKey456')
+  assert.equal(result!.subject, 'https://test.example.com')
 
-  // Cleanup.
-  delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  // Cleanup — restore original values.
+  if (savedPublic) process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = savedPublic
+  else delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  if (savedPrivate) process.env.VAPID_PRIVATE_KEY = savedPrivate
+  else delete process.env.VAPID_PRIVATE_KEY
+  if (savedUrl) process.env.NEXT_PUBLIC_APP_URL = savedUrl
+  else delete process.env.NEXT_PUBLIC_APP_URL
+})
+
+test('loadVapidConfig: returns null when only public key is set', () => {
+  const savedPublic = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const savedPrivate = process.env.VAPID_PRIVATE_KEY
+
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'BFakePublicKey123'
   delete process.env.VAPID_PRIVATE_KEY
+
+  const result = loadVapidConfig()
+  assert.equal(result, null)
+
+  if (savedPublic) process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = savedPublic
+  else delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  if (savedPrivate) process.env.VAPID_PRIVATE_KEY = savedPrivate
+})
+
+test('loadVapidConfig: falls back to localhost when APP_URL is absent', () => {
+  const savedPublic = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const savedPrivate = process.env.VAPID_PRIVATE_KEY
+  const savedUrl = process.env.NEXT_PUBLIC_APP_URL
+
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'BKey'
+  process.env.VAPID_PRIVATE_KEY = 'PKey'
+  delete process.env.NEXT_PUBLIC_APP_URL
+
+  const result = loadVapidConfig()
+  assert.ok(result !== null)
+  assert.equal(result!.subject, 'http://localhost:3000')
+
+  if (savedPublic) process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = savedPublic
+  else delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  if (savedPrivate) process.env.VAPID_PRIVATE_KEY = savedPrivate
+  else delete process.env.VAPID_PRIVATE_KEY
+  if (savedUrl) process.env.NEXT_PUBLIC_APP_URL = savedUrl
 })

--- a/test/features/push-config.test.ts
+++ b/test/features/push-config.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+test('push-config: isPushEnabled is false when VAPID keys are absent', async () => {
+  // Clear env to simulate unconfigured state.
+  const savedPublic = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const savedPrivate = process.env.VAPID_PRIVATE_KEY
+  delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  delete process.env.VAPID_PRIVATE_KEY
+
+  // Re-import to get fresh module evaluation.
+  // Node caches modules, so we use a query-string trick to bust the cache.
+  const mod = await import(`@/lib/pwa/push-config?t=${Date.now()}`)
+  assert.equal(mod.isPushEnabled, false)
+  assert.equal(mod.vapidConfig, null)
+
+  // Restore.
+  if (savedPublic) process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = savedPublic
+  if (savedPrivate) process.env.VAPID_PRIVATE_KEY = savedPrivate
+})
+
+test('push-config: exports VapidConfig type structure', async () => {
+  // Set fake keys.
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'BFakePublicKey123'
+  process.env.VAPID_PRIVATE_KEY = 'FakePrivateKey456'
+  process.env.NEXT_PUBLIC_APP_URL = 'https://test.example.com'
+
+  const mod = await import(`@/lib/pwa/push-config?t=${Date.now() + 1}`)
+  assert.equal(mod.isPushEnabled, true)
+  assert.ok(mod.vapidConfig !== null)
+  assert.equal(mod.vapidConfig!.publicKey, 'BFakePublicKey123')
+  assert.equal(mod.vapidConfig!.privateKey, 'FakePrivateKey456')
+  assert.equal(mod.vapidConfig!.subject, 'https://test.example.com')
+
+  // Cleanup.
+  delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  delete process.env.VAPID_PRIVATE_KEY
+})

--- a/test/features/push-subscription-schema.test.ts
+++ b/test/features/push-subscription-schema.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+
+// Replicate the schema from the server action to test it without importing
+// the 'use server' module directly (which would fail in node:test).
+const subscribeSchema = z.object({
+  endpoint: z.string().url(),
+  p256dh: z.string().min(1),
+  auth: z.string().min(1),
+  userAgent: z.string().max(500).optional(),
+})
+
+test('push subscription schema: valid input passes', () => {
+  const input = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(result.success)
+})
+
+test('push subscription schema: with userAgent', () => {
+  const input = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+    userAgent: 'Mozilla/5.0 (Linux; Android 14)',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(result.success)
+})
+
+test('push subscription schema: rejects invalid endpoint URL', () => {
+  const input = {
+    endpoint: 'not-a-url',
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(!result.success)
+})
+
+test('push subscription schema: rejects empty p256dh', () => {
+  const input = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    p256dh: '',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(!result.success)
+})
+
+test('push subscription schema: rejects empty auth', () => {
+  const input = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: '',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(!result.success)
+})
+
+test('push subscription schema: rejects userAgent over 500 chars', () => {
+  const input = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+    userAgent: 'x'.repeat(501),
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(!result.success)
+})
+
+test('push subscription schema: missing endpoint rejects', () => {
+  const input = {
+    p256dh: 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQ',
+    auth: 'tBHItJI5svbpC7D2LlAnFA',
+  }
+  const result = subscribeSchema.safeParse(input)
+  assert.ok(!result.success)
+})


### PR DESCRIPTION
Closes #463

## Summary
Full push notification infrastructure, feature-gated behind VAPID env vars.

### Database
- `PushSubscription` model: endpoint (unique), p256dh, auth, userId (cascade delete), userAgent
- Migration `20260416080000_push_subscriptions`

### Server
- `src/lib/pwa/push-config.ts`: reads `NEXT_PUBLIC_VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY`, exports `null` when absent
- `src/lib/pwa/push-send.ts`: `sendPushToUser(userId, payload)` delivers to all subscriptions, auto-deletes 404/410 stale endpoints, dynamic-imports `web-push` to keep cold starts clean
- `src/domains/push-notifications/actions.ts`: `subscribeToPush` (upsert by endpoint) + `unsubscribeFromPush` with Zod validation and session auth

### Service worker
- `push` handler: parses JSON payload, shows OS notification with icon/badge/vibrate/tag
- `notificationclick`: focuses existing tab at target URL or opens new one
- Protected prefixes still never cached/intercepted

### Client
- `src/lib/pwa/push-client.ts`: `requestPushSubscription()`, `getPushSubscriptionState()`, `unsubscribePushBrowser()`
- `src/components/pwa/PushOptIn.tsx`: toggle button hidden on unsupported/denied, wires subscribe/unsubscribe to server actions

### Feature gate
Everything degrades gracefully when `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is absent — PushOptIn hides itself, server actions throw "not configured", sendPushToUser returns 0.

## Tests (9 new, 702/703 total — same 1 pre-existing failure)
- 2 tests: VAPID config loading (present/absent env vars)
- 7 tests: subscription schema validation (valid, invalid URL, empty keys, long UA, missing fields)

## Test plan
- [x] `npm run typecheck` green
- [x] `npm run test:parallel` — 702/703 pass (baseline preserved)
- [ ] Set VAPID keys, seed DB, `npm run build && npm start`
- [ ] PushOptIn renders on buyer/vendor pages when VAPID is set
- [ ] Click "Enable" → OS permission prompt → subscription saved to DB
- [ ] `sendPushToUser(userId, { title: 'Test', body: 'Hello' })` from console → notification appears
- [ ] Click notification → opens target URL
- [ ] Unsubscribe → subscription removed from DB + browser
- [ ] Without VAPID keys: PushOptIn hidden, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)