### PR TITLE
docs(ai): contract enforcement for parallel agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This version has breaking changes — APIs, conventions, and file structure may 
 ## Conventions
 
 - **Project conventions (stack, imports, Prisma fields, server-action pattern)** — see [`docs/conventions.md`](docs/conventions.md). Read this before implementing any ticket.
+- **AI guidelines (contract rules, domain boundaries, enforcement)** — see [`docs/ai-guidelines.md`](docs/ai-guidelines.md). Rules for parallel agents. Enforced by [`scripts/audit-domain-contracts.mjs`](scripts/audit-domain-contracts.mjs).
+- **AI workflows (recipes)** — see [`docs/ai-workflows.md`](docs/ai-workflows.md) for how to add a feature, refactor safely, or change a contract.
 - **i18n** — see [`src/i18n/README.md`](src/i18n/README.md) for when to use flat keys vs `*-copy.ts` modules and the `labelKey` server pattern.
 - **Git workflow (trunk-based, branch prefixes, hygiene)** — see [`docs/git-workflow.md`](docs/git-workflow.md). `main` is the only long-lived branch; no `integration/*`, `develop`, `next`. Run `scripts/git-hygiene.sh` periodically.
 - **PWA (service worker, manifest, install prompts, offline fallback, cache allow-list)** — see [`docs/pwa.md`](docs/pwa.md). Required reading before touching `public/sw.js`, `src/app/manifest.ts`, or anything under `src/components/pwa/`. The SW has a strict denylist (`/api`, `/admin`, `/vendor`, `/checkout`, `/auth`) that must never be weakened.

--- a/docs/ai-guidelines.md
+++ b/docs/ai-guidelines.md
@@ -1,0 +1,199 @@
+---
+title: AI Guidelines — contract rules for agents working in parallel
+last_verified_against_main: 2026-04-16
+---
+
+# AI Guidelines — contract rules for agents working in parallel
+
+> Purpose: keep multiple agents (and humans) from stepping on each other while the repo scales.
+> Canonical source. Linked from [`AGENTS.md`](../AGENTS.md) and [`docs/conventions.md`](./conventions.md).
+> For hands-on recipes see [`docs/ai-workflows.md`](./ai-workflows.md).
+
+This file describes **what must not drift**. Read [`docs/conventions.md`](./conventions.md) first for the stack-level rules (Prisma, auth, imports that bite) — this file layers architecture rules on top.
+
+---
+
+## 0. Core principles
+
+Order matters when they conflict:
+
+1. **Safety > clarity > speed.** Prefer a small, reversible change over a clever rewrite.
+2. **Small, isolated PRs.** One concern per PR. A bug fix is not an invitation to refactor nearby code.
+3. **Backward compatibility is the default.** A public signature change is a contract break — treat it as such.
+4. **When in doubt, don't modify.** Leave a `TODO(agent-handoff):` comment and surface the ambiguity in the PR description.
+
+---
+
+## 1. Domain architecture
+
+All business logic lives in [`src/domains/`](../src/domains/). Each folder is a **domain** (bounded context): `catalog`, `orders`, `payments`, `shipping`, `subscriptions`, `reviews`, `vendors`, etc.
+
+### 1.1 Public surface of a domain
+
+A module inside `src/domains/<d>/` is **public** (may be imported from outside the domain) if it:
+
+- Lives directly under `src/domains/<d>/` (not inside a sub-folder whose name starts with `_`, `internal`, or `private`).
+- Has no `// @internal` JSDoc tag on its top-level exports.
+- Is not a Zustand store (`*-store.ts`) — those are client-only and covered by §4.
+
+Everything else is **private to the domain**.
+
+### 1.2 Cross-domain import rules
+
+```ts
+// ✅ Allowed — public module of another domain
+import { getOrderDetail } from '@/domains/orders/actions'
+import { createReview } from '@/domains/reviews/actions'
+
+// ❌ Forbidden — reaching into a private/internal subfolder
+import { foo } from '@/domains/orders/internal/price-calc'
+import { bar } from '@/domains/orders/_private/helpers'
+
+// ❌ Forbidden — importing a Zustand store from another domain
+import { useCartStore } from '@/domains/orders/cart-store' // except from the same domain or explicit client boundaries — see §4
+```
+
+> **Today's reality (2026-04-16):** all 18 domains ship an `index.ts` barrel (added in PR #480) that `export *`s from their public files — stores are deliberately excluded. Call sites are a mix: some import from the barrel (`@/domains/orders`), others still use file-level imports (`@/domains/orders/actions`). Both are tolerated today. New code should prefer the barrel; opportunistic migration is welcome but avoid wholesale churn that conflicts with other agents.
+
+### 1.3 Working with barrels
+
+All existing domains ship a barrel. Rule of thumb for agents:
+
+- **New code:** import from the barrel (`import { foo } from '@/domains/orders'`) unless that creates an import cycle.
+- **Editing existing call sites:** if the file already imports deep (`@/domains/orders/actions`), don't churn it just to use the barrel — leave it unless you're already modifying that import line.
+- **Creating a new domain:** add an `index.ts` barrel from the start. `export *` from the public files; **never** from `*-store.ts` or private subfolders.
+- **Adding to an existing barrel:** if you add a new public file to a domain, add an `export *` line to its `index.ts` in the same PR.
+
+### 1.4 No circular dependencies between domains
+
+Use [`scripts/audit-domain-contracts.mjs`](../scripts/audit-domain-contracts.mjs) to detect cycles. A cycle is a design smell — break it by extracting the shared type to `src/types/` or inverting the dependency.
+
+---
+
+## 2. Contracts (internal APIs)
+
+A **contract** is anything one domain exposes that another domain (or the `app/`, `components/`, `lib/` layers) depends on:
+
+- Exported function signatures from a domain module.
+- Exported TypeScript types and Zod schemas.
+- Server Action input/output shapes.
+- Prisma model field names (see [`docs/conventions.md`](./conventions.md) §Prisma).
+
+### 2.1 Breaking a contract
+
+A contract change is **breaking** if it:
+
+- Removes or renames an exported symbol.
+- Narrows a function signature (removes an overload, tightens a parameter type, adds a required parameter).
+- Changes return type in a way that forces callers to adapt.
+- Renames a Zod schema field or makes an optional field required.
+
+### 2.2 What to do instead
+
+1. **Add, don't mutate.** Introduce `fooV2()` alongside `foo()`. Mark `foo()` with `/** @deprecated use fooV2 */`.
+2. **Migrate callers in the same PR** — or in a follow-up PR linked in the deprecation comment.
+3. **Only remove the old symbol** once every caller has moved. Record the removal in the PR description so reviewers can verify.
+4. **Zod schemas:** prefer `.extend()` / new schema variants over mutating the original. If you must rename a field, ship a parser shim for one release.
+
+### 2.3 Non-breaking changes
+
+These are safe and don't need versioning:
+
+- Adding a new exported symbol.
+- Adding an *optional* parameter at the end of a signature.
+- Widening a return type (as long as the widened type is still assignable where callers use it).
+- Adding a new optional field to a Zod schema.
+
+---
+
+## 3. Shared types and schemas
+
+- Project-wide types that are **not** owned by any one domain live in [`src/types/`](../src/types/).
+- Domain-owned types live in the domain and are re-exported from the domain's public surface (see §1.1).
+- **Do not duplicate** a type that already exists. Before adding, grep for the type name across `src/types/` and `src/domains/*/types.ts`.
+- **Runtime boundaries must use Zod.** Any Server Action, API route, or external-input parser must validate with a Zod schema. The parsed type is the source of truth (`type Foo = z.infer<typeof fooSchema>`).
+- **Never `any` in domain code.** The only `any` allowed in `src/domains/` today is for Prisma `$queryRaw` / `$executeRaw` escapes, and generated code under `src/generated/`. See the audit script for the allowlist.
+
+---
+
+## 4. Zustand stores (client-only)
+
+Zustand is the only client state library in this repo. Rules:
+
+- **Every store file starts with `'use client'`.** No exceptions.
+- **Store files are named `*-store.ts`** (e.g. `cart-store.ts`, `favorites-store.ts`).
+- **Stores are NOT re-exported from domain barrels** (`index.ts`). If a component needs a store, it imports the store file directly.
+- **Stores are never imported from Server Components, Server Actions, `middleware.ts`, or any file without `'use client'`.** Doing so bundles client code into the server graph and typically surfaces as cryptic hydration errors.
+- **Stores should not call server code.** If a store needs data from the server, it receives it via props from a `'use client'` component that got it from a Server Component.
+
+Current stores (as of 2026-04-16):
+
+- [`src/domains/orders/cart-store.ts`](../src/domains/orders/cart-store.ts)
+- [`src/domains/catalog/favorites-store.ts`](../src/domains/catalog/favorites-store.ts)
+- [`src/components/admin/analytics/useAnalyticsFiltersStore.ts`](../src/components/admin/analytics/useAnalyticsFiltersStore.ts)
+
+---
+
+## 5. Database (Prisma)
+
+See [`docs/conventions.md`](./conventions.md) §Prisma for field-name gotchas. Rules for migrations:
+
+- **Never edit `prisma/schema.prisma` without generating a migration** (`npm run db:migrate` in dev; a reviewer-auditable `prisma/migrations/<ts>_*/migration.sql` in CI).
+- **Migrations must be backward compatible across one deploy.** A rename must be done as `ADD new column → dual-write → backfill → switch reads → DROP old`. Never `ALTER COLUMN RENAME` in a single migration if the column is in active use.
+- **NOT NULL + DEFAULT on a big table:** add the column nullable, backfill, then set NOT NULL in a follow-up migration.
+- **Prisma client is `@/generated/prisma/client`** — never `@prisma/client`.
+
+---
+
+## 6. Imports — enforcement
+
+Enforcement is layered:
+
+1. **[`eslint.config.mjs`](../eslint.config.mjs)** — blocks at lint time. Relevant rules:
+   - `@typescript-eslint/no-explicit-any` (errors in `src/**`, off under `test/`, `e2e/`, `scripts/`).
+   - `no-restricted-imports` on `src/lib/**` — forbids `@/domains/*/*` deep imports (barrel-only in lib). Added in PR #483 (Phase 4). Limited to `src/lib/` because a wider scope collides with Next.js bundling of barrel re-exports into client bundles; the barrel-split into server/client halves is the prerequisite for app-wide enforcement.
+   - `no-restricted-imports` on `src/**` — forbids cross-domain reaches into `@/domains/*/internal/*`, `@/domains/*/_*/**`, `@/domains/*/private/*`.
+   - Runs in CI via `npm run lint`.
+2. **[`scripts/audit-domain-contracts.mjs`](../scripts/audit-domain-contracts.mjs)** — covers dynamic checks that static lint can't express cleanly:
+   - Domain-level dependency cycles (A imports B imports A transitively).
+   - `*-store.ts` pulled into the server graph (files without `'use client'`).
+   - Belt-and-braces sweep for `any` in `src/domains/` with an explicit allowlist.
+   Run locally with `npm run audit:contracts`. Flags: `--soft` (always exit 0), `--json` (machine-readable).
+3. **Code review** — rules this document can express normatively but tooling cannot (e.g. "don't add abstractions for hypothetical futures", scope discipline).
+
+The **cross-domain store rule** is intentionally in the audit script rather than ESLint: stores may legitimately be imported from client components outside the owning domain, and the `'use client'` signal that distinguishes valid from invalid imports is easier to check dynamically than with a static glob.
+
+---
+
+## 7. Development philosophy for agents
+
+- **Scope discipline.** A bug fix does not bundle "while I'm here" cleanups. Cleanups get their own PR.
+- **Don't add abstractions for hypothetical futures.** Three similar lines beat a premature helper.
+- **Don't leave half-implemented features.** If a change cannot land cleanly, open an issue and *revert*, don't commit a fragment.
+- **Hidden constraints deserve a comment.** If a line exists to work around a subtle bug or upstream quirk, say so in a short comment. Otherwise skip comments — well-named identifiers do the job.
+- **If another agent's WIP is in the worktree, stop and ask.** See [`AGENTS.md`](../AGENTS.md) §"Concurrent-agent safety".
+
+---
+
+## 8. Checklist before opening a PR
+
+- [ ] No cross-domain import into `internal/`, `_private/`, or `_*/`.
+- [ ] No cross-domain import of a `*-store.ts`.
+- [ ] No new `any` in `src/domains/` (except in the audit allowlist).
+- [ ] If a Prisma schema changed: a migration file was generated and is backward compatible.
+- [ ] If a public contract (exported function / Zod schema / Prisma field) changed: either non-breaking, or versioned with deprecation per §2.2.
+- [ ] Ran `npm run lint` — clean (blocks on the `no-restricted-imports` rule).
+- [ ] Ran `npm run audit:contracts` — no new violations introduced.
+- [ ] Ran `npm run typecheck` — clean.
+- [ ] PR description lists any contract changes and whether they are breaking.
+
+---
+
+## 9. Roadmap / open items
+
+Tracked so the next agent doesn't re-discover them:
+
+- **`eslint-plugin-boundaries`** — installed (dep present in `package.json`) but not yet wired into [`eslint.config.mjs`](../eslint.config.mjs). Wiring it would enable declarative domain-to-domain allow-lists beyond what `no-restricted-imports` covers. Defer until the domain graph stabilises (current graph still has one cycle — see below).
+- **App-wide barrel-only enforcement** — PR #483 landed enforcement for `src/lib/ → @/domains/<d>/*` only. Extending to `src/domains/`, `src/app/`, and `src/components/` requires first splitting each domain barrel into server + client halves (`index.ts` + `index.client.ts`) so Next.js doesn't bundle server-only code into client chunks. That refactor is its own PR.
+- **Contract tests** — [`test/contract/`](../test/contract/) does not exist yet. Recommended when a domain's surface stabilises.
+- **`orders` ↔ `shipping` cycle** — both domains import each other at the file level: `orders/actions.ts` → `shipping/calculator`, `orders/checkout.ts` → `shipping/spain-provinces`, and `shipping/actions.ts` → `orders/order-line-snapshot`. `order-line-snapshot.ts` is an 8-line parser around a shared type in `src/types/order.ts` and is a good candidate to move to a neutral location (e.g. `src/types/` or `src/lib/orders-snapshot.ts`) to break the cycle. Tracked by [`scripts/audit-domain-contracts.mjs`](../scripts/audit-domain-contracts.mjs).

--- a/docs/ai-workflows.md
+++ b/docs/ai-workflows.md
@@ -1,0 +1,207 @@
+---
+title: AI Workflows — recipes for agents
+last_verified_against_main: 2026-04-16
+---
+
+# AI Workflows — recipes for agents
+
+> Practical recipes built on top of [`docs/ai-guidelines.md`](./ai-guidelines.md) (rules) and [`docs/conventions.md`](./conventions.md) (stack). Read those first.
+
+---
+
+## TL;DR for a new agent
+
+1. `git status` in any worktree you touch. If there are uncommitted changes that are not yours, **stop and ask** ([`AGENTS.md`](../AGENTS.md) §concurrent-agent safety).
+2. Read the three docs: [`AGENTS.md`](../AGENTS.md) → [`docs/conventions.md`](./conventions.md) → [`docs/ai-guidelines.md`](./ai-guidelines.md).
+3. Plan the smallest change that solves the task.
+4. Before opening a PR run:
+   - `npm run typecheck`
+   - `npm run lint`
+   - `npm run audit:contracts`
+   - the relevant slice of the test suite
+5. PR description lists any contract changes and whether they are breaking.
+
+---
+
+## Recipe 1 — Add a new feature inside an existing domain
+
+**Goal:** implement `markOrderDelivered(orderId)` inside `orders`.
+
+1. Grep the domain first:
+   ```bash
+   rg -n "markOrder|delivered" src/domains/orders/
+   ```
+   Don't duplicate an existing function.
+2. Add the action to [`src/domains/orders/actions.ts`](../src/domains/orders/actions.ts) (or a new file under the same domain). Follow the Server Action pattern in [`docs/conventions.md`](./conventions.md) §Server Action pattern:
+   ```ts
+   'use server'
+   import { z } from 'zod'
+   import { db } from '@/lib/db'
+   import { getActionSession } from '@/lib/action-session'
+   import { isVendor } from '@/lib/roles'
+   import { safeRevalidatePath } from '@/lib/revalidate'
+
+   const markDeliveredSchema = z.object({ orderId: z.string().cuid() })
+
+   export async function markOrderDelivered(input: unknown) {
+     const { orderId } = markDeliveredSchema.parse(input)
+     const session = await getActionSession()
+     if (!session || !isVendor(session.user.role)) return { ok: false as const, error: 'forbidden' }
+     // ... update + revalidate
+     safeRevalidatePath('/vendor/pedidos')
+     return { ok: true as const }
+   }
+   ```
+3. Consume it from the page (`app/(vendor)/.../page.tsx`) — same file-level import surface the rest of the repo uses.
+4. Run the checks in the TL;DR.
+
+**Do NOT:**
+- Reach into another domain's private helpers.
+- Add a `utils.ts` full of speculative helpers — add only what this feature needs.
+- Forget the Zod parse at the server-action boundary.
+
+---
+
+## Recipe 2 — Add a new domain
+
+**Goal:** add `notifications` as a new domain.
+
+1. Create [`src/domains/notifications/`](../src/domains/notifications/).
+2. Add files for the feature (`actions.ts`, `types.ts`, `queries.ts` as needed).
+3. **Create a barrel** `src/domains/notifications/index.ts` matching the style of the other 18 domains:
+   ```ts
+   export * from './actions'
+   export * from './types'
+   // NOT exported: *-store.ts, anything under internal/ or _*/
+   ```
+4. Call sites outside the domain should import from `@/domains/notifications`. (Existing domains still have a mix of barrel and deep imports — don't churn them; see [`docs/ai-guidelines.md`](./ai-guidelines.md) §1.3.)
+5. Add the domain to the directory layout block in [`docs/conventions.md`](./conventions.md).
+
+---
+
+## Recipe 3 — Refactor safely
+
+> Goal: rename an exported function without breaking callers.
+
+**Don't** find-and-replace across the repo in one PR. Instead:
+
+1. **Add** the new name in the same file, delegating to the old one:
+   ```ts
+   /** @deprecated use fulfillOrder */
+   export const completeOrder = fulfillOrder
+
+   export async function fulfillOrder(orderId: string) { /* ... */ }
+   ```
+2. Open PR #1 — adds the new name, leaves the old one as a deprecated alias. Nothing breaks.
+3. Migrate callers in PR #2. Small commits, one area at a time.
+4. Remove the alias in PR #3 once `rg "completeOrder" src/` returns nothing.
+
+**Why split into three PRs?** If PR #2 conflicts with concurrent work, you can land the first and last independently. The repo is never in a broken intermediate state.
+
+---
+
+## Recipe 4 — Modify a Prisma schema
+
+1. Edit [`prisma/schema.prisma`](../prisma/schema.prisma).
+2. Generate a migration: `npm run db:migrate -- --name add_foo_to_bar`.
+3. Inspect the SQL. If it locks a large table or changes a column type in place, split:
+   - Migration A: `ADD COLUMN` nullable.
+   - Migration B (separate PR, after deploy): backfill + `SET NOT NULL`.
+4. Regenerate the client: `npm run prisma:generate`.
+5. Update any Zod schemas that mirror the Prisma model.
+6. Never merge a migration that cannot roll back gracefully while code from the previous deploy is still running.
+
+See [`docs/ai-guidelines.md`](./ai-guidelines.md) §5 for the full backward-compat rules.
+
+---
+
+## Recipe 5 — Change a contract (exported function / schema shape)
+
+Follow [`docs/ai-guidelines.md`](./ai-guidelines.md) §2. The short version:
+
+| Change | Breaking? | How to ship |
+|---|---|---|
+| Add a new export | No | Ship directly. |
+| Add an optional param at end | No | Ship directly. |
+| Widen a return type | Usually no | Spot-check callers. |
+| Add an optional Zod field | No | Ship directly. |
+| Rename an export | **Yes** | Add alias → migrate callers → remove alias. |
+| Remove/rename a required Zod field | **Yes** | New schema (`fooV2Schema`) → parse shim → migrate → retire. |
+| Change a Prisma field name | **Yes** | Dual-write migration. See Recipe 4. |
+| Narrow a function signature | **Yes** | Add overload or new function; deprecate old. |
+
+In the PR description, include a line: `Contract changes: none` / `Contract changes: <list + breaking y/n>`. Reviewers grep for it.
+
+---
+
+## Recipe 6 — Touch Zustand state
+
+1. Locate the existing store (grep for `create` + `zustand` or `-store.ts`).
+2. Open the store file — it must start with `'use client'`.
+3. Add your slice **inside** the existing store if the state is part of the same concern, or create a new `something-store.ts` in the domain that owns the data.
+4. **Do not import the store from a Server Component, Server Action, route handler, or middleware.** The audit script flags that.
+5. If a server-computed initial value is needed, receive it as a prop in a `'use client'` wrapper and hydrate the store from there.
+
+---
+
+## Recipe 7 — Touch a file that's already modified in the worktree
+
+From [`AGENTS.md`](../AGENTS.md):
+
+1. Run `git status`.
+2. If the file is modified but **not yours**, stop. Ask the user or check the last commit author.
+3. Never `git stash` or `git restore` someone else's work.
+4. If the change is yours from an earlier session, proceed — but do a `git diff <file>` first to remember what's pending.
+
+---
+
+## Imports — quick reference
+
+```ts
+// ✅ Correct — preferred for new code (uses the domain barrel)
+import { getOrderDetail } from '@/domains/orders'
+import { db } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { UserRole } from '@/generated/prisma/enums'
+import { useCartStore } from '@/domains/orders/cart-store' // only from 'use client' files
+
+// ✅ Tolerated — existing deep file imports still work. Don't churn them just
+// to switch to the barrel; only touch when you're editing the import line anyway.
+import { getOrderDetail } from '@/domains/orders/actions'
+
+// ❌ Wrong — path does not exist
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
+import { PrismaClient } from '@prisma/client'
+
+// ❌ Wrong — reaches into private/internal subfolder of another domain (ESLint blocks)
+import { foo } from '@/domains/orders/internal/price-calc'
+import { bar } from '@/domains/orders/_helpers/format'
+
+// ❌ Wrong — Zustand store pulled into the server graph (audit script flags)
+// (file does not start with 'use client')
+import { useCartStore } from '@/domains/orders/cart-store'
+```
+
+---
+
+## Commands cheat-sheet
+
+```bash
+npm run typecheck                          # tsc --noEmit
+npm run lint                               # eslint . --max-warnings=0
+npm run audit:contracts                    # dynamic architecture checks
+npm run audit:contracts -- --soft --json   # machine-readable, never fails
+npm run test                               # node tests
+npm run test:e2e:smoke                     # playwright smoke
+./scripts/git-hygiene.sh                   # branch hygiene (periodically)
+```
+
+---
+
+## What to do when…
+
+- **…you're not sure which domain something belongs to.** Leave it where it is and ask. Arbitrary reshuffles create merge conflicts for other agents.
+- **…the rule says X but the code clearly needs Y.** Write the guideline update in the same PR and justify it. The guidelines are source of truth — but they *follow* code when a good reason exists.
+- **…the audit script is wrong.** Open a PR fixing [`scripts/audit-domain-contracts.mjs`](../scripts/audit-domain-contracts.mjs) with a test case (a fixture file under `test/contract/audit/` would be ideal). Don't silently widen the allowlist.
+- **…you hit a merge conflict from another agent's work.** Prefer `git rebase origin/main` on a small branch over trying to untangle. Ask the user if stuck.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -315,4 +315,6 @@ src/
 
 ## Related documents
 
+- [`docs/ai-guidelines.md`](./ai-guidelines.md) — contract rules, domain boundaries, and how the audit script enforces them.
+- [`docs/ai-workflows.md`](./ai-workflows.md) — recipes: add a feature, refactor safely, change a contract.
 - [`src/i18n/README.md`](../src/i18n/README.md) — i18n conventions (flat keys vs `*-copy.ts` vs `labelKey`).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,26 @@ export default [
     plugins: { '@typescript-eslint': tseslint.plugin },
     rules: {
       '@typescript-eslint/no-explicit-any': 'error',
+      // Contract enforcement — see docs/ai-guidelines.md §1.2 and §6.
+      // Cross-domain reaches into private/internal subfolders are forbidden.
+      // The audit script (scripts/audit-domain-contracts.mjs) covers
+      // additional dynamic checks (cycles, stores in server graph).
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: [
+              '@/domains/*/internal/*',
+              '@/domains/*/internal',
+              '@/domains/*/_*/**',
+              '@/domains/*/_*',
+              '@/domains/*/private/*',
+              '@/domains/*/private',
+            ],
+            message:
+              'Private modules of a domain are not importable from outside that domain. See docs/ai-guidelines.md §1.2.',
+          },
+        ],
+      }],
     },
   },
   // The barrel-only rule lives here on src/lib/ only. See the file

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck:app": "tsc -p tsconfig.app.json --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "lint": "eslint . --max-warnings=0",
+    "audit:contracts": "node ./scripts/audit-domain-contracts.mjs",
     "prisma:generate": "prisma generate",
     "db:migrate": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate dev",
     "db:seed": "node --env-file=.env --env-file-if-exists=.env.local --import tsx prisma/seed.ts",

--- a/scripts/audit-domain-contracts.mjs
+++ b/scripts/audit-domain-contracts.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * audit-domain-contracts.mjs
+ *
+ * Lightweight enforcement of the rules in docs/ai-guidelines.md while the repo
+ * has no ESLint. Walks src/, parses imports with regex, and reports:
+ *
+ *   1. Cross-domain deep imports into `internal/`, `_private/`, `_*` subfolders.
+ *   2. Imports of `*-store.ts` (Zustand) from non-`'use client'` files.
+ *      Stores may be imported directly from client files, but must NEVER be
+ *      pulled into the server graph (Server Components, Server Actions,
+ *      middleware, route handlers without `'use client'`).
+ *   3. `any` usage inside src/domains/ outside the allowlist.
+ *   4. Circular dependencies between domains (A imports B, B imports A transitively).
+ *
+ * Exit codes:
+ *   0 — no violations
+ *   1 — violations found (use --soft to always exit 0)
+ *
+ * Usage:
+ *   node scripts/audit-domain-contracts.mjs [--soft] [--json]
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+const ROOT = process.cwd()
+const SRC = join(ROOT, 'src')
+const DOMAINS = join(SRC, 'domains')
+const SOFT = process.argv.includes('--soft')
+const JSON_OUT = process.argv.includes('--json')
+
+// Files where an `any` is allowed (Prisma raw query escapes, generated code).
+const ANY_ALLOWLIST = new Set([
+  'src/domains/payments/webhook-dlq.ts',
+  'src/domains/orders/actions.ts',
+])
+
+const VIOLATIONS = {
+  privateDeepImport: [],
+  storeInServerGraph: [],
+  anyInDomain: [],
+  cycles: [],
+}
+
+/** Recursively list .ts/.tsx files under a directory. */
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === '.next' || entry === 'generated') continue
+      walk(full, acc)
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.d\.ts$/.test(entry)) {
+      acc.push(full)
+    }
+  }
+  return acc
+}
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)\s+(?:[^'"`;]*?from\s+)?['"]([^'"]+)['"]/g
+
+/** Return the list of module specifiers imported/re-exported by `src`. */
+function extractImports(src) {
+  const out = []
+  let m
+  IMPORT_RE.lastIndex = 0
+  while ((m = IMPORT_RE.exec(src)) !== null) out.push(m[1])
+  return out
+}
+
+function domainOfFile(relPath) {
+  const parts = relPath.split(sep)
+  if (parts[0] !== 'src' || parts[1] !== 'domains') return null
+  return parts[2] || null
+}
+
+function domainOfSpecifier(spec) {
+  if (!spec.startsWith('@/domains/')) return null
+  const rest = spec.slice('@/domains/'.length).split('/')
+  return rest[0] || null
+}
+
+function isPrivateSegment(seg) {
+  return seg === 'internal' || seg === 'private' || seg.startsWith('_')
+}
+
+function isStoreSpecifier(spec) {
+  return /-store(\.ts|\.tsx)?$/.test(spec)
+}
+
+const ANY_RE = /(?<![a-zA-Z_$0-9])(?::\s*any\b|as\s+any\b|<\s*any\s*>)/g
+
+const USE_CLIENT_RE = /^\s*['"]use client['"]/m
+
+function checkFile(absPath) {
+  const rel = relative(ROOT, absPath)
+  const src = readFileSync(absPath, 'utf8')
+  const fileDomain = domainOfFile(rel)
+  const isClient = USE_CLIENT_RE.test(src.split('\n').slice(0, 5).join('\n'))
+
+  for (const spec of extractImports(src)) {
+    if (!spec.startsWith('@/domains/')) continue
+
+    const targetDomain = domainOfSpecifier(spec)
+    const crossDomain = fileDomain && targetDomain && fileDomain !== targetDomain
+    const external = !fileDomain
+
+    const subPath = spec.slice(`@/domains/${targetDomain}/`.length).split('/')
+    const firstSeg = subPath[0] || ''
+
+    if ((crossDomain || external) && isPrivateSegment(firstSeg)) {
+      VIOLATIONS.privateDeepImport.push({ file: rel, import: spec })
+    }
+
+    if (!isClient && isStoreSpecifier(spec)) {
+      VIOLATIONS.storeInServerGraph.push({ file: rel, import: spec })
+    }
+  }
+
+  if (rel.startsWith(`src${sep}domains${sep}`) && !ANY_ALLOWLIST.has(rel.split(sep).join('/'))) {
+    const lines = src.split('\n')
+    lines.forEach((line, i) => {
+      if (line.trim().startsWith('//')) return
+      ANY_RE.lastIndex = 0
+      if (ANY_RE.test(line)) {
+        VIOLATIONS.anyInDomain.push({ file: rel, line: i + 1, text: line.trim().slice(0, 140) })
+      }
+    })
+  }
+}
+
+/** Build a domain-level import graph and report cycles. */
+function detectCycles(files) {
+  const graph = new Map()
+  for (const abs of files) {
+    const rel = relative(ROOT, abs)
+    const from = domainOfFile(rel)
+    if (!from) continue
+    const src = readFileSync(abs, 'utf8')
+    const targets = graph.get(from) ?? new Set()
+    for (const spec of extractImports(src)) {
+      const to = domainOfSpecifier(spec)
+      if (to && to !== from) targets.add(to)
+    }
+    graph.set(from, targets)
+  }
+
+  const WHITE = 0, GRAY = 1, BLACK = 2
+  const color = new Map()
+  const stack = []
+  const cycles = []
+
+  function visit(node) {
+    color.set(node, GRAY)
+    stack.push(node)
+    for (const next of graph.get(node) ?? []) {
+      const c = color.get(next) ?? WHITE
+      if (c === GRAY) {
+        const i = stack.indexOf(next)
+        cycles.push(stack.slice(i).concat(next))
+      } else if (c === WHITE) {
+        visit(next)
+      }
+    }
+    stack.pop()
+    color.set(node, BLACK)
+  }
+
+  for (const node of graph.keys()) {
+    if ((color.get(node) ?? WHITE) === WHITE) visit(node)
+  }
+
+  const seen = new Set()
+  for (const c of cycles) {
+    const key = [...c].sort().join('>')
+    if (seen.has(key)) continue
+    seen.add(key)
+    VIOLATIONS.cycles.push(c.join(' → '))
+  }
+}
+
+function main() {
+  const files = walk(SRC)
+  for (const f of files) checkFile(f)
+  detectCycles(files)
+
+  const total =
+    VIOLATIONS.privateDeepImport.length +
+    VIOLATIONS.storeInServerGraph.length +
+    VIOLATIONS.anyInDomain.length +
+    VIOLATIONS.cycles.length
+
+  if (JSON_OUT) {
+    process.stdout.write(JSON.stringify({ total, ...VIOLATIONS }, null, 2) + '\n')
+    process.exit(total === 0 || SOFT ? 0 : 1)
+  }
+
+  const L = (n) => `\x1b[${n}m`
+  const RED = L(31), YEL = L(33), GRN = L(32), DIM = L(2), RST = L(0)
+
+  console.log(`${DIM}audit-domain-contracts · scanning ${files.length} files${RST}`)
+  console.log()
+
+  function section(title, items, color = YEL) {
+    console.log(`${color}▸ ${title} (${items.length})${RST}`)
+    if (items.length === 0) {
+      console.log(`  ${GRN}none${RST}`)
+    } else {
+      for (const it of items.slice(0, 50)) {
+        if (typeof it === 'string') console.log(`  ${it}`)
+        else if (it.line) console.log(`  ${it.file}:${it.line}  ${DIM}${it.text}${RST}`)
+        else console.log(`  ${it.file}  ${DIM}← ${it.import}${RST}`)
+      }
+      if (items.length > 50) console.log(`  ${DIM}… and ${items.length - 50} more${RST}`)
+    }
+    console.log()
+  }
+
+  section('Cross-domain deep imports into internal/private/_*', VIOLATIONS.privateDeepImport, RED)
+  section('*-store.ts imported from non-`use client` files', VIOLATIONS.storeInServerGraph, RED)
+  section('`any` in src/domains/ outside allowlist', VIOLATIONS.anyInDomain, YEL)
+  section('Domain-level dependency cycles', VIOLATIONS.cycles, RED)
+
+  if (total === 0) {
+    console.log(`${GRN}✓ No contract violations.${RST}`)
+    process.exit(0)
+  }
+
+  console.log(`${total > 0 ? RED : GRN}${total} violation(s) total.${RST}`)
+  console.log(`${DIM}See docs/ai-guidelines.md for the rules.${RST}`)
+  process.exit(SOFT ? 0 : 1)
+}
+
+main()


### PR DESCRIPTION
## Summary

Layers enforcement so multiple agents can work on the repo without breaking each other's contracts.

- **`docs/ai-guidelines.md`** — normative rules (domain boundaries + barrels, contract versioning, Zod at boundaries, Zustand server isolation, Prisma migration safety, pre-PR checklist, roadmap).
- **`docs/ai-workflows.md`** — seven recipes: new feature, new domain, safe refactor, Prisma schema change, contract change, Zustand edit, handling another agent's WIP. Plus an import cheat-sheet.
- **`eslint.config.mjs`** — `no-restricted-imports` blocks cross-domain reaches into `internal/`, `_*/`, `private/` subfolders. Reinforces §1.2 of the guidelines at lint time.
- **`scripts/audit-domain-contracts.mjs` + `npm run audit:contracts`** — dynamic checks static lint can't express cleanly: domain-level dependency cycles, `*-store.ts` pulled into the server graph, `any` sweep in `src/domains/` with an allowlist. Flags: `--soft`, `--json`.
- Cross-links added from `AGENTS.md` and `docs/conventions.md`.

## Baseline after this PR

- `npm run lint` — clean.
- `npm run typecheck:app` — clean.
- `npm run audit:contracts` — one pre-existing finding surfaced: `orders ↔ shipping` cycle via `src/domains/orders/order-line-snapshot.ts`. Documented as a roadmap item; fix is a separate small PR (move the 8-line parser to `src/lib/` or `src/types/`).

## Test plan

- [ ] `npm run lint` passes.
- [ ] `npm run audit:contracts -- --soft` runs and reports the expected cycle only.
- [ ] Open `docs/ai-guidelines.md` and `docs/ai-workflows.md` and sanity-check the links.
- [ ] `AGENTS.md` now points to both new docs.

## Out of scope (tracked in `ai-guidelines.md` §9)

- Wiring `eslint-plugin-boundaries` (dep present, not configured).
- Hard ban on deep `@/domains/<d>/<file>` imports (deferred until call-site migration is further along).
- Contract tests under `test/contract/`.
- Breaking the `orders ↔ shipping` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)