### PR TITLE
chore(shared): extract CartItemInput + profile field limits to src/shared

### DIFF
--- a/src/app/api/buyers/profile/route.ts
+++ b/src/app/api/buyers/profile/route.ts
@@ -3,10 +3,20 @@ import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { apiError, apiInternalError, apiUnauthorized, apiValidationFromZod } from '@/lib/api-response'
+import { PROFILE_FIELD_LIMITS } from '@/shared/types/profile'
 
+// Shape mirrors @/shared/types/profile (single source of truth for field
+// limits via PROFILE_FIELD_LIMITS); messages stay localized to ES here
+// because the API surface speaks Spanish to the buyer client.
 const profileSchema = z.object({
-  firstName: z.string().min(1, 'El nombre es obligatorio').max(50, 'Máximo 50 caracteres'),
-  lastName: z.string().min(1, 'El apellido es obligatorio').max(50, 'Máximo 50 caracteres'),
+  firstName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.firstName.min, 'El nombre es obligatorio')
+    .max(PROFILE_FIELD_LIMITS.firstName.max, `Máximo ${PROFILE_FIELD_LIMITS.firstName.max} caracteres`),
+  lastName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.lastName.min, 'El apellido es obligatorio')
+    .max(PROFILE_FIELD_LIMITS.lastName.max, `Máximo ${PROFILE_FIELD_LIMITS.lastName.max} caracteres`),
   email: z.string().email('Email inválido'),
 })
 

--- a/src/components/buyer/BuyerProfileForm.tsx
+++ b/src/components/buyer/BuyerProfileForm.tsx
@@ -7,12 +7,9 @@ import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { useT } from '@/i18n'
 import type { TranslationKeys } from '@/i18n'
+import { PROFILE_FIELD_LIMITS, profileBaseSchema } from '@/shared/types/profile'
 
-const profileSchemaShape = z.object({
-  firstName: z.string().min(1).max(50),
-  lastName: z.string().min(1).max(50),
-  email: z.string().email(),
-})
+const profileSchemaShape = profileBaseSchema
 
 const passwordSchemaShape = z.object({
   currentPassword: z.string().min(1),
@@ -22,8 +19,14 @@ const passwordSchemaShape = z.object({
 
 function buildSchemas(t: (key: TranslationKeys) => string) {
   const profileSchema = z.object({
-    firstName: z.string().min(1, t('account.profileNameRequired')).max(50),
-    lastName: z.string().min(1, t('account.profileLastNameRequired')).max(50),
+    firstName: z
+      .string()
+      .min(PROFILE_FIELD_LIMITS.firstName.min, t('account.profileNameRequired'))
+      .max(PROFILE_FIELD_LIMITS.firstName.max),
+    lastName: z
+      .string()
+      .min(PROFILE_FIELD_LIMITS.lastName.min, t('account.profileLastNameRequired'))
+      .max(PROFILE_FIELD_LIMITS.lastName.max),
     email: z.string().email(t('account.profileEmailInvalid')),
   })
 

--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -37,11 +37,8 @@ import {
 } from '@/domains/promotions/evaluation'
 import { countBuyerRedemptions, loadEvaluablePromotions } from '@/domains/promotions/loader'
 
-export interface CartItemInput {
-  productId: string
-  variantId?: string
-  quantity: number
-}
+export type { CartItemInput } from '@/shared/types/cart'
+import type { CartItemInput } from '@/shared/types/cart'
 
 export type CreateCheckoutOrderResult =
   | {

--- a/src/shared/types/cart.ts
+++ b/src/shared/types/cart.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared cart-input contract. Phase 8 of the contract-hardening plan.
+ *
+ * `CartItemInput` was previously declared inline in
+ * `src/domains/orders/actions.ts` and copied at every call site that
+ * built a checkout payload. Centralizing it here keeps consumers
+ * (cart store, checkout actions, subscription renewals) in lockstep
+ * when the input shape evolves (e.g. adding a `note` field).
+ */
+export interface CartItemInput {
+  productId: string
+  variantId?: string
+  quantity: number
+}

--- a/src/shared/types/profile.ts
+++ b/src/shared/types/profile.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+/**
+ * Shared profile contract. Phase 8 of the contract-hardening plan.
+ *
+ * Two consumers exist today:
+ * - `src/app/api/buyers/profile/route.ts` (server validation, ES messages)
+ * - `src/components/buyer/BuyerProfileForm.tsx` (client validation,
+ *   i18n via `useT()`)
+ *
+ * Both used to copy the field shape independently. This file owns the
+ * structure (which fields exist + constraints); each consumer wraps it
+ * with its own messages (ES strings on the server, i18n keys on the
+ * client) since the message localization model differs across the two.
+ *
+ * If you add a field here, both consumers must opt in explicitly.
+ * That is intentional — message localization is per-surface and the
+ * field-list change should be reviewed with the localization in mind.
+ */
+export const PROFILE_FIELD_LIMITS = {
+  firstName: { min: 1, max: 50 },
+  lastName: { min: 1, max: 50 },
+} as const
+
+export const profileBaseSchema = z.object({
+  firstName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.firstName.min)
+    .max(PROFILE_FIELD_LIMITS.firstName.max),
+  lastName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.lastName.min)
+    .max(PROFILE_FIELD_LIMITS.lastName.max),
+  email: z.string().email(),
+})
+
+export type ProfileInput = z.infer<typeof profileBaseSchema>


### PR DESCRIPTION
## Summary

**Phase 8 of the contract-hardening initiative.** Closes the two follow-ups Phase 5 explicitly punted on.

- \`src/shared/types/cart.ts\` (new) — \`CartItemInput\` moved out of \`src/domains/orders/actions.ts\`. Orders re-exports the type so existing consumers don't change.
- \`src/shared/types/profile.ts\` (new) — exports \`PROFILE_FIELD_LIMITS\` (firstName/lastName 1..50 constraints) and \`profileBaseSchema\` (bare zod shape) plus the inferred \`ProfileInput\` type. Single source for "what fields exist + how long they can be".
- \`src/app/api/buyers/profile/route.ts\` — imports \`PROFILE_FIELD_LIMITS\` to drive its localized ES schema. Min/max bounds + "Máximo N caracteres" error text derive from shared limits.
- \`src/components/buyer/BuyerProfileForm.tsx\` — same, consumed by the i18n schema factory.

## Why now

Phase 5 deferred these on grounds of "would touch i18n surfaces" and "schema messages aren't unifiable". The compromise here unifies the **shape** (field list, numeric bounds) and leaves message localization per-surface. Result: if a field is added or a limit changes, both sides break together; messages stay localized to their surface (ES strings on server, i18n keys on client).

## Test plan

- [x] \`npm run lint\` exits 0
- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run typecheck:test\` exits 0
- [x] \`npm test\` passes 743/743

🤖 Generated with [Claude Code](https://claude.com/claude-code)