### PR TITLE
chore(ts): enable noImplicitOverride + tsconfig drift survey note

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -19,7 +19,9 @@ Last verified against `main`: 2026-04-15.
 
 ### Strictness — current state
 
-`tsconfig.json` enables `strict: true` plus `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters`, and **`noUncheckedIndexedAccess: true`** (Phase 10 of the contract-hardening plan; was a 45-error fix).
+`tsconfig.json` enables `strict: true` plus `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noUnusedLocals`, `noUnusedParameters`, **`noUncheckedIndexedAccess: true`** (Phase 10 of the contract-hardening plan; was a 45-error fix), and **`noImplicitOverride: true`** (one-line follow-up; one site needed the `override` modifier on `ShippingError.cause`).
+
+Two further flags surveyed and **deferred** (~120 errors each): `exactOptionalPropertyTypes` and `noPropertyAccessFromIndexSignature`. Each would be a multi-PR cleanup with low marginal safety vs the existing flags.
 
 `tsconfig.test.json` overrides `noUncheckedIndexedAccess: false` so test code can spread arrays / use bracket access without `!` everywhere — tests fail at runtime if they're wrong, so the extra static guard adds noise without value.
 

--- a/src/domains/shipping/domain/errors.ts
+++ b/src/domains/shipping/domain/errors.ts
@@ -1,7 +1,10 @@
 export class ShippingError extends Error {
   readonly code: string
   readonly retryable: boolean
-  readonly cause?: unknown
+  // ES2022 added `cause` to the built-in Error class. We override
+  // explicitly so noImplicitOverride catches future shadowing of
+  // base-Error fields without a marker.
+  override readonly cause?: unknown
 
   constructor(message: string, code: string, retryable: boolean, cause?: unknown) {
     super(message)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
         "./src/*"
       ]
     },
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary

One-line follow-up to Phase 10 (PR #491). Surveyed three additional strictness flags by counting errors against the post-Phase-10 baseline:

| Flag | Errors | Decision |
|------|--------|----------|
| \`noImplicitOverride\` | **1** | ✅ landed here |
| \`exactOptionalPropertyTypes\` | 126 | deferred — multi-PR cleanup |
| \`noPropertyAccessFromIndexSignature\` | 122 | deferred — multi-PR cleanup |

The single \`noImplicitOverride\` violation lived in \`src/domains/shipping/domain/errors.ts\`: \`ShippingError\` shadows the ES2022 \`Error.cause\` field without the \`override\` keyword. Marked it \`override readonly cause?: unknown\` — the only compile-impact change.

## Why this flag matters

TypeScript catches future class hierarchies that accidentally shadow base-class fields without intent. Same family of "tooling now flags what review used to catch" moves as Phase 10's \`noUncheckedIndexedAccess\`.

## Why the other two are deferred

Each needs ~120 sites of cleanup. Marginal contract-hardening value is real but diminishing — the obvious gaps are already closed by the existing strict flags + per-domain schema freezes (PRs #502/#509/#511/#513). \`docs/conventions.md\` notes the survey result so future agents don't re-discover.

## Test plan

- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run typecheck:test\` exits 0
- [x] \`npm run lint\` exits 0
- [x] Full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)