### PR TITLE
fix(pwa): remove target=_blank on vendor internal nav (reported bug)

### DIFF
--- a/src/components/vendor/ProductActions.tsx
+++ b/src/components/vendor/ProductActions.tsx
@@ -128,7 +128,6 @@ export function ProductActions({ product }: Props) {
             {product.status === 'ACTIVE' && !isExpired && (
               <Link
                 href={`/productos/${product.slug}`}
-                target="_blank"
                 className="block px-4 py-2 text-sm text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
                 onClick={() => setMenuOpen(false)}
               >

--- a/src/components/vendor/VendorHeader.tsx
+++ b/src/components/vendor/VendorHeader.tsx
@@ -44,7 +44,6 @@ export function VendorHeader({ user, vendor, portals = [] }: Props) {
         {vendor?.slug && (
           <Link
             href={`/productores/${vendor.slug}`}
-            target="_blank"
             className="hidden sm:inline-flex rounded-lg px-3 py-1.5 text-sm text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
           >
             {t('vendor.header.myShowcase')} ↗

--- a/src/components/vendor/VendorSidebar.tsx
+++ b/src/components/vendor/VendorSidebar.tsx
@@ -180,7 +180,6 @@ export function VendorSidebar({ vendor }: Props) {
           {vendor?.slug && (
             <Link
               href={`/productores/${vendor.slug}`}
-              target="_blank"
               title={collapsed ? t('vendor.sidebar.viewStore') : undefined}
               aria-label={t('vendor.sidebar.viewStore')}
               style={labelStyle}

--- a/test/features/pwa-internal-link-targets.test.ts
+++ b/test/features/pwa-internal-link-targets.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Regression tests for the "link opens in browser instead of installed PWA"
+ * bug. Internal same-origin links in vendor/buyer-portal components MUST
+ * NOT use `target="_blank"` — it overrides the manifest's
+ * `launch_handler` and spawns a new browser window.
+ *
+ * External URLs (carrier tracking, shipping labels) legitimately keep
+ * `target="_blank"`, so this suite explicitly allow-lists them.
+ *
+ * Admin components are NOT covered here: admin runs on a separate host
+ * in production (ADMIN_HOST isolation), so cross-origin navigations
+ * legitimately open in a new window.
+ */
+
+const INTERNAL_NAV_FILES = [
+  'src/components/vendor/VendorSidebar.tsx',
+  'src/components/vendor/VendorHeader.tsx',
+  'src/components/vendor/ProductActions.tsx',
+]
+
+for (const rel of INTERNAL_NAV_FILES) {
+  test(`${rel}: no target="_blank" on internal navigation`, () => {
+    const content = readFileSync(join(process.cwd(), rel), 'utf-8')
+    const blankCount = (content.match(/target="_blank"/g) ?? []).length
+    assert.equal(
+      blankCount,
+      0,
+      `Found target="_blank" in ${rel}. Internal same-origin links ` +
+        `must navigate within the installed PWA window. If this is a ` +
+        `legitimate external URL (tracking, label), move the link or ` +
+        `add it to INTERNAL_NAV_FILES exceptions.`
+    )
+  })
+}
+
+// Explicit allow-list: these files have external-URL targets that must
+// keep target="_blank" (third-party trackers, PDF labels).
+test('FulfillmentActions keeps target="_blank" for external tracking/label URLs', () => {
+  const content = readFileSync(
+    join(process.cwd(), 'src/components/vendor/FulfillmentActions.tsx'),
+    'utf-8'
+  )
+  // Should have at least one target="_blank" for external URLs.
+  const blankMatches = content.match(/target="_blank"/g) ?? []
+  assert.ok(
+    blankMatches.length >= 2,
+    'FulfillmentActions must keep target="_blank" for labelUrl and trackingUrl'
+  )
+})
+
+test('OrderDetailClient keeps target="_blank" for external tracking URL', () => {
+  const content = readFileSync(
+    join(process.cwd(), 'src/app/(buyer)/cuenta/pedidos/[id]/OrderDetailClient.tsx'),
+    'utf-8'
+  )
+  assert.ok(
+    content.includes('target="_blank"'),
+    'OrderDetailClient must keep target="_blank" for the carrier tracking URL'
+  )
+})


### PR DESCRIPTION
## User report
From the installed vendor PWA on Brave/Windows 11, clicking "Ver mi tienda" in the left sidebar opens the store in a new browser window instead of navigating inside the app. \`launch_handler\` in the manifest (shipped in #490) can't override an explicit \`target="_blank"\` on the link.

## Fix
Removes \`target="_blank"\` from 3 same-origin internal vendor links:

| File | Link text | Target |
|------|-----------|--------|
| \`VendorSidebar.tsx\` | Ver mi tienda | \`/productores/<slug>\` |
| \`VendorHeader.tsx\` | Mi escaparate | \`/productores/<slug>\` |
| \`ProductActions.tsx\` | Ver en tienda | \`/productos/<slug>\` |

## Kept intentionally
- **Admin components** (AdminSidebar, AdminProducersClient): admin runs on a separate host in production (\`ADMIN_HOST\` isolation for cookie security). Cross-origin nav legitimately opens a new window.
- **External URLs**: \`FulfillmentActions\` labelUrl/trackingUrl, \`OrderDetailClient\` trackingUrl, admin envios trackingUrl — all point to third-party carrier trackers or PDF labels. Must stay in browser.

## Tests
5 new tests in \`test/features/pwa-internal-link-targets.test.ts\`:
- 3 scans asserting the fixed files have zero \`target="_blank"\` 
- 2 positive assertions that FulfillmentActions + OrderDetailClient still have it (catches accidental over-aggressive removal)

## Test plan
- [x] \`npm run typecheck\` green
- [x] \`npm run test:parallel\` — 754/772 (baseline preserved, 18 pre-existing failures unchanged)
- [ ] Uninstall current PWA → rebuild + reinstall
- [ ] In vendor portal: click "Ver mi tienda" → stays in the installed window ✅
- [ ] Click "Mi escaparate" in header → stays in window ✅
- [ ] Product actions menu → "Ver en tienda" → stays in window ✅
- [ ] Order detail page: tracking URL → opens in browser (expected) ✅
- [ ] Fulfillment label PDF → opens in browser (expected) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)