### PR TITLE
ops(payments): DLQ triage CLI + alert policy + runbook (#419)

### DIFF
--- a/docs/runbooks/payment-incidents.md
+++ b/docs/runbooks/payment-incidents.md
@@ -109,10 +109,55 @@ Collect from the user:
      - DB down
      - Code bug in handler
      - Subscription-before-created race
-5. If dead after 3 days, it will hit DLQ. Check:
-     SELECT * FROM "WebhookDeadLetter" ORDER BY "createdAt" DESC LIMIT 20;
-   Rehydrate manually after fixing the root cause.
+5. If dead after 3 days, it will hit DLQ. Use the CLI (see
+   "DLQ operations" section below):
+     npm run dlq:list
+     npm run dlq:list -- --json
 ```
+
+## DLQ operations (#419)
+
+The `WebhookDeadLetter` table holds Stripe events the handler couldn't
+reconcile to an existing Payment/Order. Operators triage it with two
+scripts backed by `src/domains/payments/webhook-dlq-ops.ts`:
+
+| Command | Purpose |
+|---|---|
+| `npm run dlq:list` | Last 50 unresolved rows, table output. |
+| `npm run dlq:list -- --json` | Same content as JSON — pipe to `jq` / monitoring. |
+| `npm run dlq:list -- --include-resolved` | Show historical resolved rows too. |
+| `npm run dlq:list -- --event-type <type>` | Narrow by Stripe event type. |
+| `npm run dlq:list -- --provider <name>` | Narrow by provider (default `stripe`). |
+| `npm run dlq:list -- --limit N` | Page size (clamped 1..500). |
+| `npm run dlq:resolve -- <rowId> --by "<email>"` | Stamp a row as resolved after you manually replayed it via Stripe dashboard. |
+
+### Alert thresholds
+
+`shouldAlertDlq()` in `webhook-dlq-ops.ts` implements the default policy:
+
+- **total pending ≥ 10** → alert
+- **new in last 24h ≥ 3** → alert
+
+Wire the JSON output to your oncall channel (cron every 15 min):
+
+```bash
+DLQ_JSON=$(npm run -s dlq:list -- --json)
+if [ "$(jq -r '.alerting' <<<"$DLQ_JSON")" = "true" ]; then
+  curl -X POST "$SLACK_WEBHOOK_URL" \
+    -d "{\"text\": \"DLQ alert: $(jq -c '.counts' <<<"$DLQ_JSON")\"}"
+fi
+```
+
+### Manual replay flow
+
+1. `npm run dlq:list` — pick the row to replay. Note `eventId` and `providerRef`.
+2. Stripe dashboard → Developers → Events → find `eventId` → **Resend**.
+3. Watch logs for `stripe.webhook.received` with that `eventId` and the
+   follow-up handler event (`stripe.webhook.payment_*` or similar).
+4. If it processes cleanly, mark it resolved:
+   `npm run dlq:resolve -- <rowId> --by "<your@email>"`
+5. If it still fails, capture the new error from
+   `stripe.webhook.processing_failed` and escalate.
 
 ## Scenario 4: amount mismatch (possible fraud / tampering)
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "db:seed": "node --env-file=.env --env-file-if-exists=.env.local --import tsx prisma/seed.ts",
     "db:clear-demo": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/clear-demo-data.ts",
     "db:studio": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js studio",
-    "db:reset": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate reset --force && npm run db:seed"
+    "db:reset": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate reset --force && npm run db:seed",
+    "dlq:list": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/dlq-list.ts",
+    "dlq:resolve": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/dlq-mark-resolved.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/scripts/dlq-list.ts
+++ b/scripts/dlq-list.ts
@@ -1,0 +1,85 @@
+/**
+ * Lists recent WebhookDeadLetter rows.
+ *
+ * Usage:
+ *   npx tsx scripts/dlq-list.ts                 # last 50 unresolved rows, table
+ *   npx tsx scripts/dlq-list.ts --json          # JSON output (scriptable)
+ *   npx tsx scripts/dlq-list.ts --limit 100     # custom page size
+ *   npx tsx scripts/dlq-list.ts --include-resolved
+ *   npx tsx scripts/dlq-list.ts --event-type invoice.paid
+ *   npx tsx scripts/dlq-list.ts --provider stripe
+ *
+ * Run from a host that has DATABASE_URL set (production or a staging copy).
+ * The output is safe to paste into an incident: `reason`, `eventType`,
+ * `providerRef` are the fields oncall needs to start the runbook.
+ */
+import { db } from '../src/lib/db'
+import { listDlqRows, countDlqRows, shouldAlertDlq } from '../src/domains/payments/webhook-dlq-ops'
+
+function parseFlag(name: string): string | null {
+  const idx = process.argv.indexOf(`--${name}`)
+  if (idx === -1) return null
+  return process.argv[idx + 1] ?? null
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`)
+}
+
+async function main() {
+  const limit = Number(parseFlag('limit') ?? '50')
+  const eventType = parseFlag('event-type') ?? undefined
+  const provider = parseFlag('provider') ?? undefined
+  const includeResolved = hasFlag('include-resolved')
+  const asJson = hasFlag('json')
+
+  const rows = await listDlqRows(db, {
+    limit,
+    eventType,
+    provider,
+    includeResolved,
+  })
+  const counts = await countDlqRows(db, { includeResolved: false })
+  const alerting = shouldAlertDlq(counts)
+
+  if (asJson) {
+    console.log(JSON.stringify({ counts, alerting, rows }, null, 2))
+    return
+  }
+
+  console.log(
+    `\nDLQ summary: ${counts.total} total pending  ·  ${counts.recent} in last ${Math.round(
+      counts.windowMs / 3_600_000
+    )}h  ·  alert=${alerting ? 'YES' : 'no'}\n`
+  )
+
+  if (rows.length === 0) {
+    console.log('No DLQ rows match the filter. 🎉')
+    return
+  }
+
+  for (const row of rows) {
+    const age = Math.round((Date.now() - new Date(row.createdAt).getTime()) / 60_000)
+    const status = row.resolvedAt ? `resolved by ${row.resolvedBy ?? '?'}` : 'PENDING'
+    console.log(
+      [
+        row.id,
+        row.eventType.padEnd(36),
+        (row.providerRef ?? '-').padEnd(32),
+        `${age}m ago`.padEnd(14),
+        status.padEnd(28),
+        row.reason,
+      ].join('  ')
+    )
+  }
+  console.log(`\nShowing ${rows.length} of up to ${limit}. Use --limit to widen.\n`)
+}
+
+main()
+  .catch((err) => {
+    console.error('[dlq-list] error', err)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await db.$disconnect()
+  })

--- a/scripts/dlq-mark-resolved.ts
+++ b/scripts/dlq-mark-resolved.ts
@@ -1,0 +1,52 @@
+/**
+ * Marks a WebhookDeadLetter row as resolved after an operator manually
+ * replayed / reconciled it.
+ *
+ * Usage:
+ *   npx tsx scripts/dlq-mark-resolved.ts <rowId> [--by "jane@example.com"]
+ *
+ * Does NOT replay the event — use the Stripe dashboard or a future
+ * replay script for that. This only stamps the audit trail so the row
+ * drops out of `npx tsx scripts/dlq-list.ts`.
+ */
+import { db } from '../src/lib/db'
+import { markDlqResolved } from '../src/domains/payments/webhook-dlq-ops'
+
+function parseFlag(name: string): string | null {
+  const idx = process.argv.indexOf(`--${name}`)
+  if (idx === -1) return null
+  return process.argv[idx + 1] ?? null
+}
+
+async function main() {
+  const rowId = process.argv[2]
+  if (!rowId || rowId.startsWith('--')) {
+    console.error('Usage: npx tsx scripts/dlq-mark-resolved.ts <rowId> [--by "user"]')
+    process.exit(1)
+  }
+  const resolvedBy = parseFlag('by') ?? process.env.USER ?? 'operator'
+
+  const existing = await db.webhookDeadLetter.findUnique({ where: { id: rowId } })
+  if (!existing) {
+    console.error(`DLQ row ${rowId} not found.`)
+    process.exit(1)
+  }
+  if (existing.resolvedAt) {
+    console.log(
+      `DLQ row ${rowId} was already resolved at ${existing.resolvedAt.toISOString()} by ${existing.resolvedBy ?? '?'}.`
+    )
+    return
+  }
+
+  await markDlqResolved(db, rowId, resolvedBy)
+  console.log(`✓ DLQ row ${rowId} marked resolved by ${resolvedBy}.`)
+}
+
+main()
+  .catch((err) => {
+    console.error('[dlq-mark-resolved] error', err)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await db.$disconnect()
+  })

--- a/src/domains/payments/webhook-dlq-ops.ts
+++ b/src/domains/payments/webhook-dlq-ops.ts
@@ -1,0 +1,119 @@
+/**
+ * Operational helpers for the WebhookDeadLetter table: list, count, and
+ * mark rows as resolved.
+ *
+ * The CLI scripts (`scripts/dlq-list.ts`, `scripts/dlq-mark-resolved.ts`)
+ * delegate to these so the same logic can be driven from a cron job /
+ * admin UI in the future without shelling out.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDelegate = { findMany: (args?: any) => Promise<any>; count: (args?: any) => Promise<number>; update: (args: any) => Promise<any> }
+export type WebhookDlqOpsClient = { webhookDeadLetter: AnyDelegate }
+
+export interface DlqListOptions {
+  limit?: number
+  includeResolved?: boolean
+  provider?: string
+  eventType?: string
+}
+
+export interface DlqRow {
+  id: string
+  provider: string
+  eventId: string | null
+  eventType: string
+  providerRef: string | null
+  reason: string
+  resolvedAt: Date | null
+  resolvedBy: string | null
+  createdAt: Date
+}
+
+/**
+ * Returns recent DLQ rows ordered by createdAt DESC. By default filters
+ * out resolved rows so operators see only the pending queue.
+ */
+export async function listDlqRows(
+  client: WebhookDlqOpsClient,
+  opts: DlqListOptions = {}
+): Promise<DlqRow[]> {
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 500))
+  const where: Record<string, unknown> = {}
+  if (!opts.includeResolved) where.resolvedAt = null
+  if (opts.provider) where.provider = opts.provider
+  if (opts.eventType) where.eventType = opts.eventType
+
+  const rows = await client.webhookDeadLetter.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    select: {
+      id: true,
+      provider: true,
+      eventId: true,
+      eventType: true,
+      providerRef: true,
+      reason: true,
+      resolvedAt: true,
+      resolvedBy: true,
+      createdAt: true,
+    },
+  })
+  return rows as DlqRow[]
+}
+
+/**
+ * Counts DLQ rows in a rolling time window. Returns `{ total, bySince }`
+ * so the caller can page a dashboard tile ("12 pending, 3 in last 24h").
+ */
+export async function countDlqRows(
+  client: WebhookDlqOpsClient,
+  opts: { sinceMs?: number; includeResolved?: boolean } = {}
+): Promise<{ total: number; recent: number; windowMs: number }> {
+  const windowMs = opts.sinceMs ?? 24 * 60 * 60 * 1000
+  const since = new Date(Date.now() - windowMs)
+
+  const baseWhere: Record<string, unknown> = {}
+  if (!opts.includeResolved) baseWhere.resolvedAt = null
+
+  const [total, recent] = await Promise.all([
+    client.webhookDeadLetter.count({ where: baseWhere }),
+    client.webhookDeadLetter.count({
+      where: { ...baseWhere, createdAt: { gte: since } },
+    }),
+  ])
+
+  return { total, recent, windowMs }
+}
+
+/**
+ * Marks a DLQ row as resolved. Does not replay the event — callers that
+ * replay successfully should then call this to stamp who handled it.
+ */
+export async function markDlqResolved(
+  client: WebhookDlqOpsClient,
+  rowId: string,
+  resolvedBy: string
+): Promise<void> {
+  await client.webhookDeadLetter.update({
+    where: { id: rowId },
+    data: {
+      resolvedAt: new Date(),
+      resolvedBy,
+    },
+  })
+}
+
+/**
+ * Threshold helper for an oncall alert: returns `true` when the rolling
+ * window holds more than `threshold` pending rows. Leaves the actual
+ * delivery (Slack / PagerDuty / email) to the cron script so this module
+ * stays pure.
+ */
+export function shouldAlertDlq(
+  count: { total: number; recent: number },
+  threshold = { total: 10, recent: 3 }
+): boolean {
+  return count.total >= threshold.total || count.recent >= threshold.recent
+}

--- a/src/domains/payments/webhook-dlq-ops.ts
+++ b/src/domains/payments/webhook-dlq-ops.ts
@@ -7,9 +7,18 @@
  * admin UI in the future without shelling out.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyDelegate = { findMany: (args?: any) => Promise<any>; count: (args?: any) => Promise<number>; update: (args: any) => Promise<any> }
-export type WebhookDlqOpsClient = { webhookDeadLetter: AnyDelegate }
+/**
+ * Structural type for the subset of `PrismaClient['webhookDeadLetter']`
+ * we actually use. We keep it loose (`unknown`) rather than binding to
+ * the Prisma generated delegate so unit tests can mock it with a plain
+ * object without reimplementing the full Prisma surface.
+ */
+type WebhookDlqDelegate = {
+  findMany: (args?: { where?: Record<string, unknown>; orderBy?: Record<string, unknown>; take?: number; select?: Record<string, unknown> }) => Promise<unknown[]>
+  count: (args?: { where?: Record<string, unknown> }) => Promise<number>
+  update: (args: { where: { id: string }; data: Record<string, unknown> }) => Promise<unknown>
+}
+export type WebhookDlqOpsClient = { webhookDeadLetter: WebhookDlqDelegate }
 
 export interface DlqListOptions {
   limit?: number

--- a/test/features/webhook-dlq-ops.test.ts
+++ b/test/features/webhook-dlq-ops.test.ts
@@ -1,0 +1,212 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  listDlqRows,
+  countDlqRows,
+  markDlqResolved,
+  shouldAlertDlq,
+  type WebhookDlqOpsClient,
+} from '@/domains/payments/webhook-dlq-ops'
+
+/**
+ * Minimal in-memory mock that mimics just the `findMany` / `count` /
+ * `update` surface the ops helpers touch. Keeping it local keeps the
+ * test free of database setup.
+ */
+interface MockRow {
+  id: string
+  provider: string
+  eventId: string | null
+  eventType: string
+  providerRef: string | null
+  reason: string
+  resolvedAt: Date | null
+  resolvedBy: string | null
+  createdAt: Date
+}
+
+function buildMockClient(rows: MockRow[]): WebhookDlqOpsClient {
+  return {
+    webhookDeadLetter: {
+      async findMany(args: {
+        where?: Record<string, unknown>
+        orderBy?: { createdAt?: 'asc' | 'desc' }
+        take?: number
+      } = {}) {
+        let out = rows.slice()
+        const where = args.where ?? {}
+        if ('resolvedAt' in where) {
+          if (where.resolvedAt === null) {
+            out = out.filter((r) => r.resolvedAt === null)
+          }
+        }
+        if (typeof where.provider === 'string') {
+          out = out.filter((r) => r.provider === where.provider)
+        }
+        if (typeof where.eventType === 'string') {
+          out = out.filter((r) => r.eventType === where.eventType)
+        }
+        if (args.orderBy?.createdAt === 'desc') {
+          out.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        }
+        if (typeof args.take === 'number') {
+          out = out.slice(0, args.take)
+        }
+        return out
+      },
+      async count(args: { where?: Record<string, unknown> } = {}) {
+        let out = rows.slice()
+        const where = args.where ?? {}
+        if ('resolvedAt' in where && where.resolvedAt === null) {
+          out = out.filter((r) => r.resolvedAt === null)
+        }
+        if (
+          where.createdAt &&
+          typeof (where.createdAt as { gte?: Date }).gte !== 'undefined'
+        ) {
+          const since = (where.createdAt as { gte: Date }).gte
+          out = out.filter((r) => r.createdAt.getTime() >= since.getTime())
+        }
+        return out.length
+      },
+      async update(args: { where: { id: string }; data: Partial<MockRow> }) {
+        const row = rows.find((r) => r.id === args.where.id)
+        if (!row) throw new Error(`row ${args.where.id} not found`)
+        Object.assign(row, args.data)
+        return row
+      },
+    },
+  }
+}
+
+function seedRow(overrides: Partial<MockRow> = {}): MockRow {
+  return {
+    id: `row-${Math.random().toString(36).slice(2, 8)}`,
+    provider: 'stripe',
+    eventId: `evt_${Math.random().toString(36).slice(2, 8)}`,
+    eventType: 'payment_intent.succeeded',
+    providerRef: 'pi_x',
+    reason: 'orphan event',
+    resolvedAt: null,
+    resolvedBy: null,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+// ── listDlqRows ──────────────────────────────────────────────────────────
+
+test('listDlqRows: defaults to unresolved rows ordered DESC by createdAt', async () => {
+  const now = Date.now()
+  const client = buildMockClient([
+    seedRow({ id: 'old', createdAt: new Date(now - 10_000), reason: 'old' }),
+    seedRow({ id: 'new', createdAt: new Date(now - 1_000), reason: 'new' }),
+    seedRow({
+      id: 'resolved',
+      resolvedAt: new Date(now - 100),
+      resolvedBy: 'jane',
+      reason: 'done',
+    }),
+  ])
+
+  const rows = await listDlqRows(client)
+  assert.equal(rows.length, 2)
+  assert.equal(rows[0].id, 'new')
+  assert.equal(rows[1].id, 'old')
+})
+
+test('listDlqRows: includeResolved true surfaces resolved rows too', async () => {
+  const client = buildMockClient([
+    seedRow({ id: 'a' }),
+    seedRow({ id: 'b', resolvedAt: new Date(), resolvedBy: 'jane' }),
+  ])
+  const rows = await listDlqRows(client, { includeResolved: true })
+  assert.equal(rows.length, 2)
+})
+
+test('listDlqRows: filters by eventType and provider', async () => {
+  const client = buildMockClient([
+    seedRow({ id: 'a', eventType: 'payment_intent.succeeded' }),
+    seedRow({ id: 'b', eventType: 'invoice.paid' }),
+    seedRow({ id: 'c', eventType: 'invoice.paid', provider: 'other' }),
+  ])
+
+  const only = await listDlqRows(client, { eventType: 'invoice.paid' })
+  assert.equal(only.length, 2)
+
+  const onlyStripe = await listDlqRows(client, {
+    eventType: 'invoice.paid',
+    provider: 'stripe',
+  })
+  assert.equal(onlyStripe.length, 1)
+  assert.equal(onlyStripe[0].id, 'b')
+})
+
+test('listDlqRows: limit clamps to [1, 500]', async () => {
+  const client = buildMockClient(Array.from({ length: 20 }, () => seedRow()))
+  assert.equal((await listDlqRows(client, { limit: 0 })).length, 1)
+  assert.equal((await listDlqRows(client, { limit: 5 })).length, 5)
+  assert.equal((await listDlqRows(client, { limit: 10_000 })).length, 20)
+})
+
+// ── countDlqRows ─────────────────────────────────────────────────────────
+
+test('countDlqRows: total excludes resolved by default', async () => {
+  const client = buildMockClient([
+    seedRow(),
+    seedRow(),
+    seedRow({ resolvedAt: new Date(), resolvedBy: 'jane' }),
+  ])
+
+  const out = await countDlqRows(client)
+  assert.equal(out.total, 2)
+  // All rows just created, so recent also 2.
+  assert.equal(out.recent, 2)
+})
+
+test('countDlqRows: recent uses the sinceMs window', async () => {
+  const now = Date.now()
+  const client = buildMockClient([
+    seedRow({ createdAt: new Date(now - 1_000) }),
+    seedRow({ createdAt: new Date(now - 1000 * 60 * 60 * 48) }), // 48h ago
+  ])
+  const out = await countDlqRows(client, { sinceMs: 24 * 60 * 60 * 1000 })
+  assert.equal(out.total, 2)
+  assert.equal(out.recent, 1)
+  assert.equal(out.windowMs, 24 * 60 * 60 * 1000)
+})
+
+// ── markDlqResolved ──────────────────────────────────────────────────────
+
+test('markDlqResolved: stamps resolvedAt and resolvedBy', async () => {
+  const row = seedRow({ id: 'target' })
+  const client = buildMockClient([row])
+
+  await markDlqResolved(client, 'target', 'jane@example.com')
+
+  assert.ok(row.resolvedAt instanceof Date, 'resolvedAt must be a Date')
+  assert.equal(row.resolvedBy, 'jane@example.com')
+})
+
+// ── shouldAlertDlq ───────────────────────────────────────────────────────
+
+test('shouldAlertDlq: fires when total meets threshold', () => {
+  assert.equal(shouldAlertDlq({ total: 10, recent: 0 }), true)
+  assert.equal(shouldAlertDlq({ total: 9, recent: 0 }), false)
+})
+
+test('shouldAlertDlq: fires when recent meets threshold independently', () => {
+  assert.equal(shouldAlertDlq({ total: 0, recent: 3 }), true)
+  assert.equal(shouldAlertDlq({ total: 0, recent: 2 }), false)
+})
+
+test('shouldAlertDlq: custom threshold is honoured', () => {
+  assert.equal(
+    shouldAlertDlq({ total: 5, recent: 0 }, { total: 5, recent: 100 }),
+    true
+  )
+  assert.equal(
+    shouldAlertDlq({ total: 4, recent: 0 }, { total: 5, recent: 100 }),
+    false
+  )
+})


### PR DESCRIPTION
Closes #419

Adds the DLQ tooling that #416's runbook references but didn't exist yet.

## New module
\`src/domains/payments/webhook-dlq-ops.ts\` — pure functions over a \`WebhookDlqOpsClient\` interface so tests mock cleanly:
- \`listDlqRows(client, opts)\` — unresolved by default, filters + limit clamp [1, 500]
- \`countDlqRows(client, opts)\` — \`{ total, recent, windowMs }\`, default 24h window
- \`markDlqResolved(client, id, by)\` — stamps \`resolvedAt\` + \`resolvedBy\`
- \`shouldAlertDlq(count, threshold?)\` — pure predicate, default \`{ total: 10, recent: 3 }\`

## CLI
- \`npm run dlq:list\` — table output, default 50 unresolved rows
- \`npm run dlq:list -- --json\` — pipeable JSON with counts + alerting flag
- \`npm run dlq:list -- --event-type <t> --provider <p> --limit N --include-resolved\`
- \`npm run dlq:resolve -- <rowId> --by "<email>"\` — mark after manual replay

## Runbook
\`docs/runbooks/payment-incidents.md\` gains a dedicated "DLQ operations" section with:
- Command reference table
- Alert threshold policy
- Cron-style Slack webhook wiring snippet
- Step-by-step manual replay flow
- Scenario 3 updated to reference the CLI instead of raw SQL

## What is NOT in this PR
- Automatic replay script. Each event type has different idempotency semantics (payment_intent.*, customer.subscription.*, invoice.*). Writing one generic replayer risks masking edge cases; splitting into its own issue keeps the blast radius controlled.

## Tests (10 new, all pass)
- \`listDlqRows\`: defaults, includeResolved, filters (provider + eventType), limit clamping (0 → 1, 10000 → all)
- \`countDlqRows\`: total excludes resolved; recent uses sinceMs window correctly
- \`markDlqResolved\`: stamps both fields
- \`shouldAlertDlq\`: total threshold, recent threshold independently, custom thresholds

## Test plan
- [x] \`npm run typecheck\` green
- [x] 10/10 new tests pass
- [ ] Run \`npm run dlq:list\` against a staging DB with seeded DLQ rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)