### PR TITLE
db: drop runtime tolerance for missing shippingAddressSnapshot column (#307)

### DIFF
--- a/docs/runbooks/payment-incidents.md
+++ b/docs/runbooks/payment-incidents.md
@@ -41,7 +41,6 @@ you the `correlationId` → grep the logs with it per scenarios below.
 | `checkout.committed` | Order + Payment rows created. Includes `orderId`, `orderNumber`, `providerRef`, `grandTotalCents`. |
 | `checkout.address_fallback` | Saved address not found — fell back to submitted payload. |
 | `checkout.address_save_failed` | `tx.address.create` threw. Checkout continued. |
-| `checkout.snapshot_column_missing` | Retry without `shippingAddressSnapshot` column. DB migration drift. |
 | `checkout.payment_intent_failed` | Payment provider threw. Placeholder Payment row marked FAILED. |
 | `checkout.payment_mark_failed` | FAILED-marking itself failed after provider error. Requires manual cleanup. |
 | `checkout.payment_row_mismatch` | Linked ≠ 1 unlinked PENDING rows. Defensive — investigate immediately. |

--- a/src/domains/orders/actions.ts
+++ b/src/domains/orders/actions.ts
@@ -80,11 +80,6 @@ function roundCurrency2(value: number): number {
   return Math.round(value * 100) / 100
 }
 
-function isMissingShippingAddressSnapshotColumnError(error: unknown) {
-  return error instanceof Error
-    && /P2022|column .*does not exist|shippingAddressSnapshot/i.test(error.message)
-}
-
 /**
  * Detects Prisma's P2002 unique-constraint error on
  * `Order.checkoutAttemptId`. Used by `createOrder` to collapse a
@@ -116,10 +111,6 @@ function getCheckoutErrorMessage(error: unknown) {
 
     if (/direcci[óo]n guardada|no encontrada/i.test(message)) {
       return 'Tu dirección guardada ya no estaba disponible. Hemos mantenido los datos del formulario para que puedas completar la compra igualmente.'
-    }
-
-    if (isMissingShippingAddressSnapshotColumnError(error)) {
-      return 'Estamos terminando una actualización interna del checkout. Recarga la página y vuelve a intentarlo.'
     }
 
     if (/payment intent|payment_intent|stripe|temporarily unavailable|timeout|timed out|deadlock|closed the connection|ECONN|network/i.test(message)) {
@@ -515,7 +506,7 @@ export async function createOrder(
   // "try again" message.
   const env = getServerEnv()
 
-  async function createOrderRecord(includeShippingAddressSnapshot: boolean) {
+  async function createOrderRecord() {
     return db.$transaction(async tx => {
       let addressId: string | null = null
       let shouldSaveNewAddress = Boolean(validated.saveAddress)
@@ -677,7 +668,7 @@ export async function createOrder(
           customerId: sessionUserId,
           addressId: addressId ?? null,
           ...(checkoutAttemptId ? { checkoutAttemptId } : {}),
-          ...(includeShippingAddressSnapshot ? { shippingAddressSnapshot } : {}),
+          shippingAddressSnapshot,
           subtotal,
           discountTotal,
           shippingCost,
@@ -718,7 +709,7 @@ export async function createOrder(
 
   let order
   try {
-    order = await createOrderRecord(true)
+    order = await createOrderRecord()
   } catch (error) {
     // Concurrent double-submit with the same checkoutAttemptId: the
     // UNIQUE constraint on Order.checkoutAttemptId tripped. Re-read
@@ -755,17 +746,13 @@ export async function createOrder(
       throw error
     }
 
-    if (!isMissingShippingAddressSnapshotColumnError(error)) {
-      throw error
-    }
-
-    logger.error('checkout.snapshot_column_missing', {
-      correlationId,
-      userId: sessionUserId,
-      error,
-    })
-
-    order = await createOrderRecord(false)
+    // Anything else — schema drift, stock conflict, provider outage —
+    // must fail loud. The prior tolerance for a missing
+    // `shippingAddressSnapshot` column was removed in #307: the doctor
+    // workflow + /api/healthcheck already catch incompatible DB state
+    // in CI and preview before traffic hits it, so runtime fallback is
+    // no longer justified.
+    throw error
   }
 
   // Post-commit: the order + a placeholder Payment row exist. Now we

--- a/test/features/structured-log-events.test.ts
+++ b/test/features/structured-log-events.test.ts
@@ -25,7 +25,6 @@ const REQUIRED_CHECKOUT_EVENTS: EventAssertion = {
     'checkout.committed',
     'checkout.address_fallback',
     'checkout.address_save_failed',
-    'checkout.snapshot_column_missing',
     'checkout.payment_mark_failed',
     'checkout.payment_intent_failed',
     'checkout.payment_row_mismatch',


### PR DESCRIPTION
Closes #307.

## Summary
- Removes the retry-without-snapshot fallback in `createOrder()`. Production correctness now depends on migrations being applied, not on the app shrugging off drift.
- Dropped `isMissingShippingAddressSnapshotColumnError()`, the `createOrderRecord(false)` branch, and the user-facing "estamos terminando una actualización interna" error message.
- Removed the obsolete `checkout.snapshot_column_missing` scope from the structured-log regression test + runbook — it can't fire anymore.

## Why this is safe now
Deployment guard already exists from prior work:
- #525 adds `.github/workflows/doctor.yml` — runs `prisma migrate deploy` + HTTP + `/api/healthcheck` deep probe on every PR and on main post-merge.
- #526 adds authenticated post-middleware probes so a 500 inside a protected server component (e.g. the old `P2022` symptom) fails CI before merge.
- Preview server script also runs doctor — a drifted preview DB fails loud.

If a schema-drift deploy somehow reaches prod, it will now throw a loud `createCheckoutOrder` error + a Sentry event (#523) rather than silently persisting orders without their shipping snapshot.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `node --test test/features/structured-log-events.test.ts` — 8/8
- [x] `checkout-persist-first` + `checkout-failure-states` + `order-create` integration — 23/23

🤖 Generated with [Claude Code](https://claude.com/claude-code)