### PR TITLE
chore(infra): add CODEOWNERS + noUncheckedIndexedAccess dry-run config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,53 @@
+# CODEOWNERS — load-bearing files that must not change without owner review.
+#
+# This file is read by GitHub when a PR touches a matching path: the listed
+# owners are auto-requested as reviewers. It only enforces blocking review
+# when the repo's branch protection rule requires reviews from CODEOWNERS
+# (Settings → Branches → main → Require review from CODEOWNERS).
+#
+# Phase 7 of the contract-hardening plan. Add specialized owners here as
+# the team grows. Globbing semantics:
+#   /path/file       — exact file
+#   /path/*          — direct children only
+#   /path/**         — recursive
+#
+# Last entry wins, so the catch-all default goes first.
+
+* @juanmixto
+
+# --- Database schema -------------------------------------------------------
+# Migrations and schema changes require a deliberate review because they
+# affect every running deployment and existing rows.
+/prisma/schema.prisma                       @juanmixto
+/prisma/migrations/**                       @juanmixto
+
+# --- Auth, env, API response envelope --------------------------------------
+# Single sources of truth that the rest of the app trusts blindly.
+/src/lib/env.ts                             @juanmixto
+/src/lib/auth.ts                            @juanmixto
+/src/lib/auth-config.ts                     @juanmixto
+/src/lib/auth-guard.ts                      @juanmixto
+/src/lib/action-session.ts                  @juanmixto
+/src/lib/api-response.ts                    @juanmixto
+
+# --- Shared contracts (created in Phase 5) ---------------------------------
+# Any change here propagates to every consumer; reviewer must verify
+# backwards-compat shims and snapshot version discriminants.
+/src/shared/**                              @juanmixto
+
+# --- Domain public surface (barrels from Phase 3) --------------------------
+# Internal files inside each domain are free to evolve; the index.ts is
+# the contract surface that other domains depend on.
+/src/domains/*/index.ts                     @juanmixto
+
+# --- Webhook entrypoints ---------------------------------------------------
+# Signature verification + dedupe lives here; bypass risk on edits.
+/src/app/api/webhooks/**                    @juanmixto
+
+# --- CI and infra ----------------------------------------------------------
+/.github/workflows/**                       @juanmixto
+/.github/CODEOWNERS                         @juanmixto
+/eslint.config.mjs                          @juanmixto
+/tsconfig.json                              @juanmixto
+/tsconfig.app.json                          @juanmixto
+/tsconfig.test.json                         @juanmixto

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -17,6 +17,19 @@ Last verified against `main`: 2026-04-15.
 - **Stripe v22** — Connect Express for vendors.
 - **Zod v4** — schema validation.
 
+### Strictness — current state and roadmap
+
+`tsconfig.json` enables `strict: true` plus `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters`. **`noUncheckedIndexedAccess` is intentionally OFF**.
+
+A dry-run with the flag on (Phase 7 of the contract-hardening plan, captured in `tsconfig.strict.json`) surfaces **45 type errors** concentrated in:
+
+- `src/domains/promotions/checkout.ts` — 10 errors around cart-line iteration that needs guard-or-throw.
+- `src/app/(buyer)/cuenta/suscripciones/nueva/page.tsx` — 10 errors around the optional `sample` variant.
+- `src/components/catalog/ProductImageGallery.tsx` — 6 errors around `images[index]` access.
+- `src/components/{ui/modal,vendor/VendorProductPreview,layout/Footer,…}` — the rest are scattered single-digit hits.
+
+The flag will be enabled in a follow-up PR after these sites are fixed. To re-run the dry-run: `npx tsc -p tsconfig.strict.json --noEmit`.
+
 ---
 
 ## Imports — the ones that bite

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  }
+}


### PR DESCRIPTION
## Summary

**Fase 7 of the contract-hardening initiative.** Locks down review on load-bearing files and captures the cost of the next strictness upgrade.

- **`.github/CODEOWNERS`** — catch-all to `@juanmixto` plus explicit ownership on:
  - `prisma/schema.prisma` + migrations
  - `src/lib/{env,auth,auth-config,auth-guard,action-session,api-response}.ts`
  - `src/shared/**` (slot for Phase 5)
  - `src/domains/*/index.ts` (the barrel surface from Phase 3)
  - `src/app/api/webhooks/**`
  - `.github/workflows/**`, `eslint.config.mjs`, all tsconfigs
- **`tsconfig.strict.json`** — extends `tsconfig.app.json` with `noUncheckedIndexedAccess: true`. Reproducible dry-run via `npx tsc -p tsconfig.strict.json --noEmit`.
- **`docs/conventions.md`** — new "Strictness — current state and roadmap" subsection records 45 dry-run errors concentrated in 5 files; schedules the flip for Phase 8.

## Why now

With multiple agents touching the repo, schema, env loader and webhook entrypoints needed an explicit reviewer — previously any agent could land changes without a second pair of eyes. The strictness dry-run unblocks the actual flip: **45 errors < the plan's 50-error threshold**, so Phase 8 is feasible as a single follow-up PR.

## ⚠️ Manual step for repo owner

CODEOWNERS only enforces blocking review when **"Require review from CODEOWNERS"** is enabled in GitHub Settings → Branches → `main` → Branch protection rules. That setting can't ship in code.

## Test plan

- [x] `npm run typecheck:app` exits 0
- [x] `npm run lint` exits 0
- [x] `npx tsc -p tsconfig.strict.json --noEmit` reports 45 errors (the dry-run baseline; the new tsconfig is opt-in)

## Strictness dry-run distribution

| File | Errors |
|------|--------|
| `src/domains/promotions/checkout.ts` | 10 |
| `src/app/(buyer)/cuenta/suscripciones/nueva/page.tsx` | 10 |
| `src/components/catalog/ProductImageGallery.tsx` | 6 |
| `src/components/{ui/modal,vendor/VendorProductPreview,layout/Footer,…}` | 19 (scattered) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)