### PR TITLE
chore(ci): gate audit:contracts in the Verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,14 @@ jobs:
 
       - uses: ./.github/actions/setup-deps
 
-      - name: Lint + typecheck + tests (parallel)
+      - name: Lint + audit + typecheck + tests (parallel)
         run: |
           set +e
           mkdir -p .ci-logs
-          npm run lint           > .ci-logs/lint.log           2>&1 & PID_LINT=$!
-          npm run typecheck:app  > .ci-logs/typecheck-app.log  2>&1 & PID_TC_APP=$!
-          npm run typecheck:test > .ci-logs/typecheck-test.log 2>&1 & PID_TC_TEST=$!
+          npm run lint             > .ci-logs/lint.log             2>&1 & PID_LINT=$!
+          npm run audit:contracts  > .ci-logs/audit-contracts.log  2>&1 & PID_AUDIT=$!
+          npm run typecheck:app    > .ci-logs/typecheck-app.log    2>&1 & PID_TC_APP=$!
+          npm run typecheck:test   > .ci-logs/typecheck-test.log   2>&1 & PID_TC_TEST=$!
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             npm run test:coverage > .ci-logs/tests.log 2>&1 & PID_TESTS=$!
           else
@@ -57,16 +58,18 @@ jobs:
           fi
 
           STATUS=0
-          wait $PID_LINT    || { echo "::group::lint FAILED";           cat .ci-logs/lint.log;           echo "::endgroup::"; STATUS=1; }
-          wait $PID_TC_APP  || { echo "::group::typecheck:app FAILED";  cat .ci-logs/typecheck-app.log;  echo "::endgroup::"; STATUS=1; }
-          wait $PID_TC_TEST || { echo "::group::typecheck:test FAILED"; cat .ci-logs/typecheck-test.log; echo "::endgroup::"; STATUS=1; }
-          wait $PID_TESTS   || { echo "::group::tests FAILED";          cat .ci-logs/tests.log;          echo "::endgroup::"; STATUS=1; }
+          wait $PID_LINT    || { echo "::group::lint FAILED";             cat .ci-logs/lint.log;             echo "::endgroup::"; STATUS=1; }
+          wait $PID_AUDIT   || { echo "::group::audit:contracts FAILED";  cat .ci-logs/audit-contracts.log;  echo "::endgroup::"; STATUS=1; }
+          wait $PID_TC_APP  || { echo "::group::typecheck:app FAILED";    cat .ci-logs/typecheck-app.log;    echo "::endgroup::"; STATUS=1; }
+          wait $PID_TC_TEST || { echo "::group::typecheck:test FAILED";   cat .ci-logs/typecheck-test.log;   echo "::endgroup::"; STATUS=1; }
+          wait $PID_TESTS   || { echo "::group::tests FAILED";            cat .ci-logs/tests.log;            echo "::endgroup::"; STATUS=1; }
 
           if [ $STATUS -eq 0 ]; then
-            echo "::group::lint";           cat .ci-logs/lint.log;           echo "::endgroup::"
-            echo "::group::typecheck:app";  cat .ci-logs/typecheck-app.log;  echo "::endgroup::"
-            echo "::group::typecheck:test"; cat .ci-logs/typecheck-test.log; echo "::endgroup::"
-            echo "::group::tests";          cat .ci-logs/tests.log;          echo "::endgroup::"
+            echo "::group::lint";            cat .ci-logs/lint.log;             echo "::endgroup::"
+            echo "::group::audit:contracts"; cat .ci-logs/audit-contracts.log;  echo "::endgroup::"
+            echo "::group::typecheck:app";   cat .ci-logs/typecheck-app.log;    echo "::endgroup::"
+            echo "::group::typecheck:test";  cat .ci-logs/typecheck-test.log;   echo "::endgroup::"
+            echo "::group::tests";           cat .ci-logs/tests.log;            echo "::endgroup::"
           fi
           exit $STATUS
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "marketplace",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",
         "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary

- \`npm run audit:contracts\` (added in #487) was only runnable locally — nothing blocked regressions from landing on \`main\`.
- Added it to the Verify job's parallel block next to lint / typecheck / tests so domain cycles, stores leaking into the server graph, and new \`any\` usages in \`src/domains/\` fail CI.
- Cycle fix from #492 already took the baseline to 0 violations, so this is drop-in.

## Test plan

- [ ] CI Verify step output includes an \`::group::audit:contracts\` section.
- [ ] The Verify step still passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)