### PR TITLE
fix(pwa): keep same-origin clicks inside installed app window

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -119,6 +119,18 @@ accidental payment replays.
 Navigations to denylisted prefixes also bypass the offline fallback. The
 user sees the browser's native error, not a misleading offline shell.
 
+## Link capturing / launch handler
+
+The manifest declares `launch_handler: { client_mode: 'navigate-existing' }`.
+This is what makes same-origin clicks stay inside the installed PWA
+window instead of spawning a new browser tab. Without it, Chromium
+treats each link click as a separate launch target and opens the
+browser — a common source of "the app is a dead end" bug reports.
+
+`display_override: ['standalone', 'minimal-ui']` provides a deterministic
+fallback chain when the platform doesn't support the primary display mode
+(some Android launchers, WebView embeds).
+
 ## Install prompts
 
 | Platform              | Mechanism                                                |

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -11,7 +11,18 @@ export default function manifest(): MetadataRoute.Manifest {
     start_url: '/?source=pwa',
     scope: '/',
     display: 'standalone',
+    // Fallback chain if `standalone` is unsupported on the platform.
+    // `minimal-ui` keeps back/forward affordances; `browser` is the
+    // last-resort pre-install baseline.
+    display_override: ['standalone', 'minimal-ui'],
     orientation: 'portrait',
+    // Keep same-origin navigations inside the installed window instead of
+    // spawning a new browser tab — fixes Brave/Edge/Chrome desktop
+    // opening every link in the browser. `navigate-existing` focuses the
+    // already-open PWA window and navigates it to the target URL.
+    launch_handler: {
+      client_mode: 'navigate-existing',
+    },
     background_color: siteAppearance.background,
     theme_color: siteAppearance.themeColor,
     categories: ['food', 'shopping', 'lifestyle'],

--- a/test/features/manifest-link-capture.test.ts
+++ b/test/features/manifest-link-capture.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import manifest from '@/app/manifest'
+
+/**
+ * Regression tests for the PWA manifest behavior that keeps navigations
+ * inside the installed app window on desktop Chromium (Chrome, Edge,
+ * Brave). Removing any of these fields re-introduces the "every link
+ * opens in the browser" bug.
+ */
+
+test('manifest: launch_handler uses navigate-existing client mode', () => {
+  const m = manifest()
+  const launch = (m as unknown as { launch_handler?: { client_mode?: string } }).launch_handler
+  assert.ok(launch, 'manifest must declare launch_handler')
+  assert.equal(launch?.client_mode, 'navigate-existing')
+})
+
+test('manifest: display_override includes standalone + minimal-ui fallback', () => {
+  const m = manifest()
+  const override = (m as unknown as { display_override?: string[] }).display_override
+  assert.ok(Array.isArray(override), 'display_override must be an array')
+  assert.ok(override!.includes('standalone'))
+  assert.ok(override!.includes('minimal-ui'))
+})
+
+test('manifest: primary display stays standalone', () => {
+  const m = manifest()
+  assert.equal(m.display, 'standalone')
+})
+
+test('manifest: scope covers the entire origin', () => {
+  const m = manifest()
+  assert.equal(m.scope, '/')
+})
+
+test('manifest: id is stable even when start_url changes', () => {
+  const m = manifest()
+  assert.equal(m.id, '/')
+})


### PR DESCRIPTION
## Context

User report from Brave installed on Windows 11: every click inside the installed PWA opens Brave in a new tab instead of staying in the installed window. This is the default Chromium behavior when the manifest doesn't declare link capturing — the app feels like a dead end.

## Fix

Two manifest fields added:

### \`launch_handler.client_mode = 'navigate-existing'\`
Focuses the already-open PWA window and navigates it to the target URL instead of spawning a new browser tab. This is the single fix for the reported bug.

### \`display_override: ['standalone', 'minimal-ui']\`
Deterministic fallback chain for platforms where the primary \`display\` mode isn't honored (some Android launchers, WebView embeds). Prevents silent drop to \`browser\` mode.

## Tests

5 new tests in \`test/features/manifest-link-capture.test.ts\` pin the manifest shape. Removing any of these fields re-introduces the bug:

- \`launch_handler\` present with correct \`client_mode\`
- \`display_override\` array includes both \`standalone\` and \`minimal-ui\`
- Primary \`display\` stays \`standalone\`
- \`scope\` and \`id\` unchanged (regression guard on the other install-UX fields)

## Docs

\`docs/pwa.md\` gains a "Link capturing / launch handler" section explaining the why.

## Test plan

- [x] \`npm run typecheck\` green
- [x] 5 new manifest tests pass
- [ ] Uninstall the current PWA from Brave/Chrome/Edge (otherwise cached manifest)
- [ ] \`npm run build && npm start\`
- [ ] Reinstall the PWA from the browser
- [ ] Click any internal link inside the installed window → stays in the same window (NOT opens browser)
- [ ] External links (mailto:, producer external sites) still open in browser — that's correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)