### PR TITLE
security(proxy): API route auth audit + conventions (#420)

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -207,6 +207,38 @@ export const config = {
 
 ---
 
+## Edge proxy — authenticated prefixes (defence in depth)
+
+`src/proxy.ts` runs at the edge before any server component renders. It redirects unauthenticated traffic away from whole route groups via:
+
+```ts
+export const PROTECTED_PREFIXES = ['/admin', '/vendor', '/carrito', '/checkout', '/cuenta'] as const
+```
+
+Two structural tests pin this contract:
+
+- `test/integration/proxy-protected-prefixes.test.ts` — walks `src/app/(buyer|vendor|admin)/` and fails CI if a new top-level segment is added without a matching prefix. Removing an entry from `PROTECTED_PREFIXES` also fails (the canonical 5 segments are pinned).
+- `test/integration/api-route-auth-audit.test.ts` — walks every `src/app/api/**/route.ts` and fails CI when a file has no session helper (`getActionSession`, `auth()`, `require*`, etc.) AND is not on the explicit `PUBLIC_API_ROUTES` allow-list. Each allow-list entry must document a reason.
+
+### Adding a new authenticated route
+
+1. Place it under `(buyer)`, `(vendor)` or `(admin)` in `src/app/`.
+2. If its top-level segment (`/foo`) is not yet in `PROTECTED_PREFIXES`, add it there.
+3. Run `npm run test -- test/integration/proxy-protected-prefixes.test.ts` — must pass.
+
+### Adding a new API route
+
+1. Call `getActionSession()` or an equivalent helper inside the handler before touching any user data.
+2. Scope every query by `userId`/`buyerId`/`vendorId` from the session.
+3. If the endpoint is **intentionally public** (webhook, unauthenticated form), add it to `PUBLIC_API_ROUTES` in `test/integration/api-route-auth-audit.test.ts` with a clear reason.
+4. Run `npm run test -- test/integration/api-route-auth-audit.test.ts` — must pass.
+
+### Out-of-scope: admin host isolation
+
+When `ADMIN_HOST` env is set, `/admin/**` is additionally gated to a dedicated host. See `docs/admin-host.md` for DNS/TLS setup.
+
+---
+
 ## Update `navigation.ts` when activating routes
 
 `src/lib/navigation.ts` flags some routes as `available: false`. When you implement one of them, flip it to `true` in the same PR — otherwise the entry stays hidden in the header.

--- a/test/integration/api-route-auth-audit.test.ts
+++ b/test/integration/api-route-auth-audit.test.ts
@@ -1,0 +1,170 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Issue #420 companion test: audits every `src/app/api/**\/route.ts`
+ * and asserts each file is on either the PUBLIC_API_ROUTES allow-list
+ * OR imports a session helper (getActionSession / auth() / require*).
+ *
+ * The edge proxy deliberately excludes `/api` from PROTECTED_PREFIXES
+ * because REST handlers enforce their own session scoping. Without a
+ * structural check, a new handler that forgets to call an auth helper
+ * would expose the endpoint globally until someone happens to spot it
+ * in review. This test is that check.
+ *
+ * Keep the allow-list small and explicit. Adding a route here is a
+ * security decision — document WHY in the entry comment.
+ */
+
+const API_ROOT = path.join(process.cwd(), 'src', 'app', 'api')
+
+/**
+ * Routes that are PUBLIC by design. Every entry MUST document why.
+ * Anything not on this list must import a session helper somewhere
+ * in its body.
+ */
+const PUBLIC_API_ROUTES: ReadonlyArray<{ path: string; why: string }> = [
+  {
+    path: 'src/app/api/auth/[...nextauth]/route.ts',
+    why: 'NextAuth core handler — owns the session cookie lifecycle.',
+  },
+  {
+    path: 'src/app/api/auth/forgot-password/route.ts',
+    why: 'Password-reset email request. Rate-limited. Must be reachable when logged out.',
+  },
+  {
+    path: 'src/app/api/auth/reset-password/route.ts',
+    why: 'Token-based reset. Auth is the token itself, not a session.',
+  },
+  {
+    path: 'src/app/api/auth/register/route.ts',
+    why: 'Account creation. Must be reachable when logged out.',
+  },
+  {
+    path: 'src/app/api/auth/verify-email/route.ts',
+    why: 'Email-link verification. Auth is the token in the URL, not a session.',
+  },
+  {
+    path: 'src/app/api/contacto/route.ts',
+    why: 'Public contact form. Rate-limited per IP and per identity.',
+  },
+  {
+    path: 'src/app/api/catalog/featured/route.ts',
+    why: 'Public catalog JSON for PWA periodic sync prefetch. No sensitive fields.',
+  },
+  {
+    path: 'src/app/api/webhooks/stripe/route.ts',
+    why: 'Stripe webhook. Authenticates via HMAC signature, not a session.',
+  },
+  {
+    path: 'src/app/api/webhooks/sendcloud/route.ts',
+    why: 'Sendcloud webhook. Authenticates via HMAC signature, not a session.',
+  },
+  {
+    path: 'src/app/api/incidents/route.ts',
+    why: 'Thin wrapper — delegates every mutation to openIncident() which calls getActionSession internally. Route file itself has no auth keyword.',
+  },
+  {
+    path: 'src/app/api/incidents/[id]/messages/route.ts',
+    why: 'Thin wrapper — delegates to postIncidentMessage() which enforces ownership via getActionSession.',
+  },
+]
+
+const SESSION_KEYWORDS = [
+  'getActionSession',
+  'getServerSession',
+  'requireVendor',
+  'requireAdmin',
+  'requireBuyer',
+  'requireRole',
+  "from '@/lib/auth'",
+  'from "@/lib/auth"',
+  ' auth()', // NextAuth v5 helper — loose match but scoped by leading space
+  '\tauth()',
+  '(auth())',
+] as const
+
+function listRouteFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) out.push(...listRouteFiles(full))
+    else if (entry === 'route.ts' || entry === 'route.tsx') out.push(full)
+  }
+  return out
+}
+
+function hasSessionKeyword(content: string): boolean {
+  return SESSION_KEYWORDS.some((kw) => content.includes(kw))
+}
+
+test('every API route either imports a session helper OR is on the PUBLIC allow-list', () => {
+  const absPublicSet = new Set(
+    PUBLIC_API_ROUTES.map((r) => path.join(process.cwd(), r.path))
+  )
+  const routes = listRouteFiles(API_ROOT)
+
+  const violations: string[] = []
+
+  for (const file of routes) {
+    const content = readFileSync(file, 'utf-8')
+    const isPublic = absPublicSet.has(file)
+    const hasAuth = hasSessionKeyword(content)
+
+    if (!isPublic && !hasAuth) {
+      const rel = path.relative(process.cwd(), file)
+      violations.push(rel)
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `New API route(s) detected with no session helper and not on the
+PUBLIC_API_ROUTES allow-list. Either:
+  (a) add a call to getActionSession() / auth() / require* in the handler, OR
+  (b) add the path to PUBLIC_API_ROUTES in this file with a clear reason.
+
+Unauthenticated routes:
+${violations.map((v) => `  - ${v}`).join('\n')}`
+  )
+})
+
+test('PUBLIC_API_ROUTES entries all point to existing files', () => {
+  const missing: string[] = []
+  for (const entry of PUBLIC_API_ROUTES) {
+    const abs = path.join(process.cwd(), entry.path)
+    try {
+      statSync(abs)
+    } catch {
+      missing.push(entry.path)
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `Stale entries in PUBLIC_API_ROUTES — these files don't exist. Remove:\n${missing.map((m) => `  - ${m}`).join('\n')}`
+  )
+})
+
+test('PUBLIC_API_ROUTES entries all document a reason', () => {
+  for (const entry of PUBLIC_API_ROUTES) {
+    assert.ok(
+      entry.why.length > 10,
+      `PUBLIC_API_ROUTES entry ${entry.path} must document a reason. Got: ${JSON.stringify(entry.why)}`
+    )
+  }
+})
+
+test('PUBLIC_API_ROUTES has no duplicates', () => {
+  const seen = new Set<string>()
+  const dupes: string[] = []
+  for (const entry of PUBLIC_API_ROUTES) {
+    if (seen.has(entry.path)) dupes.push(entry.path)
+    seen.add(entry.path)
+  }
+  assert.deepEqual(dupes, [], `Duplicate PUBLIC_API_ROUTES entries: ${dupes.join(', ')}`)
+})


### PR DESCRIPTION
Closes #420

## Context
Previous work on #420 (merged in the PWA base PR) shipped `test/integration/proxy-protected-prefixes.test.ts` — a structural audit that walks \`src/app/(buyer|vendor|admin)/\` and fails CI if a route group top-level segment is missing from \`PROTECTED_PREFIXES\`.

What was missing was the **API handler side**: \`/api/**\` is intentionally excluded from \`PROTECTED_PREFIXES\` because REST handlers enforce auth themselves — but no test ensured they actually do. This PR closes that gap.

## New test
\`test/integration/api-route-auth-audit.test.ts\` walks every \`src/app/api/**/route.ts\` and fails CI when:

- The file has no session helper keyword (\`getActionSession\`, \`auth()\`, \`requireVendor\`, \`requireAdmin\`, \`requireBuyer\`, \`requireRole\`, \`from '@/lib/auth'\`), AND
- The file is not on the explicit \`PUBLIC_API_ROUTES\` allow-list.

Allow-list entries (each with documented reason):

| Route | Why public |
|---|---|
| \`auth/[...nextauth]\` | NextAuth core — owns session cookies |
| \`auth/forgot-password\` | Must be reachable when logged out, rate-limited |
| \`auth/reset-password\` | Auth is the token, not a session |
| \`auth/register\` | Account creation |
| \`auth/verify-email\` | Auth is the token in the URL |
| \`contacto\` | Public form, rate-limited per IP + identity |
| \`catalog/featured\` | Public catalog JSON for PWA periodic sync |
| \`webhooks/stripe\` | HMAC-signed |
| \`webhooks/sendcloud\` | HMAC-signed |
| \`incidents\` (POST) | Thin wrapper — delegates to \`openIncident()\` which calls \`getActionSession\` internally |
| \`incidents/[id]/messages\` | Same — thin wrapper over auth'd server action |

Two meta tests:
- Every allow-list entry points to a real file (stale entries fail CI)
- Every allow-list entry has a non-trivial reason (> 10 chars)

## Audit findings

**No code changes needed.** Of 26 API route files:

- 15 call a session helper directly
- 11 delegate to server actions that enforce auth, or are public by design (webhooks, unauth'd forms, PWA catalog prefetch)
- Zero orphans

The thin-wrapper pattern (\`incidents/*\` delegating to \`openIncident()\`) is correct but opaque to a static grep, which is why the allow-list entry documents it explicitly.

## Docs
\`docs/conventions.md\` gains an "Edge proxy — authenticated prefixes" section:
- Both structural tests explained (proxy prefixes + API handler audit)
- Step-by-step recipe for adding a new authenticated route group
- Step-by-step recipe for adding a new API endpoint (including the public-by-design path)

## Test plan
- [x] \`npm run typecheck\` green
- [x] 4/4 new tests pass when run directly
- [ ] CI runs full integration suite including the new file
- [ ] Review: anyone who added an API route recently should double-check their file either imports an auth helper or has a \`PUBLIC_API_ROUTES\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)