### PR TITLE
obs: migrate last 3 console.* calls to logger + thread correlationId (#311)

### DIFF
--- a/docs/runbooks/payment-incidents.md
+++ b/docs/runbooks/payment-incidents.md
@@ -69,6 +69,14 @@ you the `correlationId` → grep the logs with it per scenarios below.
 | `stripe.webhook.invoice_paid_stale` | Out-of-order invoice dropped. |
 | `stripe.webhook.invoice_payment_failed_stale` | Out-of-order invoice.failed dropped. |
 | `stripe.webhook.dead_letter_record_failed` | DLQ row couldn't be written. On-call emergency. |
+| `stripe.webhook.retry` | Transient DB/network failure inside a webhook handler step — backing off and retrying (attempt N of M). Emitted from `src/domains/payments/webhook.ts`. |
+| `stripe.webhook.retry_exhausted` | All retries failed. The handler then throws → Stripe sees 500 and will redeliver. Investigate the `operation` field to know which step (`insertWebhookDelivery`, `confirmOrder`, etc.). |
+
+### Payment-provider events (from `src/domains/payments/provider.ts`)
+
+| Scope | What it means |
+|---|---|
+| `checkout.stripe_intent_create_failed` | `stripe.paymentIntents.create()` threw. Retries up to 2 times internally. Context carries `orderId`, `correlationId`, `amountCents`, `attempt`, `connectDestination`. Correlate to [`checkout.payment_intent_failed`](#checkout-events-from-createorder--createcheckoutorder) upstream — same incident, caller's view. |
 
 ## Scenario 1: buyer says "I was charged but I don't have an order"
 

--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -776,7 +776,7 @@ export async function createOrder(
   try {
     payment = await createPaymentIntent(
       Math.round(grandTotal * 100), // cents
-      { userId: sessionUserId },
+      { userId: sessionUserId, orderId: order.id, correlationId },
       connectDestination ? { connect: connectDestination } : undefined
     )
   } catch (paymentError) {

--- a/src/domains/payments/provider.ts
+++ b/src/domains/payments/provider.ts
@@ -5,6 +5,7 @@
  */
 import crypto from 'crypto'
 import { getServerEnv } from '@/lib/env'
+import { logger } from '@/lib/logger'
 
 export interface PaymentIntent {
   id: string
@@ -88,10 +89,12 @@ export async function createPaymentIntent(
       }
     } catch (error) {
       lastError = error
-      console.error('[checkout] stripe payment intent creation failed', {
+      logger.error('checkout.stripe_intent_create_failed', {
         amountCents,
         attempt,
         connectDestination: options?.connect?.vendorAccountId ?? null,
+        orderId: metadata.orderId ?? null,
+        correlationId: metadata.correlationId ?? null,
         error,
       })
     }

--- a/src/domains/payments/webhook.ts
+++ b/src/domains/payments/webhook.ts
@@ -1,4 +1,5 @@
 import type { OrderStatus, PaymentStatus } from '@/generated/prisma/enums'
+import { logger } from '@/lib/logger'
 
 interface PaymentSnapshot {
   paymentStatus: PaymentStatus
@@ -155,7 +156,7 @@ export async function retryWebhookOperation<T>(
     } catch (error) {
       if (!isRetryableWebhookError(error) || attempt === maxAttempts) {
         if (attempt === maxAttempts) {
-          console.error('[stripe-webhook][retry-exhausted]', {
+          logger.error('stripe.webhook.retry_exhausted', {
             operation: operationName,
             attempts: maxAttempts,
             error,
@@ -165,7 +166,7 @@ export async function retryWebhookOperation<T>(
       }
 
       const delayMs = baseDelayMs * 2 ** (attempt - 1)
-      console.warn('[stripe-webhook][retry]', {
+      logger.warn('stripe.webhook.retry', {
         operation: operationName,
         attempt,
         nextAttempt: attempt + 1,

--- a/test/features/structured-log-events.test.ts
+++ b/test/features/structured-log-events.test.ts
@@ -57,7 +57,22 @@ const REQUIRED_STRIPE_WEBHOOK_EVENTS: EventAssertion = {
   ],
 }
 
-for (const { file, events } of [REQUIRED_CHECKOUT_EVENTS, REQUIRED_STRIPE_WEBHOOK_EVENTS]) {
+const REQUIRED_WEBHOOK_RETRY_EVENTS: EventAssertion = {
+  file: 'src/domains/payments/webhook.ts',
+  events: ['stripe.webhook.retry', 'stripe.webhook.retry_exhausted'],
+}
+
+const REQUIRED_PAYMENT_PROVIDER_EVENTS: EventAssertion = {
+  file: 'src/domains/payments/provider.ts',
+  events: ['checkout.stripe_intent_create_failed'],
+}
+
+for (const { file, events } of [
+  REQUIRED_CHECKOUT_EVENTS,
+  REQUIRED_STRIPE_WEBHOOK_EVENTS,
+  REQUIRED_WEBHOOK_RETRY_EVENTS,
+  REQUIRED_PAYMENT_PROVIDER_EVENTS,
+]) {
   test(`${file}: all required event names still present`, () => {
     const content = readFileSync(join(process.cwd(), file), 'utf-8')
     const missing: string[] = []
@@ -92,6 +107,16 @@ test('stripe webhook route no longer uses console.* for logging', () => {
     !/console\.(warn|error|info|debug|log)\s*\(/.test(content),
     'stripe webhook route must use logger.* for all structured logging'
   )
+})
+
+test('webhook retry + payment provider no longer use console.* for logging', () => {
+  for (const file of ['src/domains/payments/webhook.ts', 'src/domains/payments/provider.ts']) {
+    const content = readFileSync(join(process.cwd(), file), 'utf-8')
+    assert.ok(
+      !/console\.(warn|error|info|debug|log)\s*\(/.test(content),
+      `${file} must use logger.* for all structured logging`,
+    )
+  }
 })
 
 test('correlation ID is threaded through checkout logs', () => {


### PR DESCRIPTION
Closes #311.

## Summary
- Heavy lifting for #311 shipped in #414/#415/#416 (27 structured scopes + runbook). This PR closes three stragglers outside that coverage.
- `webhook.ts:retryWebhookOperation()` — 2 `console.*` calls inside the transient-error retry loop → `stripe.webhook.retry` / `stripe.webhook.retry_exhausted`. Oncall can now grep retry storms by scope instead of free-text.
- `provider.ts:createPaymentIntent()` — 1 `console.error` when Stripe's API throws → `checkout.stripe_intent_create_failed`. `orders/actions.ts` now threads `orderId` + `correlationId` into the metadata passed to Stripe, so the same ids land in **both** our logs AND the Stripe PaymentIntent metadata (reconciliation win).
- Regression test pins the 3 new scopes and asserts no `console.*` remains in either file.
- Runbook updated with the new entries + cross-reference to the existing `checkout.payment_intent_failed` caller-side event.

## Test plan
- [x] `node --test test/features/structured-log-events.test.ts` — 8/8 passing
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] CI (integration shards will re-run payment tests; retry handler exercised by `stripe-webhook*.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)