### PR TITLE
chore(shared): version JSON snapshots + collapse ShippingProviderCode

### DIFF
--- a/src/domains/shipping/domain/types.ts
+++ b/src/domains/shipping/domain/types.ts
@@ -1,4 +1,7 @@
-export type ShippingProviderCode = 'SENDCLOUD'
+// Re-export the canonical Prisma enum so domain code keeps the same
+// import path while the source of truth lives in @/shared/types/shipping.
+import { ShippingProviderCode } from '@/shared/types/shipping'
+export { ShippingProviderCode }
 
 export interface PostalAddress {
   contactName: string

--- a/src/shared/types/shipping.ts
+++ b/src/shared/types/shipping.ts
@@ -1,0 +1,10 @@
+/**
+ * Single source of truth for the shipping-provider discriminator.
+ * Phase 5 of the contract-hardening plan.
+ *
+ * Previously this lived as a literal type ('SENDCLOUD') in
+ * src/domains/shipping/domain/types.ts AND as a Prisma enum at the same
+ * time, so adding a provider in one place silently diverged from the
+ * other. This re-export collapses them.
+ */
+export { ShippingProviderCode } from '@/generated/prisma/enums'

--- a/src/shared/types/snapshots.ts
+++ b/src/shared/types/snapshots.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod'
+
+/**
+ * Versioned JSON-snapshot schemas. Phase 5 of the contract-hardening plan.
+ *
+ * Snapshots are written into Prisma `Json` columns at order creation time
+ * (`OrderLine.productSnapshot`, `Order.shippingAddressSnapshot`) so that
+ * later edits to the source Product / Address rows do not retroactively
+ * change historical orders. The risk this file mitigates: silently adding
+ * a new field to a snapshot schema and reading old (now-incomplete) rows
+ * without realizing it.
+ *
+ * Every snapshot carries a `version: 1` discriminant. When we need a v2
+ * shape, we add a `v2Schema` with `version: z.literal(2)` and wrap the
+ * union with `z.discriminatedUnion('version', [v1Schema, v2Schema])`.
+ * The default on `version` keeps legacy rows (written before the
+ * discriminant existed) parseable as v1.
+ */
+
+const orderLineSnapshotV1Schema = z.object({
+  version: z.literal(1).default(1),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  slug: z.string().min(1),
+  images: z.array(z.string()),
+  unit: z.string().min(1),
+  vendorName: z.string().min(1),
+  variantName: z.string().nullable().optional(),
+})
+
+export const orderLineSnapshotSchema = orderLineSnapshotV1Schema
+
+export type OrderLineSnapshot = z.infer<typeof orderLineSnapshotSchema>
+
+const orderAddressSnapshotV1Schema = z.object({
+  version: z.literal(1).default(1),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  line1: z.string().min(1),
+  line2: z.string().nullable().optional(),
+  city: z.string().min(1),
+  province: z.string().min(1),
+  postalCode: z.string().min(1),
+  phone: z.string().nullable().optional(),
+})
+
+export const orderAddressSnapshotSchema = orderAddressSnapshotV1Schema
+
+export type OrderAddressSnapshot = z.infer<typeof orderAddressSnapshotSchema>
+
+export function parseOrderAddressSnapshot(payload: unknown): OrderAddressSnapshot | null {
+  const parsed = orderAddressSnapshotSchema.safeParse(payload)
+  return parsed.success ? parsed.data : null
+}
+
+export const paymentConfirmedEventPayloadSchema = z.object({
+  providerRef: z.string().min(1),
+  amount: z.number().int().nonnegative().optional(),
+  eventId: z.string().min(1).optional(),
+  source: z.string().min(1).optional(),
+})
+
+export type PaymentConfirmedEventPayload = z.infer<typeof paymentConfirmedEventPayloadSchema>
+
+export const paymentFailedEventPayloadSchema = z.object({
+  providerRef: z.string().min(1),
+  eventId: z.string().min(1).optional(),
+})
+
+export type PaymentFailedEventPayload = z.infer<typeof paymentFailedEventPayloadSchema>
+
+export const paymentMismatchEventPayloadSchema = z.object({
+  providerRef: z.string().min(1),
+  amount: z.number().int().nonnegative().optional(),
+  currency: z.string().min(1).optional(),
+  eventId: z.string().min(1).optional(),
+  expectedAmount: z.number().nonnegative(),
+  expectedCurrency: z.string().min(1),
+})
+
+export type PaymentMismatchEventPayload = z.infer<typeof paymentMismatchEventPayloadSchema>

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,58 +1,18 @@
-import { z } from 'zod'
-
-export const orderLineSnapshotSchema = z.object({
-  id: z.string().min(1),
-  name: z.string().min(1),
-  slug: z.string().min(1),
-  images: z.array(z.string()),
-  unit: z.string().min(1),
-  vendorName: z.string().min(1),
-  variantName: z.string().nullable().optional(),
-})
-
-export type OrderLineSnapshot = z.infer<typeof orderLineSnapshotSchema>
-
-export const orderAddressSnapshotSchema = z.object({
-  firstName: z.string().min(1),
-  lastName: z.string().min(1),
-  line1: z.string().min(1),
-  line2: z.string().nullable().optional(),
-  city: z.string().min(1),
-  province: z.string().min(1),
-  postalCode: z.string().min(1),
-  phone: z.string().nullable().optional(),
-})
-
-export type OrderAddressSnapshot = z.infer<typeof orderAddressSnapshotSchema>
-
-export function parseOrderAddressSnapshot(payload: unknown): OrderAddressSnapshot | null {
-  const parsed = orderAddressSnapshotSchema.safeParse(payload)
-  return parsed.success ? parsed.data : null
-}
-
-export const paymentConfirmedEventPayloadSchema = z.object({
-  providerRef: z.string().min(1),
-  amount: z.number().int().nonnegative().optional(),
-  eventId: z.string().min(1).optional(),
-  source: z.string().min(1).optional(),
-})
-
-export type PaymentConfirmedEventPayload = z.infer<typeof paymentConfirmedEventPayloadSchema>
-
-export const paymentFailedEventPayloadSchema = z.object({
-  providerRef: z.string().min(1),
-  eventId: z.string().min(1).optional(),
-})
-
-export type PaymentFailedEventPayload = z.infer<typeof paymentFailedEventPayloadSchema>
-
-export const paymentMismatchEventPayloadSchema = z.object({
-  providerRef: z.string().min(1),
-  amount: z.number().int().nonnegative().optional(),
-  currency: z.string().min(1).optional(),
-  eventId: z.string().min(1).optional(),
-  expectedAmount: z.number().nonnegative(),
-  expectedCurrency: z.string().min(1),
-})
-
-export type PaymentMismatchEventPayload = z.infer<typeof paymentMismatchEventPayloadSchema>
+/**
+ * Back-compat re-export. The canonical home of these schemas is
+ * src/shared/types/snapshots.ts (Phase 5 of contract-hardening).
+ * Existing imports of `@/types/order` keep working unchanged.
+ */
+export {
+  orderLineSnapshotSchema,
+  orderAddressSnapshotSchema,
+  parseOrderAddressSnapshot,
+  paymentConfirmedEventPayloadSchema,
+  paymentFailedEventPayloadSchema,
+  paymentMismatchEventPayloadSchema,
+  type OrderLineSnapshot,
+  type OrderAddressSnapshot,
+  type PaymentConfirmedEventPayload,
+  type PaymentFailedEventPayload,
+  type PaymentMismatchEventPayload,
+} from '@/shared/types/snapshots'

--- a/test/features/order-json-types.test.ts
+++ b/test/features/order-json-types.test.ts
@@ -20,6 +20,9 @@ test('parseOrderLineSnapshot returns typed snapshot for valid payloads', () => {
   })
 
   assert.deepEqual(snapshot, {
+    // Phase 5: snapshots carry a version discriminant; the schema's
+    // .default(1) backfills it for legacy rows missing the field.
+    version: 1,
     id: 'prod_123',
     name: 'Tomate rosa',
     slug: 'tomate-rosa',
@@ -125,6 +128,9 @@ test('parseOrderAddressSnapshot returns typed address for valid payloads', () =>
   })
 
   assert.deepEqual(snapshot, {
+    // Phase 5: snapshots carry a version discriminant; .default(1)
+    // backfills it on legacy rows.
+    version: 1,
     firstName: 'Ada',
     lastName: 'Lovelace',
     line1: 'Calle Mayor 1',

--- a/test/features/snapshot-versioning.test.ts
+++ b/test/features/snapshot-versioning.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  orderLineSnapshotSchema,
+  orderAddressSnapshotSchema,
+  parseOrderAddressSnapshot,
+} from '@/shared/types/snapshots'
+
+/**
+ * Phase 5 of the contract-hardening plan.
+ *
+ * Locks down the JSON-snapshot versioning behavior so a future v2
+ * schema can be introduced without breaking reads of v1 rows already
+ * sitting in the database.
+ */
+
+test('orderLineSnapshotSchema parses legacy rows (no version field) as v1', () => {
+  const legacy = {
+    id: 'prod_123',
+    name: 'Aceite de oliva',
+    slug: 'aceite-oliva',
+    images: ['/img/oil.jpg'],
+    unit: 'L',
+    vendorName: 'Olivar Andaluz',
+    variantName: '500ml',
+  }
+  const parsed = orderLineSnapshotSchema.parse(legacy)
+  assert.equal(parsed.version, 1)
+  assert.equal(parsed.id, 'prod_123')
+  assert.equal(parsed.variantName, '500ml')
+})
+
+test('orderLineSnapshotSchema parses explicit v1 rows (round-trip)', () => {
+  const v1 = {
+    version: 1 as const,
+    id: 'prod_456',
+    name: 'Queso curado',
+    slug: 'queso-curado',
+    images: [],
+    unit: 'kg',
+    vendorName: 'Quesería',
+  }
+  const parsed = orderLineSnapshotSchema.parse(v1)
+  assert.equal(parsed.version, 1)
+  assert.equal(parsed.images.length, 0)
+  assert.equal(parsed.variantName, undefined)
+})
+
+test('orderAddressSnapshotSchema parses legacy rows as v1', () => {
+  const legacy = {
+    firstName: 'Ana',
+    lastName: 'García',
+    line1: 'Calle Mayor 1',
+    city: 'Madrid',
+    province: 'Madrid',
+    postalCode: '28001',
+  }
+  const parsed = orderAddressSnapshotSchema.parse(legacy)
+  assert.equal(parsed.version, 1)
+  assert.equal(parsed.firstName, 'Ana')
+  assert.equal(parsed.line2, undefined)
+  assert.equal(parsed.phone, undefined)
+})
+
+test('parseOrderAddressSnapshot returns the parsed object on legacy rows', () => {
+  const legacy = {
+    firstName: 'Luis',
+    lastName: 'Soto',
+    line1: 'Av. de la Paz 12',
+    city: 'Sevilla',
+    province: 'Sevilla',
+    postalCode: '41001',
+  }
+  const parsed = parseOrderAddressSnapshot(legacy)
+  assert.ok(parsed)
+  assert.equal(parsed!.version, 1)
+})
+
+test('parseOrderAddressSnapshot returns null for malformed payloads', () => {
+  // Missing required field `city`.
+  const malformed = {
+    firstName: 'X',
+    lastName: 'Y',
+    line1: 'Z',
+    province: 'Madrid',
+    postalCode: '28001',
+  }
+  const parsed = parseOrderAddressSnapshot(malformed)
+  assert.equal(parsed, null)
+})
+
+test('snapshot schemas reject foreign version values', () => {
+  // A row written by a future v2 producer must not silently coerce to
+  // v1; the literal(1) on the v1 schema rejects anything that is not 1.
+  const futureRow = {
+    version: 2,
+    id: 'p',
+    name: 'p',
+    slug: 'p',
+    images: [],
+    unit: 'L',
+    vendorName: 'v',
+  }
+  const result = orderLineSnapshotSchema.safeParse(futureRow)
+  assert.equal(result.success, false)
+})

--- a/test/integration/order-create.test.ts
+++ b/test/integration/order-create.test.ts
@@ -91,6 +91,7 @@ test('createOrder stores a shipping address snapshot even when the address is no
 
   assert.equal(order?.addressId, null)
   assert.deepEqual(order?.shippingAddressSnapshot, {
+    version: 1,
     firstName: 'Ada',
     lastName: 'Lovelace',
     line1: 'Calle Mayor 1',
@@ -235,6 +236,7 @@ test('createOrder falls back to the submitted address when a saved address goes 
 
   assert.equal(order?.addressId, null)
   assert.deepEqual(order?.shippingAddressSnapshot, {
+    version: 1,
     firstName: 'Ada',
     lastName: 'Lovelace',
     line1: 'Calle Mayor 1',
@@ -300,6 +302,7 @@ test('createOrder ignores a stale submitted address when selectedAddressId resol
   assert.equal(order?.addressId, savedAddress.id)
   // The snapshot is built from the saved DB row, not the garbage payload.
   assert.deepEqual(order?.shippingAddressSnapshot, {
+    version: 1,
     firstName: 'Ada',
     lastName: 'Lovelace',
     line1: 'Calle Mayor 1',


### PR DESCRIPTION
## Summary

**Fase 5 of the contract-hardening initiative.** Introduces \`src/shared/\` for cross-domain types and adds a version discriminant to JSON-snapshot schemas so a future v2 shape lands without breaking reads of v1 rows already in the database.

- \`src/shared/types/snapshots.ts\` (new) — canonical home for \`orderLineSnapshotSchema\`, \`orderAddressSnapshotSchema\`, the three payment-event payload schemas, and \`parseOrderAddressSnapshot\`. Each snapshot now carries \`version: z.literal(1).default(1)\`: legacy rows backfill to v1, foreign \`version: 2\` fails parse instead of silently being misread.
- \`src/types/order.ts\` — back-compat re-export shim. Existing imports of \`@/types/order\` keep working unchanged.
- \`src/shared/types/shipping.ts\` (new) — re-exports \`ShippingProviderCode\` from the Prisma enum. Single source of truth.
- \`src/domains/shipping/domain/types.ts\` — drops the literal \`'SENDCLOUD'\` type and re-exports \`ShippingProviderCode\` through the new shared module.
- \`test/features/snapshot-versioning.test.ts\` (new) — 6 cases pinning the legacy-rows-parse-as-v1 behavior.
- \`test/features/order-json-types.test.ts\` — two existing \`deepEqual\` assertions updated to include \`version: 1\`.

## Why now

\`OrderLine.productSnapshot\` and \`Order.shippingAddressSnapshot\` are written at order creation time and read forever after. Without a discriminant, adding a field to the schema changes how legacy rows parse — silently. With it, every snapshot self-describes and the parse step catches a producer/reader version mismatch at IO time, not at "why does the order page render wrong" time.

## Out of scope (deliberately deferred)

- Consolidating \`CheckoutPageClient.tsx\`'s inline \`addressSchema\` with \`src/domains/orders/checkout.ts\`. The inline one has localized error messages and extra fields (\`saveAddress\`, \`selectedAddressId\`); reconciling it cleanly is its own follow-up PR.
- \`src/shared/types/cart.ts\` (CartItemInput extraction) and \`src/shared/types/profile.ts\` (unified profile schema) — kept narrow to focus on the snapshot hardening.

## Test plan

- [x] \`npm run lint\` exits 0
- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run typecheck:test\` exits 0
- [x] \`npm test\` passes 749/749 (6 new snapshot-versioning + baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)