### PR TITLE
feat(telegram): Marcar enviado button on fulfillment-ready notifications (EPIC 5)

### DIFF
--- a/src/domains/notifications/telegram/actions/mark-shipped.ts
+++ b/src/domains/notifications/telegram/actions/mark-shipped.ts
@@ -1,0 +1,24 @@
+import { markShippedByUserId } from '@/domains/vendors'
+import type { ActionContext } from './registry'
+import {
+  answerCallbackQuery,
+  editMessageRemoveKeyboard,
+} from '../service'
+
+export async function markShippedAction(ctx: ActionContext): Promise<void> {
+  const result = await markShippedByUserId(ctx.userId, ctx.targetId)
+
+  if (!result.ok) {
+    const message =
+      result.code === 'NOT_FOUND'
+        ? 'Pedido no encontrado o ya no es tuyo'
+        : result.message
+    await answerCallbackQuery(ctx.callbackQueryId, message)
+    return
+  }
+
+  await answerCallbackQuery(ctx.callbackQueryId, '📦 Pedido enviado')
+  if (ctx.messageId !== null) {
+    await editMessageRemoveKeyboard(ctx.chatId, ctx.messageId).catch(() => undefined)
+  }
+}

--- a/src/domains/notifications/telegram/handlers/register.ts
+++ b/src/domains/notifications/telegram/handlers/register.ts
@@ -5,6 +5,7 @@ import { onOrderPending } from './on-order-pending'
 import { onMessageReceived } from './on-message-received'
 import { registerAction } from '../actions/registry'
 import { confirmFulfillmentAction } from '../actions/confirm-fulfillment'
+import { markShippedAction } from '../actions/mark-shipped'
 
 const GLOBAL_KEY = '__marketplaceTelegramHandlersRegistered'
 
@@ -20,6 +21,7 @@ export function registerTelegramHandlers(): void {
   on('message.received', onMessageReceived)
 
   registerAction('confirmFulfillment', confirmFulfillmentAction)
+  registerAction('markShipped', markShippedAction)
 
   g[GLOBAL_KEY] = true
 }

--- a/src/domains/notifications/telegram/templates.ts
+++ b/src/domains/notifications/telegram/templates.ts
@@ -48,11 +48,14 @@ export function orderPendingTemplate(payload: OrderPendingPayload): OutboundMess
     payload.reason === 'NEEDS_CONFIRMATION'
       ? 'Esperando confirmación.'
       : 'Pendiente de enviar.'
+  const buttons: InlineKeyboardButton[] = []
+  if (payload.reason === 'NEEDS_SHIPMENT' && payload.fulfillmentId) {
+    buttons.push({ text: '📦 Marcar enviado', callback_data: `markShipped:${payload.fulfillmentId}` })
+  }
+  buttons.push({ text: 'Ver', url: `${appUrl()}/vendor/pedidos/${payload.orderId}` })
   return {
     text: `⏳ Pedido <b>#${id}</b>\n${reasonText}`,
-    inline_keyboard: [[
-      { text: 'Ver', url: `${appUrl()}/vendor/pedidos/${payload.orderId}` },
-    ]],
+    inline_keyboard: [buttons],
   }
 }
 

--- a/src/domains/shipping/transitions.ts
+++ b/src/domains/shipping/transitions.ts
@@ -13,6 +13,8 @@ import { db } from '@/lib/db'
 import { safeRevalidatePath } from '@/lib/revalidate'
 import type { ShipmentStatusInternal } from '@/domains/shipping/domain/types'
 import { isValidTransition } from '@/domains/shipping/domain/state-machine'
+// eslint-disable-next-line no-restricted-imports -- dispatcher is intentionally server-only, excluded from notifications barrel
+import { emit as emitNotification } from '@/domains/notifications/dispatcher'
 import type {
   FulfillmentStatus,
   ShipmentStatus,
@@ -155,6 +157,15 @@ export async function applyShipmentTransition(input: ApplyTransitionInput) {
       },
     })
     await recomputeOrderStatus(shipment.fulfillment.orderId)
+
+    if (nextFulfillment === 'READY') {
+      emitNotification('order.pending', {
+        orderId: shipment.fulfillment.orderId,
+        vendorId: shipment.fulfillment.vendorId,
+        fulfillmentId: shipment.fulfillmentId,
+        reason: 'NEEDS_SHIPMENT',
+      })
+    }
   }
 
   safeRevalidatePath('/vendor/pedidos')

--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -401,6 +401,59 @@ export async function confirmFulfillmentByUserId(
   return { ok: true, fulfillmentId }
 }
 
+/**
+ * Mark a READY fulfillment as SHIPPED on behalf of the vendor identified by
+ * userId rather than a browser session. Mirrors confirmFulfillmentByUserId
+ * for out-of-band entrypoints (Telegram webhook callbacks).
+ *
+ * Only READY → SHIPPED is allowed — any other state is rejected so stale
+ * Telegram buttons cannot move the FSM backwards or skip states. The
+ * parent order status is recomputed in the same transaction as
+ * advanceFulfillment does.
+ */
+export async function markShippedByUserId(
+  userId: string,
+  fulfillmentId: string,
+): Promise<
+  | { ok: true; fulfillmentId: string }
+  | { ok: false; code: 'NOT_FOUND' | 'INVALID_STATE'; message: string }
+> {
+  const fulfillment = await db.vendorFulfillment.findFirst({
+    where: { id: fulfillmentId, vendor: { userId } },
+    select: { id: true, status: true, orderId: true },
+  })
+  if (!fulfillment) {
+    return { ok: false, code: 'NOT_FOUND', message: 'Fulfillment no encontrado' }
+  }
+  if (fulfillment.status !== 'READY') {
+    return {
+      ok: false,
+      code: 'INVALID_STATE',
+      message: `No se puede marcar como enviado desde el estado ${fulfillment.status}`,
+    }
+  }
+
+  await db.$transaction(async tx => {
+    await tx.vendorFulfillment.update({
+      where: { id: fulfillmentId },
+      data: { status: 'SHIPPED', shippedAt: new Date() },
+    })
+
+    const siblings = await tx.vendorFulfillment.findMany({
+      where: { orderId: fulfillment.orderId },
+      select: { status: true },
+    })
+    const allShipped = siblings.every(f => f.status === 'SHIPPED')
+    await tx.order.update({
+      where: { id: fulfillment.orderId },
+      data: { status: allShipped ? 'SHIPPED' : 'PARTIALLY_SHIPPED' },
+    })
+  })
+
+  safeRevalidatePath('/vendor/pedidos')
+  return { ok: true, fulfillmentId }
+}
+
 export async function getMyFulfillments(filter?: 'active' | 'urgent' | 'shipped' | 'all') {
   const { vendor } = await requireVendor()
 

--- a/test/features/telegram-templates.test.ts
+++ b/test/features/telegram-templates.test.ts
@@ -101,6 +101,38 @@ test('every callback_data payload fits within the 64-byte Telegram limit', () =>
   }
 })
 
+test('orderPendingTemplate includes markShipped button only for NEEDS_SHIPMENT with fulfillmentId', () => {
+  const withFul = orderPendingTemplate({
+    orderId: 'ord_1',
+    vendorId: 'vnd_1',
+    fulfillmentId: 'ful_XYZ',
+    reason: 'NEEDS_SHIPMENT',
+  })
+  const needsConfirm = orderPendingTemplate({
+    orderId: 'ord_1',
+    vendorId: 'vnd_1',
+    fulfillmentId: 'ful_XYZ',
+    reason: 'NEEDS_CONFIRMATION',
+  })
+  const noFul = orderPendingTemplate({
+    orderId: 'ord_1',
+    vendorId: 'vnd_1',
+    reason: 'NEEDS_SHIPMENT',
+  })
+
+  const callbacksOf = (msg: { inline_keyboard?: Array<Array<unknown>> }) =>
+    (msg.inline_keyboard ?? [])
+      .flat()
+      .filter((b): b is { callback_data: string } =>
+        typeof b === 'object' && b !== null && 'callback_data' in b,
+      )
+      .map(b => b.callback_data)
+
+  assert.deepEqual(callbacksOf(withFul), ['markShipped:ful_XYZ'])
+  assert.deepEqual(callbacksOf(needsConfirm), [])
+  assert.deepEqual(callbacksOf(noFul), [])
+})
+
 test('orderPendingTemplate picks copy based on reason', () => {
   const needsConfirm = orderPendingTemplate({
     orderId: 'ord_1',


### PR DESCRIPTION
## Summary
- Closes the second half of EPIC 5 from [RFC 0002](docs/rfcs/0002-telegram-integration.md). Vendors get a **📦 Marcar enviado** inline button on Telegram notifications fired when a Sendcloud webhook lands their fulfillment on `READY`.
- New `markShippedByUserId(userId, fulfillmentId)` domain action in `vendors/actions.ts` performs the `READY → SHIPPED` transition plus the order-status recompute (mirrors `advanceFulfillment`). Any non-READY state is rejected.
- `applyShipmentTransition` now emits `order.pending(NEEDS_SHIPMENT)` when a shipment transition flips the fulfillment to READY. The manual `advanceFulfillment` path stays silent — the vendor is already in the app in that case.
- Telegram layer stays logic-free: the `markShipped` callback handler simply reuses the domain action, mirrors the `confirmFulfillment` pattern from #518.

## Scope kept narrow
- No changes to the Sendcloud label-creation branch (that was the original reason the RFC deferred this button).
- No changes to `order.created` emission, no new events.
- `confirmFulfillment` untouched.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint …` clean on touched files
- [x] `node scripts/audit-domain-contracts.mjs` clean
- [x] `test/features/telegram-templates.test.ts` — added coverage for the new button rendering rules (present only for NEEDS_SHIPMENT + fulfillmentId; absent otherwise). All 8 tests pass.
- [ ] Manual: set `TELEGRAM_BOT_TOKEN`, drive a Sendcloud webhook to `LABEL_CREATED`, confirm the Telegram message arrives with the button and tapping it transitions the fulfillment to SHIPPED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)