### PR TITLE
refactor(routes): extract inline route schemas to src/shared + freeze them

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,13 +8,7 @@ import { sendEmail } from '@/lib/email'
 import { getServerEnv } from '@/lib/env'
 import { EmailVerificationEmail } from '@/emails/EmailVerification'
 import { createElement } from 'react'
-
-const schema = z.object({
-  firstName: z.string().min(1).max(50),
-  lastName: z.string().min(1).max(50),
-  email: z.string().email(),
-  password: z.string().min(8).max(100),
-})
+import { registerSchema as schema } from '@/shared/types/auth'
 
 import { isUniqueConstraintViolation } from '@/lib/prisma-errors'
 

--- a/src/app/api/incidents/[id]/messages/route.ts
+++ b/src/app/api/incidents/[id]/messages/route.ts
@@ -2,10 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 import { addIncidentMessage } from '@/domains/incidents/actions'
 import { IncidentAuthError, IncidentValidationError } from '@/domains/incidents/errors'
-
-const bodySchema = z.object({
-  body: z.string().min(1).max(5000),
-})
+import { incidentMessageBodySchema as bodySchema } from '@/shared/types/incidents'
 
 interface RouteParams {
   params: Promise<{ id: string }>

--- a/src/app/api/incidents/route.ts
+++ b/src/app/api/incidents/route.ts
@@ -2,13 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { z } from 'zod'
 import { openIncident } from '@/domains/incidents/actions'
 import { IncidentAuthError, IncidentValidationError } from '@/domains/incidents/errors'
-import { IncidentType } from '@/generated/prisma/enums'
-
-const bodySchema = z.object({
-  orderId: z.string().min(1),
-  type: z.nativeEnum(IncidentType),
-  description: z.string().min(10).max(5000),
-})
+import { openIncidentBodySchema as bodySchema } from '@/shared/types/incidents'
 
 /**
  * POST /api/incidents — buyer opens an incident on one of their orders.

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import { PROFILE_FIELD_LIMITS } from '@/shared/types/profile'
+
+/**
+ * Shared auth contracts. The registration body shape was previously
+ * declared inline inside `src/app/api/auth/register/route.ts`; now it
+ * lives here so freeze tests can pin the field set + limits, and the
+ * client signup form can derive its constraints from the same source.
+ *
+ * `firstName` / `lastName` reuse `PROFILE_FIELD_LIMITS` so a single
+ * width change propagates to both registration and profile-edit flows.
+ */
+export const REGISTER_PASSWORD_LIMITS = {
+  min: 8,
+  max: 100,
+} as const
+
+export const registerSchema = z.object({
+  firstName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.firstName.min)
+    .max(PROFILE_FIELD_LIMITS.firstName.max),
+  lastName: z
+    .string()
+    .min(PROFILE_FIELD_LIMITS.lastName.min)
+    .max(PROFILE_FIELD_LIMITS.lastName.max),
+  email: z.string().email(),
+  password: z.string().min(REGISTER_PASSWORD_LIMITS.min).max(REGISTER_PASSWORD_LIMITS.max),
+})
+
+export type RegisterInput = z.infer<typeof registerSchema>

--- a/src/shared/types/incidents.ts
+++ b/src/shared/types/incidents.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+import { IncidentType } from '@/generated/prisma/enums'
+
+/**
+ * Shared incident contracts. Both bodies were previously declared
+ * inline in their respective routes:
+ *
+ *   - openIncidentBodySchema       → src/app/api/incidents/route.ts
+ *   - incidentMessageBodySchema    → src/app/api/incidents/[id]/messages/route.ts
+ *
+ * The numeric limits are exported so any future client-side counter
+ * (e.g. "N/5000 characters") stays in sync with the server cap.
+ */
+export const INCIDENT_DESCRIPTION_LIMITS = {
+  min: 10,
+  max: 5000,
+} as const
+
+export const INCIDENT_MESSAGE_LIMITS = {
+  min: 1,
+  max: 5000,
+} as const
+
+export const openIncidentBodySchema = z.object({
+  orderId: z.string().min(1),
+  type: z.nativeEnum(IncidentType),
+  description: z
+    .string()
+    .min(INCIDENT_DESCRIPTION_LIMITS.min)
+    .max(INCIDENT_DESCRIPTION_LIMITS.max),
+})
+
+export type OpenIncidentInput = z.infer<typeof openIncidentBodySchema>
+
+export const incidentMessageBodySchema = z.object({
+  body: z
+    .string()
+    .min(INCIDENT_MESSAGE_LIMITS.min)
+    .max(INCIDENT_MESSAGE_LIMITS.max),
+})
+
+export type IncidentMessageInput = z.infer<typeof incidentMessageBodySchema>

--- a/test/contracts/domain/auth-schemas.test.ts
+++ b/test/contracts/domain/auth-schemas.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { registerSchema, REGISTER_PASSWORD_LIMITS } from '@/shared/types/auth'
+import { PROFILE_FIELD_LIMITS } from '@/shared/types/profile'
+
+/**
+ * Schema-freeze for the registration endpoint contract. The route at
+ * `src/app/api/auth/register/route.ts` consumes registerSchema directly,
+ * so any drift here surfaces both server-side validation regressions
+ * and the future client signup-form constraints derived from these
+ * limits.
+ *
+ * Companion to:
+ *   - test/contracts/domain/profile-schema.test.ts (the profile shape
+ *     this schema mirrors for firstName/lastName)
+ *   - test/contracts/domain/orders-schemas.test.ts
+ *   - test/contracts/domain/snapshots.test.ts
+ */
+
+function assertShape(
+  label: string,
+  schema: { _zod: { def: { shape: Record<string, { _zod: { optin?: string } }> } } },
+  expected: { required: readonly string[]; optional: readonly string[] },
+) {
+  const shape = schema._zod.def.shape
+  const actualKeys = Object.keys(shape).sort()
+  const expectedKeys = [...expected.required, ...expected.optional].sort()
+
+  assert.deepEqual(actualKeys, expectedKeys, `${label}: schema key set drifted.`)
+
+  const required: string[] = []
+  const optional: string[] = []
+  for (const [key, field] of Object.entries(shape)) {
+    const isOptional = field._zod.optin === 'optional'
+    if (isOptional) optional.push(key)
+    else required.push(key)
+  }
+  required.sort()
+  optional.sort()
+
+  assert.deepEqual(required, [...expected.required].sort(), `${label}: required drifted.`)
+  assert.deepEqual(optional, [...expected.optional].sort(), `${label}: optional drifted.`)
+}
+
+test('registerSchema — frozen shape', () => {
+  assertShape('registerSchema', registerSchema as never, {
+    required: ['firstName', 'lastName', 'email', 'password'],
+    optional: [],
+  })
+})
+
+test('REGISTER_PASSWORD_LIMITS — frozen numeric bounds', () => {
+  // Critical security contract — relaxing min would weaken signup
+  // password strength; tightening it would break existing passwords on
+  // the next change-password flow if not coordinated. Either way,
+  // touching these without intent should fail review.
+  assert.equal(REGISTER_PASSWORD_LIMITS.min, 8)
+  assert.equal(REGISTER_PASSWORD_LIMITS.max, 100)
+})
+
+test('registerSchema — firstName/lastName limits derive from PROFILE_FIELD_LIMITS', () => {
+  // Sanity check that signup and profile-edit use the same width;
+  // a mismatch would let users register with names the profile
+  // form would later reject as too long.
+  const tooLongFirst = 'x'.repeat(PROFILE_FIELD_LIMITS.firstName.max + 1)
+  const result = registerSchema.safeParse({
+    firstName: tooLongFirst,
+    lastName: 'OK',
+    email: 'a@b.co',
+    password: 'longenough',
+  })
+  assert.equal(result.success, false)
+})
+
+test('registerSchema — rejects short password', () => {
+  const result = registerSchema.safeParse({
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'ada@example.com',
+    password: 'x'.repeat(REGISTER_PASSWORD_LIMITS.min - 1),
+  })
+  assert.equal(result.success, false)
+})
+
+test('registerSchema — rejects invalid email', () => {
+  const result = registerSchema.safeParse({
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'not-an-email',
+    password: 'longenough',
+  })
+  assert.equal(result.success, false)
+})

--- a/test/contracts/domain/incidents-schemas.test.ts
+++ b/test/contracts/domain/incidents-schemas.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  openIncidentBodySchema,
+  incidentMessageBodySchema,
+  INCIDENT_DESCRIPTION_LIMITS,
+  INCIDENT_MESSAGE_LIMITS,
+} from '@/shared/types/incidents'
+import { IncidentType } from '@/generated/prisma/enums'
+
+/**
+ * Schema-freeze for the buyer-facing incidents endpoints. Both bodies
+ * cross the HTTP boundary (buyer client → server route) and are
+ * consumed by:
+ *
+ *   - src/app/api/incidents/route.ts                 (POST /api/incidents)
+ *   - src/app/api/incidents/[id]/messages/route.ts   (POST .../messages)
+ *
+ * The integration tests in test/integration/api-incidents-auth.test.ts
+ * exercise the auth/ownership gate; this file pins the shape so a
+ * silent rename of `description` → `body` (or similar) fails CI before
+ * the buyer form notices.
+ */
+
+function assertShape(
+  label: string,
+  schema: { _zod: { def: { shape: Record<string, { _zod: { optin?: string } }> } } },
+  expected: { required: readonly string[]; optional: readonly string[] },
+) {
+  const shape = schema._zod.def.shape
+  const actualKeys = Object.keys(shape).sort()
+  const expectedKeys = [...expected.required, ...expected.optional].sort()
+
+  assert.deepEqual(actualKeys, expectedKeys, `${label}: schema key set drifted.`)
+
+  const required: string[] = []
+  const optional: string[] = []
+  for (const [key, field] of Object.entries(shape)) {
+    const isOptional = field._zod.optin === 'optional'
+    if (isOptional) optional.push(key)
+    else required.push(key)
+  }
+  required.sort()
+  optional.sort()
+
+  assert.deepEqual(required, [...expected.required].sort(), `${label}: required drifted.`)
+  assert.deepEqual(optional, [...expected.optional].sort(), `${label}: optional drifted.`)
+}
+
+test('openIncidentBodySchema — frozen shape', () => {
+  assertShape('openIncidentBodySchema', openIncidentBodySchema as never, {
+    required: ['orderId', 'type', 'description'],
+    optional: [],
+  })
+})
+
+test('INCIDENT_DESCRIPTION_LIMITS — frozen bounds', () => {
+  assert.equal(INCIDENT_DESCRIPTION_LIMITS.min, 10)
+  assert.equal(INCIDENT_DESCRIPTION_LIMITS.max, 5000)
+})
+
+test('openIncidentBodySchema — rejects short description', () => {
+  const result = openIncidentBodySchema.safeParse({
+    orderId: 'ord_1',
+    type: IncidentType.WRONG_ITEM,
+    description: 'x'.repeat(INCIDENT_DESCRIPTION_LIMITS.min - 1),
+  })
+  assert.equal(result.success, false)
+})
+
+test('openIncidentBodySchema — rejects description over the cap', () => {
+  const result = openIncidentBodySchema.safeParse({
+    orderId: 'ord_1',
+    type: IncidentType.WRONG_ITEM,
+    description: 'x'.repeat(INCIDENT_DESCRIPTION_LIMITS.max + 1),
+  })
+  assert.equal(result.success, false)
+})
+
+test('openIncidentBodySchema — rejects unknown incident type', () => {
+  const result = openIncidentBodySchema.safeParse({
+    orderId: 'ord_1',
+    type: 'TOTALLY_FAKE_TYPE',
+    description: 'A perfectly long description that explains the issue.',
+  })
+  assert.equal(result.success, false)
+})
+
+test('incidentMessageBodySchema — frozen shape', () => {
+  assertShape('incidentMessageBodySchema', incidentMessageBodySchema as never, {
+    required: ['body'],
+    optional: [],
+  })
+})
+
+test('INCIDENT_MESSAGE_LIMITS — frozen bounds', () => {
+  assert.equal(INCIDENT_MESSAGE_LIMITS.min, 1)
+  assert.equal(INCIDENT_MESSAGE_LIMITS.max, 5000)
+})
+
+test('incidentMessageBodySchema — rejects empty body', () => {
+  const result = incidentMessageBodySchema.safeParse({ body: '' })
+  assert.equal(result.success, false)
+})


### PR DESCRIPTION
## Summary

Continues the contract-hardening pattern from PRs #488/#489/#509: inline Zod schemas declared inside HTTP route handlers were invisible to the freeze suite. Extracting them puts them on the public surface so per-domain freeze tests can pin shape + limits.

## What lands

- **\`src/shared/types/auth.ts\`** (new) — \`registerSchema\` + \`REGISTER_PASSWORD_LIMITS\` (8..100). \`firstName\`/\`lastName\` limits derive from \`PROFILE_FIELD_LIMITS\` so a width change propagates to both signup and profile-edit.
- **\`src/shared/types/incidents.ts\`** (new) — \`openIncidentBodySchema\` (\`orderId\` + \`IncidentType\` + 10..5000 \`description\`) and \`incidentMessageBodySchema\` (1..5000 \`body\`), with numeric-limit constants exported.
- **3 route files** swap inline schema for shared import:
  - \`src/app/api/auth/register/route.ts\`
  - \`src/app/api/incidents/route.ts\`
  - \`src/app/api/incidents/[id]/messages/route.ts\`
- **\`test/contracts/domain/auth-schemas.test.ts\`** — 5 tests (frozen shape, password-bounds pin, cross-check that firstName max really derives from \`PROFILE_FIELD_LIMITS\`, short-password + bad-email probes).
- **\`test/contracts/domain/incidents-schemas.test.ts\`** — 7 tests (both shapes frozen, both limit constants pinned, short/oversized description + unknown \`IncidentType\` + empty-body rejection probes).

## Why each schema

Every extracted schema crosses an HTTP boundary (buyer client posts JSON; server parses). Drift here breaks the buyer flow silently — the route would still 200 with wrong validation, or 422 a previously-valid payload, depending on the change.

Side benefit: the public-surface barrels under \`@/shared/types\` now hold the four key buyer-facing contracts (snapshots, profile, auth, incidents) — easy to grep and update together.

## Test plan

- [x] \`npm run lint\` exits 0
- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run typecheck:test\` exits 0
- [x] \`npm test\` passes 817/817 (13 new + baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)