### PR TITLE
feat(ops): /api/healthcheck synthetic probe + doctor integration

### DIFF
--- a/src/app/api/healthcheck/route.ts
+++ b/src/app/api/healthcheck/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+/**
+ * Synthetic health probe.
+ *
+ * Does ONE tiny Prisma query against every model that has historically
+ * been a source of schema drift (Order, Vendor, Subscription, Payment,
+ * User, Product). Each query is wrapped individually so we can report
+ * which model failed — a ColumnNotFound on Order.checkoutAttemptId
+ * shows up as { checks: { order: { ok: false, error: "..." } } }
+ * instead of a generic 500.
+ *
+ * Intentionally public (no auth): operators and external monitors need
+ * to hit this without credentials. Leaks no user data — every query is
+ * `count({ take: 0 })` equivalent (or a trivial `findFirst` that selects
+ * only the id). Added to PUBLIC_API_ROUTES with a documented reason.
+ *
+ * Response shape:
+ *   200 { ok: true, checks: { [model]: { ok: true } } }
+ *   503 { ok: false, checks: { [model]: { ok, error? } } }
+ *
+ * Never 500s — any thrown error is caught and serialized. A 500 here
+ * would defeat the point of a probe that exists to diagnose 500s.
+ */
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+type CheckResult = { ok: true } | { ok: false; error: string }
+
+async function probe(label: string, fn: () => Promise<unknown>): Promise<[string, CheckResult]> {
+  try {
+    await fn()
+    return [label, { ok: true }]
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return [label, { ok: false, error: message.slice(0, 300) }]
+  }
+}
+
+export async function GET() {
+  // Each probe exercises a column set that has broken in the past OR is
+  // central to the buy/sell flow. Queries are deliberately minimal so
+  // the route stays fast enough to poll every 30s.
+  const probes = await Promise.all([
+    probe('user', () => db.user.findFirst({ select: { id: true } })),
+    probe('vendor', () => db.vendor.findFirst({ select: { id: true, status: true } })),
+    probe('product', () =>
+      db.product.findFirst({ select: { id: true, basePrice: true, stock: true } })
+    ),
+    // Order is the model that produced the April 2026 ColumnNotFound on
+    // checkoutAttemptId — selecting the full row via "*" semantics would
+    // be more aggressive but less predictable. Naming the critical
+    // columns keeps the probe targeted.
+    probe('order', () =>
+      db.order.findFirst({
+        select: { id: true, checkoutAttemptId: true, paymentStatus: true },
+      })
+    ),
+    probe('payment', () =>
+      db.payment.findFirst({ select: { id: true, status: true, providerRef: true } })
+    ),
+    probe('subscription', () =>
+      db.subscription.findFirst({
+        select: { id: true, status: true, lastStripeEventAt: true },
+      })
+    ),
+    // Sub-issue: added 2026-04-17 after the checkoutAttemptId drift
+    // incident. The DLQ table is new-ish and has drifted before — keep
+    // a probe so operators see it here first, not as a 500 on oncall.
+    probe('webhookDeadLetter', () => db.webhookDeadLetter.findFirst({ select: { id: true } })),
+  ])
+
+  const checks: Record<string, CheckResult> = {}
+  let allOk = true
+  for (const [label, result] of probes) {
+    checks[label] = result
+    if (!result.ok) allOk = false
+  }
+
+  if (!allOk) {
+    // Log at error level so this shows up in existing observability
+    // infrastructure even when the caller only looks at the HTTP code.
+    logger.error('healthcheck.probe_failed', {
+      failedModels: Object.entries(checks)
+        .filter(([, r]) => !r.ok)
+        .map(([k]) => k),
+    })
+  }
+
+  return NextResponse.json(
+    { ok: allOk, checks },
+    {
+      status: allOk ? 200 : 503,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    }
+  )
+}

--- a/test/features/healthcheck-route.test.ts
+++ b/test/features/healthcheck-route.test.ts
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Structural pins for /api/healthcheck (#522).
+ *
+ * The route is operational infrastructure — the doctor script and any
+ * external monitor depend on its shape. These tests catch accidental
+ * removal of probes or changes that would break the script.
+ */
+
+const ROUTE = 'src/app/api/healthcheck/route.ts'
+
+function routeContent(): string {
+  return readFileSync(join(process.cwd(), ROUTE), 'utf-8')
+}
+
+test('healthcheck route exists', () => {
+  assert.ok(routeContent().length > 0)
+})
+
+test('healthcheck exports a GET handler', () => {
+  const content = routeContent()
+  assert.match(content, /export\s+async\s+function\s+GET\s*\(/)
+})
+
+test('healthcheck probes every model known to have drifted or centrally matter', () => {
+  const content = routeContent()
+  // These are the seven probes the doctor script + outside monitors
+  // rely on. Removing any requires updating the script AND any
+  // external alerting.
+  const required = [
+    "probe('user'",
+    "probe('vendor'",
+    "probe('product'",
+    "probe('order'",
+    "probe('payment'",
+    "probe('subscription'",
+    "probe('webhookDeadLetter'",
+  ]
+  for (const pattern of required) {
+    assert.ok(
+      content.includes(pattern),
+      `healthcheck must include ${pattern}. If removed intentionally, update doctor + this test.`
+    )
+  }
+})
+
+test('healthcheck Order probe specifically selects checkoutAttemptId (drift regression guard)', () => {
+  const content = routeContent()
+  // The April 2026 incident was ColumnNotFound on Order.checkoutAttemptId.
+  // Pinning this select keeps the probe's resolution as fine as the
+  // bug that motivated it.
+  assert.match(
+    content,
+    /db\.order\.findFirst[\s\S]{1,200}checkoutAttemptId/,
+    'Order probe must explicitly select checkoutAttemptId — see April 2026 drift incident.'
+  )
+})
+
+test('healthcheck never reaches a 500 — any throw is caught inside probe()', () => {
+  const content = routeContent()
+  // The contract: every failing probe returns `{ok: false, error}`.
+  // The handler itself returns 503 on any failure, 200 on all-ok.
+  // A 500 on /api/healthcheck would defeat its purpose as a probe.
+  assert.ok(
+    content.includes("status: allOk ? 200 : 503"),
+    'GET must return 200 on success, 503 on any probe failure — never 500.'
+  )
+  assert.ok(
+    content.includes('try {') && content.includes('catch'),
+    'probe() wrapper must use try/catch so individual failures never bubble.'
+  )
+})
+
+test('healthcheck response never caches (operators rely on live status)', () => {
+  const content = routeContent()
+  assert.ok(
+    content.includes("'Cache-Control': 'no-store'"),
+    'healthcheck must set Cache-Control: no-store so CDN / SW never serve stale health.'
+  )
+})
+
+test('healthcheck is force-dynamic (no Next static optimization)', () => {
+  const content = routeContent()
+  assert.match(content, /export\s+const\s+dynamic\s*=\s*'force-dynamic'/)
+})
+
+test('healthcheck does NOT import any session helper (public by design)', () => {
+  const content = routeContent()
+  const forbidden = [
+    'getActionSession',
+    'requireVendor',
+    'requireAdmin',
+    'requireBuyer',
+    'from \'@/lib/auth\'',
+  ]
+  for (const keyword of forbidden) {
+    assert.ok(
+      !content.includes(keyword),
+      `healthcheck must stay public — found auth helper ${keyword}. External monitors cannot authenticate.`
+    )
+  }
+})
+
+test('healthcheck logs probe failures at error level', () => {
+  const content = routeContent()
+  assert.match(
+    content,
+    /logger\.error\(['"]healthcheck\.probe_failed['"]/,
+    'Failed probes must emit logger.error("healthcheck.probe_failed", ...) so existing log alerts fire.'
+  )
+})

--- a/test/integration/api-route-auth-audit.test.ts
+++ b/test/integration/api-route-auth-audit.test.ts
@@ -74,6 +74,10 @@ const PUBLIC_API_ROUTES: ReadonlyArray<{ path: string; why: string }> = [
     path: 'src/app/api/incidents/[id]/messages/route.ts',
     why: 'Thin wrapper — delegates to postIncidentMessage() which enforces ownership via getActionSession.',
   },
+  {
+    path: 'src/app/api/healthcheck/route.ts',
+    why: 'Synthetic health probe. Public by design — external monitors and the marketplace-pwa-server doctor script hit it without credentials. Returns only boolean + model name + error message; no user data.',
+  },
 ]
 
 const SESSION_KEYWORDS = [


### PR DESCRIPTION
Closes the loop opened by the 2026-04-17 \`Order.checkoutAttemptId\` drift incident: a preview deploy that forgot \`prisma migrate deploy\` silently broke \`/vendor/dashboard\` with a \`ColumnNotFound\`. The doctor script's unauthenticated route probes couldn't catch it because the bug surfaces post-auth.

## What this PR adds

### \`/api/healthcheck\`
Synthetic probe endpoint. One tiny Prisma query per model that historically drifted or is central:

- \`user\` — sanity
- \`vendor\` — the model that 500'd in April 2026
- \`product\`
- \`order\` — explicitly selects \`checkoutAttemptId\` as drift canary
- \`payment\`
- \`subscription\` — explicitly selects \`lastStripeEventAt\` (#485 drift)
- \`webhookDeadLetter\`

### Contract (pinned by tests)
- **Never 500s.** Every probe wrapped in try/catch; handler returns 200 \`{ok: true}\` or 503 \`{ok: false, checks: {model: {ok: false, error}}}\`.
- **Public, no auth** — external monitors need this. Added to \`PUBLIC_API_ROUTES\` allow-list with documented reason. Leaks zero user data.
- \`force-dynamic\` + \`Cache-Control: no-store\` so SW/CDN never serve stale health.
- Emits \`logger.error('healthcheck.probe_failed', { failedModels })\` so existing log alerts fire.

### \`marketplace-pwa-server.sh doctor\`
Now hits \`/api/healthcheck\` after unauthenticated route probes and fails the overall doctor run if any model reports failure. This is the defence layer unauthenticated probes cannot provide.

## How this would have caught the April 17 incident
Before the fix, the vendor dashboard 500'd because \`Order.checkoutAttemptId\` didn't exist in the DB. With this endpoint, \`doctor\` would have failed at:

\`\`\`
── doctor · /api/healthcheck deep probe ───────────────────────
  ✗ healthcheck reports failures:
    "order": {
      "ok": false,
      "error": "The column \`Order.checkoutAttemptId\` does not exist in the current database."
    }
\`\`\`

...before any user tried to click "Panel productor".

## Tests (9 new, all green)
- Route exists, exports GET
- All seven probes present (regression guard)
- Order probe explicitly selects \`checkoutAttemptId\`
- Handler returns 200|503 never 500
- \`Cache-Control: no-store\` set
- \`force-dynamic\` annotation present
- No auth helper imports (public-by-design)
- Emits structured log on failure

## Test plan
- [x] \`npm run typecheck\` green
- [x] 9/9 healthcheck tests pass
- [x] \`api-route-auth-audit\` test still green (allow-list updated)
- [x] Local \`doctor\` output shows \`✓ all Prisma probes passed\`
- [ ] CI E2E smoke runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)