### PR TITLE
perf(pwa): cache cross-origin product images from allow-listed CDNs

### DIFF
--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -73,7 +73,7 @@ The SW is versioned via `SW_VERSION` in `public/sw.js`. The value is **auto-gene
 |--------------------|-------|--------------------------------------------|-------------------------|
 | `mp-offline-v1`    | 2     | `/offline` only                            | Precache on install     |
 | `mp-static-v1`     | 3     | `/_next/static/*`, icons, favicons, OG     | Stale-while-revalidate, LRU 60 |
-| `mp-images-v1`     | 4     | `/_next/image` + `/uploads/*`              | Stale-while-revalidate, LRU 200 |
+| `mp-images-v1`     | 4     | `/_next/image`, `/uploads/*`, allow-listed CDN hosts (Unsplash, Cloudinary, uploadthing, Vercel Blob) | Stale-while-revalidate, LRU 200 |
 | `mp-prefetch-v1`   | Fase3 | `/api/catalog/featured?limit=12` JSON      | Replaced on periodic sync |
 
 ### Navigation preload

--- a/public/sw.template.js
+++ b/public/sw.template.js
@@ -63,15 +63,35 @@ function isCacheableStatic(url) {
   return false
 }
 
+// Cross-origin hosts whose images we allow into the SWR cache. Must match
+// the remotePatterns allow-list in next.config.ts so we never cache from
+// a host the app wouldn't otherwise render.
+const CDN_IMAGE_HOST_SUFFIXES = [
+  'images.unsplash.com',
+  '.cloudinary.com',
+  '.uploadthing.com',
+  '.public.blob.vercel-storage.com',
+]
+
+function isAllowedImageHost(hostname) {
+  return CDN_IMAGE_HOST_SUFFIXES.some((suffix) =>
+    suffix.startsWith('.') ? hostname.endsWith(suffix) : hostname === suffix
+  )
+}
+
 function isCacheableImage(url) {
-  if (url.origin !== self.location.origin) return false
-  if (isProtected(url)) return false
-  const path = url.pathname
-  // Next's image optimizer — all product/CDN images flow through here.
-  if (path === '/_next/image' || path.startsWith('/_next/image?')) return true
-  // Locally-hosted uploads (LocalUploader dev/self-hosted path).
-  if (path.startsWith('/uploads/')) return true
-  return false
+  if (url.origin === self.location.origin) {
+    if (isProtected(url)) return false
+    const path = url.pathname
+    // Next's image optimizer — most product/CDN images flow through here.
+    if (path === '/_next/image' || path.startsWith('/_next/image?')) return true
+    // Locally-hosted uploads (LocalUploader dev/self-hosted path).
+    if (path.startsWith('/uploads/')) return true
+    return false
+  }
+  // Cross-origin: only the whitelisted CDN hosts. Responses will be
+  // opaque (no CORS), but they're still cacheable as raw bytes.
+  return isAllowedImageHost(url.hostname)
 }
 
 async function trimCache(cacheName, maxEntries) {
@@ -173,7 +193,13 @@ function handleImageAsset(event) {
       const cached = await cache.match(event.request)
       const networkPromise = fetch(event.request)
         .then(async (response) => {
-          if (response && response.ok && response.type === 'basic') {
+          if (!response) return response
+          // Same-origin → basic+ok. Cross-origin no-CORS → opaque
+          // (status 0). Cache both — opaque bytes are fine for <img>.
+          const cacheable =
+            (response.ok && response.type === 'basic') ||
+            response.type === 'opaque'
+          if (cacheable) {
             await cache.put(event.request, response.clone())
             event.waitUntil(trimCache(IMAGE_CACHE, MAX_IMAGE_ENTRIES))
           }


### PR DESCRIPTION
## Summary
- `mp-images-v1` previously only matched `/_next/image` and `/uploads/*` — direct `<img>` tags hitting Cloudinary, Unsplash, uploadthing, or Vercel Blob bypassed the SW cache
- Extend `isCacheableImage` with a CDN host allow-list that mirrors `remotePatterns` in `next.config.ts`
- Accept opaque cross-origin responses in the SWR handler (no-CORS responses come back as `type === 'opaque'`, status 0 — still fine to serve back to `<img>`)

## Test plan
- [ ] `npm run build && npm start`, install PWA
- [ ] Browse a product page that uses `<img src="https://images.unsplash.com/…">` — first request goes to network, second visit hits `mp-images-v1` (DevTools › Network shows "(ServiceWorker)")
- [ ] DevTools › Application › Cache Storage › `mp-images-v1` lists both `/_next/image?...` and `https://images.unsplash.com/...` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)