### PR TITLE
chore(cleanup): drop redundant @types deps + justify 5 stale eslint-disables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,6 @@
         "@sentry/nextjs": "^10.49.0",
         "@stripe/react-stripe-js": "^6.1.0",
         "@stripe/stripe-js": "^9.1.0",
-        "@types/bcryptjs": "^2.4.6",
-        "@types/pg": "^8.20.0",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5009,12 +5007,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
-      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
     "@sentry/nextjs": "^10.49.0",
     "@stripe/react-stripe-js": "^6.1.0",
     "@stripe/stripe-js": "^9.1.0",
-    "@types/bcryptjs": "^2.4.6",
-    "@types/pg": "^8.20.0",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/admin/AdminProducersClient.tsx
+++ b/src/components/admin/AdminProducersClient.tsx
@@ -410,7 +410,7 @@ function ProducerRow({
       <td className="px-4 py-3">
         <div className="flex items-start gap-3">
           {p.logo ? (
-            // eslint-disable-next-line @next/next/no-img-element
+            // eslint-disable-next-line @next/next/no-img-element -- vendor logo URLs come from arbitrary CDNs allow-listed at upload time; next/image's domain config would re-litigate that allowlist
             <img
               src={p.logo}
               alt=""

--- a/src/components/vendor/SubscriptionPlanForm.tsx
+++ b/src/components/vendor/SubscriptionPlanForm.tsx
@@ -152,7 +152,7 @@ export function SubscriptionPlanForm({
         setValue('cadence', next, { shouldDirty: true, shouldValidate: true })
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-evaluate when productId changes; including takenFor / cadence / setValue would re-run on every render and snap the cadence away while the user is still picking
   }, [productId])
 
   // Pre-compute the disabled-reason map for the product picker. Depends
@@ -171,7 +171,7 @@ export function SubscriptionPlanForm({
       }
     }
     return map
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- takenFor + cadenceTakenLabelKey are stable helpers (closures over takenCadencesByProduct, which IS in deps). Listing them would force a useMemo on each helper for no observable benefit
   }, [products, cadence, isEdit, takenCadencesByProduct, t])
 
   function onSubmit(values: FormValues) {

--- a/src/components/vendor/VendorHeroUpload.tsx
+++ b/src/components/vendor/VendorHeroUpload.tsx
@@ -127,7 +127,7 @@ export function VendorHeroUpload({
         >
           {hasCover ? (
             <>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
+              {/* eslint-disable-next-line @next/next/no-img-element -- vendor cover URL is from arbitrary storage (Vercel Blob, local uploads); routing it through next/image would force domain allow-list updates on every new tenant */}
               <img src={coverValue} alt="" className="h-full w-full object-cover" />
               <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 text-sm font-medium text-white opacity-0 transition group-hover:bg-black/40 group-hover:opacity-100 group-focus-visible:bg-black/40 group-focus-visible:opacity-100">
                 <span className="inline-flex items-center gap-1.5">
@@ -174,7 +174,7 @@ export function VendorHeroUpload({
           >
             {hasLogo ? (
               <>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
+                {/* eslint-disable-next-line @next/next/no-img-element -- vendor logo URL is from arbitrary storage; same reason as the cover above */}
                 <img src={logoValue} alt="" className="h-full w-full object-cover" />
                 <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/45 group-hover:opacity-100 group-focus-visible:bg-black/45 group-focus-visible:opacity-100">
                   <CameraIcon className="h-5 w-5 text-white" />

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -50,7 +50,10 @@ export async function sendEmail({
       throw new Error(`Email send failed: ${result.error.message}`)
     }
 
-    console.log(`[Email] Sent to ${to}: ${subject}`)
+    // info-level: a successful send is operationally interesting
+    // but not an error. console.info is consistent with the
+    // structured-log scope used elsewhere ([Email] prefix).
+    console.info(`[Email] Sent to ${to}: ${subject}`)
     return result
   } catch (error) {
     console.error(`[Email] Error sending to ${to}:`, error)


### PR DESCRIPTION
## Summary

Cross-codebase audit follow-up to the contract-hardening epic. A survey of \`src/\` surfaced these specific items; each is a tight, low-risk cleanup.

## What lands

### 1. Drop two redundant devDependencies

- **\`@types/bcryptjs\`** — \`bcryptjs@3.0.3\` ships its own \`.d.ts\` (\`node_modules/bcryptjs/{index,types}.d.ts\`) and declares \`"types": "umd/index.d.ts"\`. The separate \`@types\` package was pinned at 2.4.6 and contributed nothing.
- **\`@types/pg\`** — \`pg\` is never imported directly. We use \`@prisma/adapter-pg\`, which bundles its own types. The bare \`@types/pg\` was dead weight.

### 2. Replace one \`console.log\` with \`console.info\` in \`src/lib/email.ts\`

A successful send is operationally interesting but not an error; the mismatch with \`console.error\` one line below was noise for the log shipper.

### 3. Add \`--\` justifications to five \`eslint-disable\` comments

The repo's convention is to suffix every disable with \`-- <reason>\`. Five were missing that:

- **\`AdminProducersClient.tsx\`** (no-img-element) — vendor logo URLs come from arbitrary CDNs allow-listed at upload time
- **\`VendorHeroUpload.tsx\` ×2** (no-img-element) — vendor cover/logo URLs from arbitrary storage; same rationale
- **\`SubscriptionPlanForm.tsx\` ×2** (react-hooks/exhaustive-deps) — one effect intentionally depends only on productId; one \`useMemo\` intentionally lists \`takenCadencesByProduct\` over its closure helpers

## Why now

Post-Phase-11 codebase survey found these as the only real cleanup items in \`src/\` outside the deferred-by-design strict flags. Each disable now answers "why" without a reviewer digging.

## Test plan

- [x] \`npm run typecheck:app\` exits 0
- [x] \`npm run typecheck:test\` exits 0
- [x] \`npm run lint\` exits 0
- [x] \`npm test\` passes 928/928
- [x] \`npm run audit:contracts\` → 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)