### PR TITLE
chore(ci): unblock main after analytics PR (#457)

### DIFF
--- a/test/contracts/i18n-no-hardcoded-literals.test.ts
+++ b/test/contracts/i18n-no-hardcoded-literals.test.ts
@@ -50,6 +50,7 @@ const ALLOWLIST_FILES: ReadonlySet<string> = new Set([
   // remove the entry from this set.
   //
   // Admin surfaces — internal-facing, not localized yet.
+  'src/app/(admin)/admin/analytics/page.tsx',
   'src/app/(admin)/admin/auditoria/page.tsx',
   'src/app/(admin)/admin/comisiones/page.tsx',
   'src/app/(admin)/admin/configuracion/page.tsx',

--- a/test/features/navigation.test.ts
+++ b/test/features/navigation.test.ts
@@ -12,7 +12,7 @@ import {
 test('navigation helpers split available and upcoming sections correctly', () => {
   assert.equal(getAvailableNavItems(vendorNavItems).length, 8)
   assert.equal(getUpcomingNavItems(vendorNavItems).length, 0)
-  assert.equal(getAvailableNavItems(adminNavItems).length, 13)
+  assert.equal(getAvailableNavItems(adminNavItems).length, 14)
   assert.equal(getUpcomingNavItems(adminNavItems).length, 0)
 })
 


### PR DESCRIPTION
## Summary

CI has been red on every open PR since [#457 feat(analytics): integrate PostHog alongside GA4](https://github.com/juanmixto/marketplace/pull/457) merged. Two pre-existing tests expected the old state of the admin surfaces:

1. `test/contracts/i18n-no-hardcoded-literals.test.ts` flags `src/app/(admin)/admin/analytics/page.tsx` (new file added by #457) for hardcoded user-facing literals.
2. `test/features/navigation.test.ts` asserts `adminNavItems` has 13 items; #457 added a new entry, bumping it to 14.

## Changes

- `test/contracts/i18n-no-hardcoded-literals.test.ts` — add the analytics page to `ALLOWLIST_FILES`, matching the convention for other admin-only internal surfaces ("not localized yet").
- `test/features/navigation.test.ts` — bump expected admin nav count 13 → 14.

## Follow-up (out of scope)

Migrate `src/app/(admin)/admin/analytics/page.tsx` literals to `useT()` / `getServerT()` and remove the allowlist entry.

## Test plan

- [x] `npx tsx --test test/contracts/i18n-no-hardcoded-literals.test.ts test/features/navigation.test.ts` — 7/7 pass
- [ ] Full CI on PR

## Risk / rollback

Trivial. Two one-line test updates. Revert is a single PR revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)