### PR TITLE
feat(pwa): periodic background sync for catalog prefetch (#466)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -30,9 +30,10 @@
  * LRU trim at MAX_STATIC_ENTRIES keeps the cache from growing unbounded.
  */
 
-const SW_VERSION = 'mp-sw-v3'
+const SW_VERSION = 'mp-sw-v4'
 const OFFLINE_CACHE = 'mp-offline-v1'
 const STATIC_CACHE = 'mp-static-v1'
+const PREFETCH_CACHE = 'mp-prefetch-v1'
 const OFFLINE_URL = '/offline'
 const MAX_STATIC_ENTRIES = 60
 
@@ -89,7 +90,7 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
-      const allowed = new Set([OFFLINE_CACHE, STATIC_CACHE])
+      const allowed = new Set([OFFLINE_CACHE, STATIC_CACHE, PREFETCH_CACHE])
       const keys = await caches.keys()
       await Promise.all(
         keys.filter((k) => !allowed.has(k)).map((k) => caches.delete(k))
@@ -188,7 +189,6 @@ self.addEventListener('push', (event) => {
     badge: '/icons/icon-192.png',
     tag: payload.tag || 'mp-default',
     data: { url: payload.url || '/' },
-    // Vibrate on Android: short-long-short pattern for notifications.
     vibrate: [100, 50, 100],
   }
 
@@ -205,15 +205,44 @@ self.addEventListener('notificationclick', (event) => {
     self.clients
       .matchAll({ type: 'window', includeUncontrolled: true })
       .then((windowClients) => {
-        // If a tab with the target URL is already open, focus it.
         for (const client of windowClients) {
           if (client.url === fullUrl && 'focus' in client) {
             return client.focus()
           }
         }
-        // Otherwise, open a new tab/window.
         return self.clients.openWindow(fullUrl)
       })
+  )
+})
+
+// ── Periodic Background Sync ─────────────────────────────────────────────
+
+const PERIODIC_SYNC_TAG = 'mp-catalog-prefetch'
+
+self.addEventListener('periodicsync', (event) => {
+  if (event.tag !== PERIODIC_SYNC_TAG) return
+
+  event.waitUntil(
+    (async () => {
+      const conn = navigator.connection
+      if (conn && conn.saveData) return
+      if (conn && (conn.effectiveType === 'slow-2g' || conn.effectiveType === '2g')) return
+
+      try {
+        const response = await fetch('/api/catalog/featured?limit=12')
+        if (!response.ok) return
+
+        const cache = await caches.open(PREFETCH_CACHE)
+        await cache.put('/api/catalog/featured?limit=12', response)
+
+        const clients = await self.clients.matchAll({ type: 'window' })
+        for (const client of clients) {
+          client.postMessage({ type: 'catalog-prefetched' })
+        }
+      } catch {
+        // Network failure during background sync — silently skip.
+      }
+    })()
   )
 })
 

--- a/src/app/api/catalog/featured/route.ts
+++ b/src/app/api/catalog/featured/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { getFeaturedProducts } from '@/domains/catalog/queries'
+
+/**
+ * Lightweight JSON endpoint for the periodic background sync to prefetch
+ * featured products. No auth required — this is public catalog data.
+ * Returns a compact payload (no vendor relations, no heavy fields).
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const limit = Math.min(Number(url.searchParams.get('limit') ?? 12), 24)
+
+  const products = await getFeaturedProducts(limit)
+
+  const compact = products.map((p) => ({
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    price: Number(p.basePrice),
+    unit: p.unit,
+    images: p.images.slice(0, 1), // Only first image for prefetch
+    vendorName: p.vendor.displayName,
+    vendorSlug: p.vendor.slug,
+  }))
+
+  return NextResponse.json(compact, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+    },
+  })
+}

--- a/src/components/pwa/PwaRegister.tsx
+++ b/src/components/pwa/PwaRegister.tsx
@@ -62,11 +62,29 @@ export default function PwaRegister() {
       })
     }
 
+    const requestPeriodicSync = async (registration: ServiceWorkerRegistration) => {
+      try {
+        // periodicSync is Chrome-only; feature-detect before touching it.
+        const mgr = (registration as unknown as { periodicSync?: { register: (tag: string, opts: { minInterval: number }) => Promise<void> } }).periodicSync
+        if (!mgr) return
+        const status = await navigator.permissions.query({
+          name: 'periodic-background-sync' as PermissionName,
+        })
+        if (status.state !== 'granted') return
+        await mgr.register('mp-catalog-prefetch', {
+          minInterval: 12 * 60 * 60 * 1000, // 12 hours
+        })
+      } catch {
+        // Not supported or permission denied — ignore.
+      }
+    }
+
     const register = () => {
       navigator.serviceWorker
         .register('/sw.js', { scope: '/' })
         .then((registration) => {
           watchRegistration(registration)
+          requestPeriodicSync(registration)
         })
         .catch((err) => {
           // Swallow — SW registration failure must never break the app.

--- a/src/lib/pwa/prefetch-cache.ts
+++ b/src/lib/pwa/prefetch-cache.ts
@@ -1,0 +1,32 @@
+const PREFETCH_CACHE = 'mp-prefetch-v1'
+
+export interface PrefetchedProduct {
+  id: string
+  name: string
+  slug: string
+  price: number
+  unit: string
+  images: string[]
+  vendorName: string
+  vendorSlug: string
+}
+
+/**
+ * Reads the catalog prefetch cache populated by the periodic background
+ * sync in the SW. Returns null when the cache is empty or on any error
+ * (unsupported browser, no SW, cache miss). The caller should always
+ * fall back to a fresh network fetch.
+ */
+export async function readPrefetchedCatalog(): Promise<PrefetchedProduct[] | null> {
+  if (typeof caches === 'undefined') return null
+
+  try {
+    const cache = await caches.open(PREFETCH_CACHE)
+    const response = await cache.match('/api/catalog/featured?limit=12')
+    if (!response) return null
+    const data: PrefetchedProduct[] = await response.json()
+    return data
+  } catch {
+    return null
+  }
+}

--- a/test/features/periodic-sync.test.ts
+++ b/test/features/periodic-sync.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// ── Prefetch cache reader tests ──────────────────────────────────────────
+// We can't test the actual CacheStorage API in Node, but we can test the
+// readPrefetchedCatalog function handles the "no caches" case gracefully.
+
+test('readPrefetchedCatalog: returns null when CacheStorage is undefined', async () => {
+  // In Node there is no global `caches`, so the function should degrade.
+  const { readPrefetchedCatalog } = await import('@/lib/pwa/prefetch-cache')
+  const result = await readPrefetchedCatalog()
+  assert.equal(result, null)
+})
+
+// ── SW periodic sync tag constant coherence ──────────────────────────────
+// Ensures the SW and the client agree on the sync tag.
+
+test('periodic sync tag is consistent between SW comment and PwaRegister', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const swPath = path.join(process.cwd(), 'public/sw.js')
+  const swContent = fs.readFileSync(swPath, 'utf-8')
+
+  // SW defines the tag as a constant.
+  assert.ok(swContent.includes("'mp-catalog-prefetch'"), 'SW must reference mp-catalog-prefetch tag')
+
+  // PwaRegister references the same tag when requesting periodic sync.
+  const registerPath = path.join(process.cwd(), 'src/components/pwa/PwaRegister.tsx')
+  const registerContent = fs.readFileSync(registerPath, 'utf-8')
+  assert.ok(
+    registerContent.includes("'mp-catalog-prefetch'"),
+    'PwaRegister must reference the same mp-catalog-prefetch tag'
+  )
+})
+
+// ── SW respects data saver ───────────────────────────────────────────────
+
+test('SW periodic sync handler references navigator.connection.saveData', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const swPath = path.join(process.cwd(), 'public/sw.js')
+  const swContent = fs.readFileSync(swPath, 'utf-8')
+
+  assert.ok(swContent.includes('conn.saveData'), 'SW must respect saveData flag')
+  assert.ok(swContent.includes("conn.effectiveType === 'slow-2g'"), 'SW must check for slow-2g')
+  assert.ok(swContent.includes("conn.effectiveType === '2g'"), 'SW must check for 2g')
+})
+
+// ── API route returns compact payload shape ──────────────────────────────
+
+test('featured API route file exists', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const routePath = path.join(process.cwd(), 'src/app/api/catalog/featured/route.ts')
+  assert.ok(fs.existsSync(routePath), 'API route for catalog featured must exist')
+})
+
+// ── SW version bumped ────────────────────────────────────────────────────
+
+test('SW version is mp-sw-v4 after periodic sync addition', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const swPath = path.join(process.cwd(), 'public/sw.js')
+  const swContent = fs.readFileSync(swPath, 'utf-8')
+
+  assert.ok(swContent.includes("'mp-sw-v4'"), 'SW version must be bumped to v4')
+})
+
+// ── Prefetch cache name matches SW ───────────────────────────────────────
+
+test('prefetch cache name is consistent between SW and prefetch-cache module', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const swPath = path.join(process.cwd(), 'public/sw.js')
+  const swContent = fs.readFileSync(swPath, 'utf-8')
+
+  const modulePath = path.join(process.cwd(), 'src/lib/pwa/prefetch-cache.ts')
+  const moduleContent = fs.readFileSync(modulePath, 'utf-8')
+
+  assert.ok(swContent.includes("'mp-prefetch-v1'"), 'SW must define mp-prefetch-v1')
+  assert.ok(moduleContent.includes("'mp-prefetch-v1'"), 'prefetch-cache module must use mp-prefetch-v1')
+})
+
+// ── Activate prunes unknown caches ───────────────────────────────────────
+
+test('SW activate allows the prefetch cache', async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+
+  const swPath = path.join(process.cwd(), 'public/sw.js')
+  const swContent = fs.readFileSync(swPath, 'utf-8')
+
+  // The allowed set in activate must include the prefetch cache.
+  assert.ok(swContent.includes('PREFETCH_CACHE'), 'SW activate must include PREFETCH_CACHE in allowed set')
+})


### PR DESCRIPTION
Closes #466

## Summary
- New `periodicsync` handler in `public/sw.js` with tag `mp-catalog-prefetch`
- Respects `navigator.connection.saveData` + `effectiveType` (aborts on save-data, slow-2g, 2g)
- Fetches `/api/catalog/featured?limit=12` into `mp-prefetch-v1` cache
- Posts `catalog-prefetched` message to open clients
- `PwaRegister` requests periodic sync permission (12h interval) after SW registration
- New lightweight API route `src/app/api/catalog/featured/route.ts`: compact JSON, `Cache-Control: public, s-maxage=300`
- `readPrefetchedCatalog()` client helper reads from cache with null fallback
- SW bumped to `mp-sw-v4`; `activate` prunes old caches, keeps `mp-prefetch-v1`

## Browser support
Chrome Android + desktop only. Safari/Firefox don't support Periodic Background Sync — the app simply loads fresh data on open (current behavior, zero degradation).

## Tests (7 new, 700/701 total)
- Cache reader degradation (no `caches` in Node)
- Tag coherence (SW ↔ PwaRegister)
- Data-saver guards in SW (saveData, slow-2g, 2g)
- API route file existence
- SW version bump to v4
- Cache name consistency (SW ↔ prefetch-cache module)
- Activate allow-list includes prefetch cache

## Test plan
- [x] `npm run typecheck` green
- [x] `npm run test:parallel` — 700/701 pass (baseline preserved)
- [ ] Chrome Android installed PWA: DevTools > Application > Periodic Sync shows `mp-catalog-prefetch`
- [ ] After sync fires: Cache Storage shows `mp-prefetch-v1` with catalog JSON
- [ ] `GET /api/catalog/featured?limit=12` returns compact JSON
- [ ] Safari/Firefox: no errors, no periodic sync registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)