### PR TITLE
chore(ci): Lighthouse path filter → sw.template.js

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - 'src/app/manifest.ts'
-      - 'public/sw.js'
+      - 'public/sw.template.js'
+      - 'scripts/build-sw.mjs'
+      - 'next.config.ts'
       - 'src/components/pwa/**'
       - 'src/app/icons/**'
       - 'src/app/screenshots/**'


### PR DESCRIPTION
## Summary
- `public/sw.js` is now a generated artifact (gitignored since #512), so the Lighthouse workflow's path filter never matched after that PR merged
- Swap for `public/sw.template.js` (the actual tracked source) + add `scripts/build-sw.mjs` and `next.config.ts` since both changes affect the PWA surface

## Test plan
- [ ] This PR touches the workflow file itself, so Lighthouse should run on this PR and confirm the filter works