### PR TITLE
perf(pwa): image SWR cache, nav preload, immutable static assets

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -73,7 +73,23 @@ The SW is versioned via `SW_VERSION` in `public/sw.js`. The value is **auto-gene
 |--------------------|-------|--------------------------------------------|-------------------------|
 | `mp-offline-v1`    | 2     | `/offline` only                            | Precache on install     |
 | `mp-static-v1`     | 3     | `/_next/static/*`, icons, favicons, OG     | Stale-while-revalidate, LRU 60 |
+| `mp-images-v1`     | 4     | `/_next/image` + `/uploads/*`              | Stale-while-revalidate, LRU 200 |
 | `mp-prefetch-v1`   | Fase3 | `/api/catalog/featured?limit=12` JSON      | Replaced on periodic sync |
+
+### Navigation preload
+
+The `activate` handler calls `registration.navigationPreload.enable()` on
+supported browsers. This lets the browser kick off the page fetch in
+parallel with SW boot instead of waiting for the SW to wake up, which
+saves roughly 50–300 ms on cold navigations. `handleNavigation` prefers
+the preload response when available and falls back to `fetch` otherwise.
+
+### HTTP-layer caching
+
+- `/_next/static/*` → `public, max-age=31536000, immutable` (content-hashed)
+- `/_next/image` → `public, max-age=86400, stale-while-revalidate=604800`
+- `/sw.js` → `no-store` (deploys must never be pinned)
+- `/manifest.webmanifest` → `public, max-age=0, must-revalidate`
 
 On `activate` the SW deletes any cache not in the current allow-list. That's
 how old versions get pruned on each deploy.
@@ -322,7 +338,7 @@ Run this after any change to the PWA surface.
 - [ ] `npm run build && npm start`
 - [ ] DevTools › Application › Manifest: zero errors, 3 icons + 3 shortcuts + 2 screenshots
 - [ ] Service Workers: active, scope `/`, version matches `SW_VERSION`
-- [ ] Cache Storage: `mp-offline-v1`, `mp-static-v1` present; `mp-prefetch-v1` appears after periodic sync
+- [ ] Cache Storage: `mp-offline-v1`, `mp-static-v1` present; `mp-images-v1` fills as you browse product images; `mp-prefetch-v1` appears after periodic sync
 - [ ] Lighthouse › PWA audit › "Installable": ✅
 - [ ] Lighthouse › Performance on repeat visit: ≥ first-visit score
 - [ ] Install via URL bar icon → app launches in its own window in `standalone` mode

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,16 @@ const NO_STORE_CACHE_HEADER = {
   value: 'no-store, no-cache, must-revalidate, proxy-revalidate',
 }
 
+// Next emits content-hashed filenames under /_next/static (e.g. the
+// JS bundle filename includes a build hash). That means a given URL
+// never changes meaning — perfect candidate for long-term immutable
+// caching. `no-store` here was over-defensive and forced every repeat
+// visitor to revalidate on each request.
+const STATIC_IMMUTABLE_CACHE_HEADER = {
+  key: 'Cache-Control',
+  value: 'public, max-age=31536000, immutable',
+}
+
 export function buildHeaderRules(isDevelopment = process.env.NODE_ENV === 'development'): HeaderRule[] {
   const rules: HeaderRule[] = [
     {
@@ -36,11 +46,17 @@ export function buildHeaderRules(isDevelopment = process.env.NODE_ENV === 'devel
     rules.unshift(
       {
         source: '/_next/static/:path*',
-        headers: [NO_STORE_CACHE_HEADER],
+        headers: [STATIC_IMMUTABLE_CACHE_HEADER],
       },
       {
+        // Optimized images — deterministic per source+query, safe to
+        // cache for a day at the HTTP layer. The SW layer on top (see
+        // public/sw.template.js → mp-images-v1) gives repeat visits a
+        // disk-hit instead of a network round trip.
         source: '/_next/image',
-        headers: [NO_STORE_CACHE_HEADER],
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=604800' },
+        ],
       },
     )
   }

--- a/public/sw.template.js
+++ b/public/sw.template.js
@@ -1,25 +1,18 @@
 /* Mercado Productor — PWA service worker.
  *
- * Phase 3 (current): stale-while-revalidate runtime cache for a strict
- * allow-list of public static assets. Navigations still use the
- * Phase 2 offline fallback. Everything else is pass-through.
+ * Runtime strategy:
+ *   - Stale-while-revalidate for a strict allow-list of static assets
+ *   - Stale-while-revalidate for product images (/_next/image, /uploads/*)
+ *   - Navigation preload to cut SW boot latency on cold page loads
+ *   - Offline shell fallback when navigations fail
+ *   - Everything else is pass-through
  *
  * Caches
  * ------
- * - mp-offline-v1 : precached `/offline` shell (Phase 2)
- * - mp-static-v1  : runtime SWR cache for static assets (Phase 3)
- *
- * Allow-list for the static cache
- * -------------------------------
- * We only cache things that are either:
- *   a) content-addressed (hashed, safe to cache forever), or
- *   b) brand assets that change rarely and are same-origin public.
- *
- *   - /_next/static/*       (hashed JS/CSS/media from Next build)
- *   - /icons/icon-*.png     (manifest icons)
- *   - /favicon.svg, /favicon.ico
- *   - /opengraph-image, /twitter-image (crawler-facing OG images)
- *   - Anything ending in .woff2 under /_next/static (next/font)
+ * - mp-offline-v1  : precached `/offline` shell
+ * - mp-static-v1   : SWR cache for static assets (JS/CSS/fonts/icons)
+ * - mp-images-v1   : SWR cache for optimized product images, LRU 200
+ * - mp-prefetch-v1 : periodic-sync catalog JSON
  *
  * Exclusions (denylist — defensive second layer)
  * ----------------------------------------------
@@ -27,7 +20,7 @@
  *   Anything with query strings indicating user state
  *
  * An URL must pass the allow-list AND not hit the denylist to be cached.
- * LRU trim at MAX_STATIC_ENTRIES keeps the cache from growing unbounded.
+ * LRU trim keeps each cache from growing unbounded.
  */
 
 // __BUILD_ID__ is replaced at build time by scripts/build-sw.mjs. The
@@ -35,9 +28,11 @@
 const SW_VERSION = '__BUILD_ID__'
 const OFFLINE_CACHE = 'mp-offline-v1'
 const STATIC_CACHE = 'mp-static-v1'
+const IMAGE_CACHE = 'mp-images-v1'
 const PREFETCH_CACHE = 'mp-prefetch-v1'
 const OFFLINE_URL = '/offline'
 const MAX_STATIC_ENTRIES = 60
+const MAX_IMAGE_ENTRIES = 200
 
 const PROTECTED_PREFIXES = [
   '/api/',
@@ -68,6 +63,17 @@ function isCacheableStatic(url) {
   return false
 }
 
+function isCacheableImage(url) {
+  if (url.origin !== self.location.origin) return false
+  if (isProtected(url)) return false
+  const path = url.pathname
+  // Next's image optimizer — all product/CDN images flow through here.
+  if (path === '/_next/image' || path.startsWith('/_next/image?')) return true
+  // Locally-hosted uploads (LocalUploader dev/self-hosted path).
+  if (path.startsWith('/uploads/')) return true
+  return false
+}
+
 async function trimCache(cacheName, maxEntries) {
   const cache = await caches.open(cacheName)
   const keys = await cache.keys()
@@ -92,11 +98,20 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
-      const allowed = new Set([OFFLINE_CACHE, STATIC_CACHE, PREFETCH_CACHE])
+      const allowed = new Set([OFFLINE_CACHE, STATIC_CACHE, IMAGE_CACHE, PREFETCH_CACHE])
       const keys = await caches.keys()
       await Promise.all(
         keys.filter((k) => !allowed.has(k)).map((k) => caches.delete(k))
       )
+      // Navigation preload lets the browser start fetching the page in
+      // parallel with SW boot — saves ~50–300 ms on cold navigations.
+      if (self.registration.navigationPreload) {
+        try {
+          await self.registration.navigationPreload.enable()
+        } catch {
+          // Some browsers don't support it; ignore.
+        }
+      }
       await self.clients.claim()
     })()
   )
@@ -106,6 +121,9 @@ function handleNavigation(event) {
   event.respondWith(
     (async () => {
       try {
+        // Prefer the preload response if the browser fired one.
+        const preload = await event.preloadResponse
+        if (preload) return preload
         return await fetch(event.request)
       } catch {
         const cache = await caches.open(OFFLINE_CACHE)
@@ -148,6 +166,32 @@ function handleStaticAsset(event) {
   )
 }
 
+function handleImageAsset(event) {
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(IMAGE_CACHE)
+      const cached = await cache.match(event.request)
+      const networkPromise = fetch(event.request)
+        .then(async (response) => {
+          if (response && response.ok && response.type === 'basic') {
+            await cache.put(event.request, response.clone())
+            event.waitUntil(trimCache(IMAGE_CACHE, MAX_IMAGE_ENTRIES))
+          }
+          return response
+        })
+        .catch(() => null)
+
+      if (cached) {
+        event.waitUntil(networkPromise)
+        return cached
+      }
+      const network = await networkPromise
+      if (network) return network
+      return fetch(event.request)
+    })()
+  )
+}
+
 self.addEventListener('fetch', (event) => {
   const req = event.request
   if (req.method !== 'GET') return
@@ -163,6 +207,11 @@ self.addEventListener('fetch', (event) => {
 
   if (isCacheableStatic(url)) {
     handleStaticAsset(event)
+    return
+  }
+
+  if (isCacheableImage(url)) {
+    handleImageAsset(event)
     return
   }
   // Everything else: pass-through. No respondWith, no caching.


### PR DESCRIPTION
## Summary
- **Image SWR cache** (`mp-images-v1`, LRU 200) for `/_next/image` + `/uploads/*` — repeat product-image views now hit disk, no network
- **Navigation preload** enabled in SW `activate` — browser fetches the page while SW boots, saving ~50–300 ms on cold nav
- **`/_next/static/*`** now uses `public, max-age=31536000, immutable` instead of `no-store` — content-hashed URLs are safe to cache forever, and repeat visitors skip revalidation entirely
- `/_next/image` ships with `max-age=86400, stale-while-revalidate=604800` so the browser HTTP cache helps before the SW cache takes over

## Why now
After #512 (transparent auto-update) the user asked how efficient the PWA actually is. Static JS/CSS was already cached locally, but HTML navigations, product images, and the `no-store` on `_next/static` were leaving perf on the table. This closes those gaps.

## Test plan
- [ ] `npm run build && npm start` — confirm `public/sw.js` regenerates with the new handlers
- [ ] DevTools › Application › Service Workers → version bumps; Cache Storage shows `mp-images-v1` filling as you scroll the catalog
- [ ] DevTools › Network: a second visit to a product page serves the image from `(ServiceWorker)`, not the network
- [ ] `curl -I http://localhost:3000/_next/static/<hash>.js` → `Cache-Control: public, max-age=31536000, immutable`
- [ ] Navigation preload: in Network, top-level page requests show `Timing → Waiting (TTFB)` lower than before on cold starts
- [ ] Lighthouse PWA audit still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)