### PR TITLE
feat(obs): add PII redaction helper to structured logger

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -118,6 +118,47 @@ export interface Logger {
   error: (scope: string, messageOrContext?: string | LogContext, context?: LogContext) => void
 }
 
+// ─── PII redaction ───────────────────────────────────────────────────────────
+
+const DEFAULT_REDACT_KEYS = new Set([
+  'password',
+  'token',
+  'cookie',
+  'authorization',
+  'cardnumber',
+  'cvv',
+  'secret',
+  'client_secret',
+  'clientsecret',
+  'stripe_secret',
+  'stripesecretkey',
+  'webhook_secret',
+])
+
+/**
+ * Shallow-redact sensitive keys from a context object. Keys are matched
+ * case-insensitively against a built-in set (password, token, cookie,
+ * authorization, card*, cvv, secret, etc.). Returns a new object — the
+ * original is never mutated.
+ *
+ * Usage:
+ *   logger.info('scope', redact({ password: 'x', name: 'a' }))
+ *   // → { password: '[REDACTED]', name: 'a' }
+ */
+export function redact(
+  context: LogContext,
+  extraKeys?: readonly string[]
+): LogContext {
+  const sensitiveKeys = extraKeys
+    ? new Set([...DEFAULT_REDACT_KEYS, ...extraKeys.map(k => k.toLowerCase())])
+    : DEFAULT_REDACT_KEYS
+  const out: LogContext = {}
+  for (const [key, value] of Object.entries(context)) {
+    out[key] = sensitiveKeys.has(key.toLowerCase()) ? '[REDACTED]' : value
+  }
+  return out
+}
+
 export const logger: Logger = {
   debug: (scope, message, context) => writeEntry(buildLogEntry('debug', scope, message, context)),
   info: (scope, message, context) => writeEntry(buildLogEntry('info', scope, message, context)),

--- a/test/features/logger.test.ts
+++ b/test/features/logger.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { buildLogEntry, serializeContext } from '@/lib/logger'
+import { buildLogEntry, serializeContext, redact } from '@/lib/logger'
 
 test('buildLogEntry captures level, scope and ISO timestamp', () => {
   const entry = buildLogEntry('info', 'stripe-webhook', 'received')
@@ -39,4 +39,39 @@ test('serializeContext preserves primitive and plain-object values untouched', (
 test('buildLogEntry omits context when none is provided', () => {
   const entry = buildLogEntry('debug', 'noop', 'ping')
   assert.equal('context' in entry, false)
+})
+
+test('redact replaces default sensitive keys with [REDACTED]', () => {
+  const input = {
+    password: 'hunter2',
+    token: 'jwt_abc',
+    name: 'visible',
+    orderId: 'o-1',
+    authorization: 'Bearer xxx',
+    cardNumber: 'hidden',
+    CVV: '123',
+  }
+  const result = redact(input)
+  assert.equal(result.password, '[REDACTED]')
+  assert.equal(result.token, '[REDACTED]')
+  assert.equal(result.authorization, '[REDACTED]')
+  assert.equal(result.cardNumber, '[REDACTED]')
+  assert.equal(result.CVV, '[REDACTED]')
+  assert.equal(result.name, 'visible')
+  assert.equal(result.orderId, 'o-1')
+})
+
+test('redact accepts extra custom keys', () => {
+  const result = redact({ email: 'a@b.com', phone: '12345', city: 'Madrid' }, ['email', 'phone'])
+  assert.equal(result.email, '[REDACTED]')
+  assert.equal(result.phone, '[REDACTED]')
+  assert.equal(result.city, 'Madrid')
+})
+
+test('redact does not mutate the original object', () => {
+  const input = { password: 'secret', name: 'ok' }
+  const result = redact(input)
+  assert.notEqual(result, input)
+  assert.equal(input.password, 'secret')
+  assert.equal(result.password, '[REDACTED]')
 })


### PR DESCRIPTION
## Summary

Closes #413. The structured logger ([src/lib/logger.ts](src/lib/logger.ts)) already existed with JSON serialization, Error flattening, level filtering, and 6 tests. The missing piece was PII redaction — this PR adds it.

## Changes

- `src/lib/logger.ts` — new `redact(context, extraKeys?)` export. Shallow-redacts sensitive keys (password, token, cookie, authorization, cardNumber, cvv, secret, client_secret, webhook_secret, etc.) to `'[REDACTED]'`. Case-insensitive matching. Returns a new object (never mutates). Accepts optional extra keys array for call-site-specific fields.
- `test/features/logger.test.ts` — 3 new tests (total 9):
  - default keys redacted
  - extra custom keys redacted
  - original object not mutated

## Usage (for sub-issues #414, #415)

```ts
import { logger, redact } from '@/lib/logger'

logger.info('checkout.committed', redact({
  orderId,
  grandTotal,
  userId,
  clientSecret, // redacted automatically (matches 'secret' substring? No — exact key match)
}))
```

Note: `redact` matches on exact key names (case-insensitive), not substrings. `clientSecret` would NOT be redacted by default — add it explicitly via `redact(ctx, ['clientSecret'])` if needed, or name the key `client_secret` which IS in the default set.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx tsx --test test/features/logger.test.ts` — 9/9 pass
- [ ] Full CI on PR

## Risk / rollback

Trivial. Additive export + tests. No runtime behaviour change. Revert is a single PR revert.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)