### PR TITLE
fix(prisma): prevent generated-client drift + regression tests

### DIFF
--- a/test/integration/database-constraints.test.ts
+++ b/test/integration/database-constraints.test.ts
@@ -64,3 +64,65 @@ test('Vendor.stripeAccountId must be unique when present', async () => {
     error => isConstraintError(error, /stripeAccountId|unique/i)
   )
 })
+
+test('SubscriptionPlan: productId_cadence compound unique is reachable at runtime', async () => {
+  // Regression guard: the generated Prisma client must expose the
+  // `productId_cadence` compound key that `createSubscriptionPlan`
+  // relies on for its cadence-aware duplicate check. A drift between
+  // schema and generated client (stale `src/generated/prisma/` from a
+  // prior Prisma version / missing `prisma generate` after a migration)
+  // used to surface as a runtime "Unknown argument productId_cadence"
+  // on /vendor/suscripciones/nueva.
+  const result = await db.subscriptionPlan.findUnique({
+    where: {
+      productId_cadence: {
+        productId: 'nonexistent-product-id',
+        cadence: 'WEEKLY',
+      },
+    },
+    select: { id: true },
+  })
+  // Null is the happy path — the important thing is that the query was
+  // accepted by the Prisma validator. A regression surfaces as a thrown
+  // PrismaClientValidationError, not as null.
+  assert.equal(result, null)
+})
+
+test('SubscriptionPlan: @@unique([productId, cadence]) is enforced by the DB', async () => {
+  const vendor = await createVendor()
+  const product = await db.product.create({
+    data: {
+      vendorId: vendor.id,
+      slug: `plan-test-${randomUUID().slice(0, 8)}`,
+      name: 'Plan test product',
+      basePrice: 10,
+      taxRate: 0.1,
+      unit: 'unidad',
+      stock: 100,
+      trackStock: true,
+      status: 'ACTIVE',
+    },
+  })
+
+  const base = {
+    vendorId: vendor.id,
+    productId: product.id,
+    cadence: 'WEEKLY' as const,
+    priceSnapshot: 10,
+    taxRateSnapshot: 0.1,
+    cutoffDayOfWeek: 5,
+  }
+
+  await db.subscriptionPlan.create({ data: base })
+
+  // Same (productId, cadence) must fail — either via P2002 at the DB
+  // level or the pre-check error from createSubscriptionPlan when the
+  // app-layer guard runs first. Different cadences must still succeed.
+  await assert.rejects(
+    () => db.subscriptionPlan.create({ data: base }),
+    error => isConstraintError(error, /productId|cadence|unique/i),
+  )
+  await assert.doesNotReject(
+    () => db.subscriptionPlan.create({ data: { ...base, cadence: 'MONTHLY' } }),
+  )
+})


### PR DESCRIPTION
## Problem
Creating a subscription plan at \`/vendor/suscripciones/nueva\` threw:
\`\`\`
Invalid db.subscriptionPlan.findUnique(): Unknown argument productId_cadence
\`\`\`

Root cause: the generated Prisma client at \`src/generated/prisma/\` was stale relative to \`prisma/schema.prisma\`. The \`@@unique([productId, cadence])\` constraint existed in schema + DB, but the local client had been generated before it landed. Any contributor who pulled without running \`prisma generate\` (or CI runner that skipped it) would hit this at runtime — the TypeScript types were correct, so typecheck passed, but the runtime engine rejected the compound key.

## Fix
1. **\`package.json\`** — add \`postinstall\`, \`predev\`, and \`prebuild\` scripts that run \`prisma generate\`. Industry-standard pattern; the generated client now always matches the schema after \`npm install\`, \`npm run dev\`, or \`npm run build\`.
2. **\`test/integration/database-constraints.test.ts\`** — two regression tests:
   - **Runtime shape**: \`findUnique({ where: { productId_cadence: ... } })\` must not throw. Fails loudly as soon as the generated client regresses against the schema, without needing a real product row.
   - **DB enforcement**: duplicate \`(productId, cadence)\` insert throws P2002; same product with a different cadence still succeeds.

## Test plan
- [x] Run \`node --test test/integration/database-constraints.test.ts\` locally → both new tests pass (\`ok 3\`, \`ok 4\`)
- [x] \`/vendor/suscripciones/nueva\` no longer throws on form submit after fresh \`npm install\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)