### PR TITLE
chore(env): pull UPSTASH/RESEND/EMAIL_FROM/SENDCLOUD into typed env loader

### DIFF
--- a/src/app/api/webhooks/sendcloud/route.ts
+++ b/src/app/api/webhooks/sendcloud/route.ts
@@ -5,6 +5,7 @@ import {
   type SendcloudWebhookPayload,
 } from '@/domains/shipping/webhooks/sendcloud'
 import { ensureShippingProvidersRegistered } from '@/domains/shipping/providers'
+import { getServerEnv } from '@/lib/env'
 
 /**
  * Sendcloud parcel-status webhook.
@@ -16,7 +17,7 @@ import { ensureShippingProvidersRegistered } from '@/domains/shipping/providers'
 export async function POST(req: NextRequest) {
   ensureShippingProvidersRegistered()
 
-  const secret = process.env.SENDCLOUD_WEBHOOK_SECRET
+  const secret = getServerEnv().sendcloudWebhookSecret
   if (!secret) {
     console.error('[sendcloud-webhook] missing SENDCLOUD_WEBHOOK_SECRET')
     return NextResponse.json({ error: 'not_configured' }, { status: 503 })

--- a/src/domains/shipping/providers/sendcloud/config.ts
+++ b/src/domains/shipping/providers/sendcloud/config.ts
@@ -1,3 +1,5 @@
+import { getServerEnv } from '@/lib/env'
+
 export interface SendcloudConfig {
   baseUrl: string
   publicKey: string
@@ -6,28 +8,20 @@ export interface SendcloudConfig {
   webhookSecret: string
 }
 
-function requireEnv(name: string): string {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing env: ${name}`)
-  return value
-}
-
 export function loadSendcloudConfig(): SendcloudConfig {
+  const env = getServerEnv()
+  if (!env.sendcloudConfigured) {
+    throw new Error('Sendcloud is not configured; set SENDCLOUD_PUBLIC_KEY, SENDCLOUD_SECRET_KEY and SENDCLOUD_WEBHOOK_SECRET')
+  }
   return {
-    baseUrl: process.env.SENDCLOUD_BASE_URL ?? 'https://panel.sendcloud.sc/api/v2',
-    publicKey: requireEnv('SENDCLOUD_PUBLIC_KEY'),
-    secretKey: requireEnv('SENDCLOUD_SECRET_KEY'),
-    defaultSenderId: process.env.SENDCLOUD_SENDER_ID
-      ? Number(process.env.SENDCLOUD_SENDER_ID)
-      : null,
-    webhookSecret: requireEnv('SENDCLOUD_WEBHOOK_SECRET'),
+    baseUrl: env.sendcloudBaseUrl,
+    publicKey: env.sendcloudPublicKey!,
+    secretKey: env.sendcloudSecretKey!,
+    defaultSenderId: env.sendcloudSenderId,
+    webhookSecret: env.sendcloudWebhookSecret!,
   }
 }
 
 export function isSendcloudConfigured(): boolean {
-  return Boolean(
-    process.env.SENDCLOUD_PUBLIC_KEY &&
-      process.env.SENDCLOUD_SECRET_KEY &&
-      process.env.SENDCLOUD_WEBHOOK_SECRET,
-  )
+  return getServerEnv().sendcloudConfigured
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,11 +4,12 @@
  */
 
 import { Resend } from 'resend'
+import { getServerEnv } from '@/lib/env'
 
 let resend: Resend | null = null
 
 function getResendClient() {
-  const apiKey = process.env.RESEND_API_KEY
+  const apiKey = getServerEnv().resendApiKey
 
   if (!apiKey) {
     return null
@@ -39,7 +40,7 @@ export async function sendEmail({
 
   try {
     const result = await client.emails.send({
-      from: process.env.EMAIL_FROM || 'no-reply@example.com',
+      from: getServerEnv().emailFrom,
       to,
       subject,
       react,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -20,6 +20,20 @@ const baseEnvSchema = z.object({
   // a disabled banner. Flip to 'true' in staging once Stripe Subscriptions
   // are wired in phase 4b.
   SUBSCRIPTIONS_BUYER_BETA: z.enum(['true', 'false']).default('false'),
+  // Email — Resend
+  RESEND_API_KEY: z.string().min(1).optional(),
+  EMAIL_FROM: z.string().min(1).default('no-reply@example.com'),
+  // Rate limiting — Upstash Redis. Presence of REST_URL flips ratelimit
+  // from the in-memory store to Upstash; TOKEN is then required.
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
+  // Shipping — Sendcloud. The three credential fields are required as
+  // a bundle: presence of any one without the others throws at boot.
+  SENDCLOUD_BASE_URL: z.string().url().default('https://panel.sendcloud.sc/api/v2'),
+  SENDCLOUD_PUBLIC_KEY: z.string().min(1).optional(),
+  SENDCLOUD_SECRET_KEY: z.string().min(1).optional(),
+  SENDCLOUD_WEBHOOK_SECRET: z.string().min(1).optional(),
+  SENDCLOUD_SENDER_ID: z.coerce.number().int().positive().optional(),
 })
 
 export function parseServerEnv(env: NodeJS.ProcessEnv) {
@@ -40,6 +54,28 @@ export function parseServerEnv(env: NodeJS.ProcessEnv) {
     }
   }
 
+  if (parsed.UPSTASH_REDIS_REST_URL && !parsed.UPSTASH_REDIS_REST_TOKEN) {
+    throw new Error(
+      'UPSTASH_REDIS_REST_URL is set but UPSTASH_REDIS_REST_TOKEN is missing'
+    )
+  }
+
+  const sendcloudCredFields = [
+    'SENDCLOUD_PUBLIC_KEY',
+    'SENDCLOUD_SECRET_KEY',
+    'SENDCLOUD_WEBHOOK_SECRET',
+  ] as const
+  const sendcloudPresent = sendcloudCredFields.filter(key => Boolean(parsed[key]))
+  if (sendcloudPresent.length > 0 && sendcloudPresent.length < sendcloudCredFields.length) {
+    const missing = sendcloudCredFields.filter(key => !parsed[key])
+    throw new Error(
+      `Sendcloud requires all of ${sendcloudCredFields.join(', ')}; missing: ${missing.join(', ')}`
+    )
+  }
+
+  const sendcloudConfigured =
+    sendcloudPresent.length === sendcloudCredFields.length
+
   return {
     databaseUrl: env.NODE_ENV === 'test' && parsed.DATABASE_URL_TEST
       ? parsed.DATABASE_URL_TEST
@@ -53,6 +89,16 @@ export function parseServerEnv(env: NodeJS.ProcessEnv) {
     stripePublishableKey: parsed.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
     contactEmail: parsed.CONTACT_EMAIL,
     subscriptionsBuyerBeta: parsed.SUBSCRIPTIONS_BUYER_BETA === 'true',
+    resendApiKey: parsed.RESEND_API_KEY,
+    emailFrom: parsed.EMAIL_FROM,
+    upstashRedisRestUrl: parsed.UPSTASH_REDIS_REST_URL,
+    upstashRedisRestToken: parsed.UPSTASH_REDIS_REST_TOKEN,
+    sendcloudBaseUrl: parsed.SENDCLOUD_BASE_URL,
+    sendcloudPublicKey: parsed.SENDCLOUD_PUBLIC_KEY,
+    sendcloudSecretKey: parsed.SENDCLOUD_SECRET_KEY,
+    sendcloudWebhookSecret: parsed.SENDCLOUD_WEBHOOK_SECRET,
+    sendcloudSenderId: parsed.SENDCLOUD_SENDER_ID ?? null,
+    sendcloudConfigured,
   }
 }
 

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -17,6 +17,8 @@
  *   `success: false` instead of an open door.
  */
 
+import { getServerEnv } from '@/lib/env'
+
 interface RateLimitEntry {
   count: number
   resetAt: number
@@ -83,7 +85,7 @@ export async function checkRateLimit(
   const limitKey = `${action}:${cleanKey}`
   const now = Date.now()
 
-  if (process.env.UPSTASH_REDIS_REST_URL) {
+  if (getServerEnv().upstashRedisRestUrl) {
     return checkRateLimitUpstash(action, limitKey, limit, windowSeconds, now, options)
   }
 
@@ -172,13 +174,14 @@ async function checkRateLimitUpstash(
   now: number,
   options: RateLimitOptions
 ): Promise<RateLimitResult> {
+  const env = getServerEnv()
   try {
     const response = await fetch(
-      `${process.env.UPSTASH_REDIS_REST_URL}/incr/${limitKey}`,
+      `${env.upstashRedisRestUrl}/incr/${limitKey}`,
       {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+          Authorization: `Bearer ${env.upstashRedisRestToken}`,
           'Content-Type': 'application/json',
         },
       }
@@ -201,11 +204,11 @@ async function checkRateLimitUpstash(
     // Set expiry on first request
     if (count === 1) {
       await fetch(
-        `${process.env.UPSTASH_REDIS_REST_URL}/expire/${limitKey}/${windowSeconds}`,
+        `${env.upstashRedisRestUrl}/expire/${limitKey}/${windowSeconds}`,
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+            Authorization: `Bearer ${env.upstashRedisRestToken}`,
           },
         }
       ).catch(() => undefined)

--- a/test/features/ratelimit.test.ts
+++ b/test/features/ratelimit.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
+import { resetServerEnvCache } from '@/lib/env'
 
 test('checkRateLimit allows requests under limit and tracks remaining', async () => {
   const result1 = await checkRateLimit('rl-test-1', '10.0.0.1', 3, 60)
@@ -150,6 +151,7 @@ test('checkRateLimit uses Upstash when UPSTASH_REDIS_REST_URL is set', async () 
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  resetServerEnvCache()
 
   let fetchCallCount = 0
 
@@ -185,6 +187,7 @@ test('checkRateLimit uses Upstash when UPSTASH_REDIS_REST_URL is set', async () 
     } else {
       process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
     }
+    resetServerEnvCache()
   }
 })
 
@@ -195,6 +198,7 @@ test('checkRateLimit Upstash path returns failure when count exceeds limit', asy
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  resetServerEnvCache()
 
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString()
@@ -223,6 +227,7 @@ test('checkRateLimit Upstash path returns failure when count exceeds limit', asy
     } else {
       process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
     }
+    resetServerEnvCache()
   }
 })
 
@@ -235,6 +240,7 @@ test('checkRateLimit Upstash path degrades to in-memory fallback when Redis retu
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  resetServerEnvCache()
   console.error = () => undefined
   console.warn = () => undefined
 
@@ -269,6 +275,7 @@ test('checkRateLimit Upstash path degrades to in-memory fallback when Redis retu
     } else {
       process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
     }
+    resetServerEnvCache()
   }
 })
 
@@ -281,6 +288,7 @@ test('checkRateLimit Upstash path fails CLOSED for auth callers when fetch throw
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  resetServerEnvCache()
   console.error = () => undefined
   console.warn = () => undefined
 
@@ -308,6 +316,7 @@ test('checkRateLimit Upstash path fails CLOSED for auth callers when fetch throw
     } else {
       process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
     }
+    resetServerEnvCache()
   }
 })
 
@@ -320,6 +329,7 @@ test('checkRateLimit Upstash path fails CLOSED on malformed response for auth ca
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.example.com'
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token'
+  resetServerEnvCache()
   console.error = () => undefined
   console.warn = () => undefined
 
@@ -345,6 +355,7 @@ test('checkRateLimit Upstash path fails CLOSED on malformed response for auth ca
     } else {
       process.env.UPSTASH_REDIS_REST_TOKEN = originalToken
     }
+    resetServerEnvCache()
   }
 })
 


### PR DESCRIPTION
## Summary

**Fase 2 of the contract-hardening initiative.** Brings the four remaining integration env vars under the Zod-validated `getServerEnv()` so misconfig fails at boot, not at the first request.

- `src/lib/env.ts`: schema gains `RESEND_API_KEY`, `EMAIL_FROM`, `UPSTASH_REDIS_REST_{URL,TOKEN}`, `SENDCLOUD_*` (BASE_URL, PUBLIC_KEY, SECRET_KEY, WEBHOOK_SECRET, SENDER_ID coerced to int).
- Two conditional guards mirror the existing `PAYMENT_PROVIDER=stripe` pattern: presence of `UPSTASH_REDIS_REST_URL` requires `_TOKEN`; partial Sendcloud credentials throw with the missing fields named.
- `src/lib/email.ts`, `src/lib/ratelimit.ts`, `src/domains/shipping/providers/sendcloud/config.ts`, `src/app/api/webhooks/sendcloud/route.ts`: read from `getServerEnv()` instead of `process.env.*` directly. Sendcloud helpers (`loadSendcloudConfig`, `isSendcloudConfigured`) keep the same external surface.
- `test/features/ratelimit.test.ts`: 5 Upstash-path tests mutate `process.env` at runtime; added `resetServerEnvCache()` calls so the cached env picks up new values.

## Why now

A typo in `SENDCLOUD_WEBHOOK_SECRET` or a forgotten `RESEND_API_KEY` previously surfaced as a confusing webhook 503 or a silent email skip. With the loader as the single source, it surfaces at the first `getServerEnv()` call (typically during Next.js boot).

## Test plan

- [x] `npm run typecheck:app` exits 0 locally
- [x] `npm run typecheck:test` exits 0 locally
- [x] `npm test` passes 743/743 with `DATABASE_URL` set
- [x] `Grep "process\.env\.(UPSTASH|RESEND|EMAIL_FROM|SENDCLOUD)" src/` returns no matches

## Notes for reviewers

- After Phase 1 (#478) merges to main, this PR's CI will also run the new lint gate.
- The 5 ratelimit Upstash tests now require `resetServerEnvCache()` after each `process.env` mutation — pattern is repeated identically; could be extracted later but kept inline for review clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)