### PR TITLE
test(contracts/domain): freeze notifications schemas + shrink audit allowlist

### DIFF
--- a/scripts/audit-domain-contracts.mjs
+++ b/scripts/audit-domain-contracts.mjs
@@ -45,26 +45,18 @@ const ANY_ALLOWLIST = new Set([
 // only with a one-line justification in the comment. Reasons that
 // qualify: (a) the schema is a private validation helper one caller
 // uses internally, (b) the schema is intentionally lenient and the
-// shape doesn't matter, (c) deprecated and being removed,
-// (d) TODO(freeze): scheduled for a follow-up freeze PR.
+// shape doesn't matter, (c) deprecated and being removed.
 const SCHEMA_FREEZE_ALLOWLIST = new Set([
   // Wrapper around orderItemSchema (which IS pinned in
   // test/contracts/domain/orders-schemas.test.ts):
   'orderItemsSchema',
 
-  // ─── Notifications domain (PR #504 / Telegram integration) ────────────────
-  // These shipped without freeze tests; the audit caught them on first run.
-  // Recommended to freeze in a follow-up. Allowlisted here so the audit
-  // mechanism itself can ship without being held by unrelated cleanup.
-  'orderCreatedPayloadSchema',     // TODO(freeze): outbound notification payload contract
-  'orderPendingPayloadSchema',     // TODO(freeze): outbound notification payload contract
-  'messageReceivedPayloadSchema',  // TODO(freeze): outbound notification payload contract
-  'setPreferenceInputSchema',      // TODO(freeze): preference write surface
-  'telegramMessageSchema',         // sub-schema of telegramUpdateSchema (already pinned via telegramUpdateSchema test)
-  'telegramCallbackQuerySchema',   // sub-schema of telegramUpdateSchema (already pinned)
-  'notificationChannelSchema',     // TODO(freeze): nativeEnum wrapper, low-risk
-  'notificationEventTypeSchema',   // TODO(freeze): nativeEnum wrapper, low-risk
-  'notificationDeliveryStatusSchema', // TODO(freeze): nativeEnum wrapper, low-risk
+  // Sub-schemas of telegramUpdateSchema. The parent schema is
+  // exercised in test/features/telegram-update-schema.test.ts; its
+  // parse covers these via composition, so a separate freeze
+  // would be redundant.
+  'telegramMessageSchema',
+  'telegramCallbackQuerySchema',
 ])
 
 const VIOLATIONS = {

--- a/test/contracts/domain/notifications-schemas.test.ts
+++ b/test/contracts/domain/notifications-schemas.test.ts
@@ -1,0 +1,217 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  notificationChannelSchema,
+  notificationEventTypeSchema,
+  notificationDeliveryStatusSchema,
+} from '@/domains/notifications/types'
+import {
+  orderCreatedPayloadSchema,
+  orderPendingPayloadSchema,
+  messageReceivedPayloadSchema,
+  NOTIFICATION_EVENTS,
+} from '@/domains/notifications/events'
+import { setPreferenceInputSchema } from '@/domains/notifications/preferences-schema'
+
+/**
+ * Schema-freeze for the notifications domain (Telegram integration).
+ * Closes the seven `TODO(freeze)` markers added in the audit
+ * allowlist by PR #514 — those schemas now have explicit shape +
+ * value pins so the audit allowlist can stay at its principled
+ * minimum (just helpers and sub-schemas).
+ *
+ * Why these matter:
+ *
+ *   - notificationChannel/EventType/DeliveryStatus → drift here
+ *     means a new transport (e.g. WhatsApp) or event type lands
+ *     without a deliberate update; the dispatcher's switch
+ *     statements would silently miss the new variant.
+ *
+ *   - orderCreated/orderPending/messageReceivedPayload → outbound
+ *     payload contracts to Telegram. A silent rename would send
+ *     templates with the wrong fields filled in.
+ *
+ *   - setPreferenceInput → the buyer/vendor preference write
+ *     surface; drift would 422 a previously valid call from the
+ *     UI toggle.
+ */
+
+type ExpectedShape = {
+  required: readonly string[]
+  optional: readonly string[]
+}
+
+function assertObjectShape(
+  label: string,
+  schema: { _zod: { def: { shape: Record<string, { _zod: { optin?: string } }> } } },
+  expected: ExpectedShape,
+) {
+  const shape = schema._zod.def.shape
+  const actualKeys = Object.keys(shape).sort()
+  const expectedKeys = [...expected.required, ...expected.optional].sort()
+
+  assert.deepEqual(actualKeys, expectedKeys, `${label}: schema key set drifted.`)
+
+  const required: string[] = []
+  const optional: string[] = []
+  for (const [key, field] of Object.entries(shape)) {
+    const isOptional = field._zod.optin === 'optional'
+    if (isOptional) optional.push(key)
+    else required.push(key)
+  }
+  required.sort()
+  optional.sort()
+
+  assert.deepEqual(required, [...expected.required].sort(), `${label}: required drifted.`)
+  assert.deepEqual(optional, [...expected.optional].sort(), `${label}: optional drifted.`)
+}
+
+function assertEnumValues(
+  label: string,
+  schema: { _zod: { def: { values?: readonly string[]; entries?: Record<string, string> } } },
+  expected: readonly string[],
+) {
+  // z.enum stores values either as `values` (Zod v4 string-array form)
+  // or `entries` (object form). Read whichever exists.
+  const def = schema._zod.def
+  const actual = def.values
+    ? [...def.values]
+    : def.entries
+      ? Object.values(def.entries)
+      : []
+  assert.deepEqual(
+    actual.slice().sort(),
+    [...expected].sort(),
+    `${label}: enum value set drifted. Adding/removing a member here is a deliberate change — update this test in the same PR.`,
+  )
+}
+
+// ─── Discriminator enums ──────────────────────────────────────────────────────
+
+test('notificationChannelSchema — frozen value set', () => {
+  // Adding a transport (e.g. WHATSAPP, EMAIL) is a deliberate
+  // architectural change — every dispatcher that switches on
+  // channel needs a new case.
+  assertEnumValues('notificationChannelSchema', notificationChannelSchema as never, ['TELEGRAM'])
+})
+
+test('notificationEventTypeSchema — frozen value set', () => {
+  assertEnumValues('notificationEventTypeSchema', notificationEventTypeSchema as never, [
+    'ORDER_CREATED',
+    'ORDER_PENDING',
+    'MESSAGE_RECEIVED',
+  ])
+})
+
+test('notificationDeliveryStatusSchema — frozen value set', () => {
+  assertEnumValues('notificationDeliveryStatusSchema', notificationDeliveryStatusSchema as never, [
+    'SENT',
+    'FAILED',
+    'SKIPPED',
+  ])
+})
+
+test('NOTIFICATION_EVENTS string keys match the enum', () => {
+  // The runtime event-name constants and the discriminator enum
+  // values both encode the same set; they must agree or the
+  // dispatcher's lookup tables drift.
+  assert.deepEqual(
+    Object.keys(NOTIFICATION_EVENTS).sort(),
+    ['MESSAGE_RECEIVED', 'ORDER_CREATED', 'ORDER_PENDING'],
+  )
+  assert.deepEqual(
+    Object.values(NOTIFICATION_EVENTS).sort(),
+    ['message.received', 'order.created', 'order.pending'],
+  )
+})
+
+// ─── Outbound payloads ────────────────────────────────────────────────────────
+
+test('orderCreatedPayloadSchema — frozen shape', () => {
+  assertObjectShape('orderCreatedPayloadSchema', orderCreatedPayloadSchema as never, {
+    required: ['orderId', 'vendorId', 'customerName', 'totalCents', 'currency'],
+    optional: ['fulfillmentId'],
+  })
+})
+
+test('orderCreatedPayloadSchema — currency is exactly 3 chars', () => {
+  // ISO 4217 contract — drifting this would let "EURO" through
+  // and break Telegram template rendering.
+  const result = orderCreatedPayloadSchema.safeParse({
+    orderId: 'o',
+    vendorId: 'v',
+    customerName: 'A',
+    totalCents: 100,
+    currency: 'EURO',
+  })
+  assert.equal(result.success, false)
+})
+
+test('orderPendingPayloadSchema — frozen shape', () => {
+  assertObjectShape('orderPendingPayloadSchema', orderPendingPayloadSchema as never, {
+    required: ['orderId', 'vendorId', 'reason'],
+    optional: ['fulfillmentId'],
+  })
+})
+
+test('orderPendingPayloadSchema — reason set is frozen', () => {
+  // The two `reason` values map to two distinct vendor actions
+  // (confirm vs ship). A new reason without code coverage
+  // downstream would render a generic notification.
+  const ok1 = orderPendingPayloadSchema.safeParse({
+    orderId: 'o', vendorId: 'v', reason: 'NEEDS_CONFIRMATION',
+  })
+  assert.equal(ok1.success, true)
+  const ok2 = orderPendingPayloadSchema.safeParse({
+    orderId: 'o', vendorId: 'v', reason: 'NEEDS_SHIPMENT',
+  })
+  assert.equal(ok2.success, true)
+  const bad = orderPendingPayloadSchema.safeParse({
+    orderId: 'o', vendorId: 'v', reason: 'NEEDS_REFUND',
+  })
+  assert.equal(bad.success, false)
+})
+
+test('messageReceivedPayloadSchema — frozen shape', () => {
+  assertObjectShape('messageReceivedPayloadSchema', messageReceivedPayloadSchema as never, {
+    required: ['conversationId', 'vendorId', 'fromUserName', 'preview'],
+    optional: [],
+  })
+})
+
+test('messageReceivedPayloadSchema — preview is capped at 200 chars', () => {
+  // Telegram message body cap — drift would risk silently
+  // truncating mid-sentence on the recipient side.
+  const result = messageReceivedPayloadSchema.safeParse({
+    conversationId: 'c',
+    vendorId: 'v',
+    fromUserName: 'Ada',
+    preview: 'x'.repeat(201),
+  })
+  assert.equal(result.success, false)
+})
+
+// ─── Preferences write surface ────────────────────────────────────────────────
+
+test('setPreferenceInputSchema — frozen shape', () => {
+  assertObjectShape('setPreferenceInputSchema', setPreferenceInputSchema as never, {
+    required: ['channel', 'eventType', 'enabled'],
+    optional: [],
+  })
+})
+
+test('setPreferenceInputSchema — rejects unknown channel/eventType', () => {
+  const badChannel = setPreferenceInputSchema.safeParse({
+    channel: 'WHATSAPP',
+    eventType: 'ORDER_CREATED',
+    enabled: true,
+  })
+  assert.equal(badChannel.success, false)
+
+  const badEvent = setPreferenceInputSchema.safeParse({
+    channel: 'TELEGRAM',
+    eventType: 'ORDER_REFUNDED',
+    enabled: true,
+  })
+  assert.equal(badEvent.success, false)
+})


### PR DESCRIPTION
## Summary

Closes the seven \`TODO(freeze)\` markers I left in \`scripts/audit-domain-contracts.mjs\` (PR #514) for the notifications domain. Each TODO is now a real freeze test; the allowlist drops back to its principled minimum.

## What lands

- **\`test/contracts/domain/notifications-schemas.test.ts\`** (new) — 12 tests covering:
  - \`notificationChannelSchema\` (TELEGRAM only) — a new transport (WhatsApp, Email, …) forces a deliberate update
  - \`notificationEventTypeSchema\` (3 values) + matching cross-check that \`NOTIFICATION_EVENTS\` string keys agree
  - \`notificationDeliveryStatusSchema\` (SENT|FAILED|SKIPPED)
  - \`orderCreatedPayloadSchema\` frozen shape + currency-length probe (ISO 4217 contract)
  - \`orderPendingPayloadSchema\` frozen shape + reason-set probe (NEEDS_CONFIRMATION | NEEDS_SHIPMENT)
  - \`messageReceivedPayloadSchema\` frozen shape + 200-char preview cap probe
  - \`setPreferenceInputSchema\` frozen shape + rejection probes for unknown channel/eventType

- **\`scripts/audit-domain-contracts.mjs\`** — \`SCHEMA_FREEZE_ALLOWLIST\` shrunk from 9 entries to 3. Only:
  - \`orderItemsSchema\` (wrapper around the already-pinned \`orderItemSchema\`)
  - \`telegramMessageSchema\`, \`telegramCallbackQuerySchema\` (composed into \`telegramUpdateSchema\`, exercised transitively in \`test/features/telegram-update-schema.test.ts\`)

## Why now

I added those allowlist entries with TODO markers in PR #514. Closing them is debt I created. The audit script's mechanism keeps detecting NEW unfrozen schemas; this PR cleans up the seven that were already known when the mechanism shipped.

## Test plan

- [x] \`npm test\` passes 928/928 (12 new + baseline)
- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run lint\` exits 0
- [x] \`npm run audit:contracts\` → 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)