### PR TITLE
security(payments): add amount verification to confirmOrder mock path

### DIFF
--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -27,7 +27,10 @@ import {
 import { getShippingCost } from '@/domains/shipping/calculator'
 import { getActionSession } from '@/lib/action-session'
 import { revalidateCatalogExperience, safeRevalidatePath } from '@/lib/revalidate'
-import { createPaymentConfirmedEventPayload } from '@/domains/orders/order-event-payload'
+import {
+  createPaymentConfirmedEventPayload,
+  createPaymentMismatchEventPayload,
+} from '@/domains/orders/order-event-payload'
 import {
   evaluatePromotions,
   type EvaluableCartLine,
@@ -766,6 +769,35 @@ export async function confirmOrder(orderId: string, providerRef: string) {
     providerRef: payment.providerRef,
     nextStatus: 'SUCCEEDED',
   })
+
+  // Defensive amount verification — symmetric with the webhook handler's
+  // doesWebhookPaymentMatchStoredPayment check. In mock mode the amount
+  // was computed server-side so this should never fire, but if confirmOrder
+  // is ever reused from another context the guard prevents confirming a
+  // Payment whose amount was tampered with between creation and confirmation.
+  const expectedAmountCents = Math.round(Number(payment.amount) * 100)
+  const orderGrandTotalCents = Math.round(Number(payment.order.grandTotal) * 100)
+  if (expectedAmountCents !== orderGrandTotalCents) {
+    console.error('[checkout][confirm][amount-mismatch]', {
+      orderId,
+      providerRef,
+      paymentAmount: Number(payment.amount),
+      orderGrandTotal: Number(payment.order.grandTotal),
+    })
+    await db.orderEvent.create({
+      data: {
+        orderId,
+        type: 'PAYMENT_MISMATCH',
+        payload: createPaymentMismatchEventPayload({
+          providerRef: providerRef ?? orderId,
+          amount: orderGrandTotalCents,
+          expectedAmount: Number(payment.amount),
+          expectedCurrency: payment.currency,
+        }),
+      },
+    })
+    throw new Error('La verificación del importe ha fallado. Contacta con soporte.')
+  }
 
   if (!shouldApplyPaymentSucceeded({
     paymentStatus: payment.status,

--- a/test/integration/confirm-order-amount.test.ts
+++ b/test/integration/confirm-order-amount.test.ts
@@ -1,0 +1,94 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createOrder, confirmOrder } from '@/domains/orders/actions'
+import { db } from '@/lib/db'
+import { resetServerEnvCache } from '@/lib/env'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Issue #418: confirmOrder (mock mode) must verify the Payment amount
+ * matches the Order grandTotal — symmetric with the webhook handler's
+ * doesWebhookPaymentMatchStoredPayment check.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { PAYMENT_PROVIDER: 'mock', NODE_ENV: 'test' })
+  resetServerEnvCache()
+})
+
+afterEach(() => {
+  clearTestSession()
+  resetServerEnvCache()
+})
+
+test('confirmOrder succeeds when amount matches (happy path)', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 15, stock: 10 })
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const result = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    {
+      address: { firstName: 'Test', lastName: 'OK', line1: 'Calle Mayor 10', city: 'Madrid', province: 'Madrid', postalCode: '28001' },
+      saveAddress: false,
+    }
+  )
+
+  const providerRef = result.clientSecret.replace('_secret', '')
+  await confirmOrder(result.orderId, providerRef)
+
+  const order = await db.order.findUnique({ where: { id: result.orderId } })
+  assert.equal(order?.status, 'PAYMENT_CONFIRMED')
+  assert.equal(order?.paymentStatus, 'SUCCEEDED')
+})
+
+test('confirmOrder rejects when Payment.amount is tampered (defensive mismatch)', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id, { basePrice: 20, stock: 10 })
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const result = await createOrder(
+    [{ productId: product.id, quantity: 1 }],
+    {
+      address: { firstName: 'Test', lastName: 'Tamper', line1: 'Calle Mayor 10', city: 'Madrid', province: 'Madrid', postalCode: '28001' },
+      saveAddress: false,
+    }
+  )
+
+  // Simulate amount tampering: mutate the Payment row's amount AFTER
+  // creation but BEFORE confirmation. In production this could only
+  // happen through a DB injection or a bug in another code path.
+  const payment = await db.payment.findFirst({ where: { orderId: result.orderId } })
+  assert.ok(payment)
+  await db.payment.update({
+    where: { id: payment.id },
+    data: { amount: 0.01 },
+  })
+
+  const providerRef = result.clientSecret.replace('_secret', '')
+  await assert.rejects(
+    () => confirmOrder(result.orderId, providerRef),
+    /verificaci[óo]n del importe/i
+  )
+
+  // Order must NOT be confirmed
+  const order = await db.order.findUnique({ where: { id: result.orderId } })
+  assert.equal(order?.paymentStatus, 'PENDING')
+
+  // A PAYMENT_MISMATCH event must be recorded
+  const events = await db.orderEvent.findMany({
+    where: { orderId: result.orderId, type: 'PAYMENT_MISMATCH' },
+  })
+  assert.equal(events.length, 1)
+})


### PR DESCRIPTION
## Summary

Closes #418. `confirmOrder` (the mock-mode payment confirmation) now verifies the `Payment.amount` matches `Order.grandTotal` before marking as SUCCEEDED — symmetric with the webhook handler's `doesWebhookPaymentMatchStoredPayment` check.

## Problem

The webhook handler at [src/app/api/webhooks/stripe/route.ts:195-230](src/app/api/webhooks/stripe/route.ts#L195-L230) verifies the Stripe event amount matches the stored Payment amount and blocks confirmation on mismatch (PAYMENT_FRAUD_ALERT). `confirmOrder` skipped this check entirely — it only verified ownership and `providerRef`. If `confirmOrder` were ever reused from another context or if a bug manipulated the Payment row, the mismatch would be silently confirmed.

## Fix

Compare `Payment.amount` (cents) against `Order.grandTotal` (cents) before `shouldApplyPaymentSucceeded`. On mismatch:
- Log at error level with both amounts
- Emit `PAYMENT_MISMATCH` OrderEvent (same type the webhook uses)
- Throw with a user-facing message

## Tests

[test/integration/confirm-order-amount.test.ts](test/integration/confirm-order-amount.test.ts) — 2 tests:
- Happy path: amount matches → order confirmed normally
- Tampered amount: mutate `Payment.amount` post-creation → confirmOrder throws, order stays `PENDING`, `PAYMENT_MISMATCH` event emitted

## Risk / rollback

Low. Additive guard. In mock mode the amounts always match (both computed server-side). Revert is a single PR revert.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)