### PR TITLE
ci(security): gitleaks + npm audit + semgrep scanners

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,141 @@
+name: Security Scan
+
+# Three complementary scanners that catch classes this repo's manual
+# audit doesn't cover:
+#   - npm audit:   known-vuln dependencies (runtime only; devDeps are noisier
+#                  and don't ship to users)
+#   - gitleaks:    committed secrets (AUTH_SECRET, sk_live_..., etc.)
+#   - semgrep:     pattern-level SAST (OWASP Top 10, Next.js, TypeScript)
+#
+# npm audit and gitleaks are blocking — both have low false-positive rates.
+# Semgrep runs advisory (continue-on-error) because Next.js / React rulesets
+# flip between releases and we don't want a semgrep rule update to block an
+# unrelated PR at 5pm on a Friday. Findings still appear in the job summary.
+#
+# Required-check status:
+#   - "Security scan" = the aggregate "all-blocking-steps-passed" job below.
+#   - Add it to branch protection once the first run is green to keep
+#     secrets and known-vuln deps out of main.
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.vscode/**'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.vscode/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dep-audit:
+    name: npm audit (runtime deps)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/setup-deps
+
+      - name: Fail on high/critical vulnerabilities in runtime deps
+        run: |
+          # --omit=dev: devDeps don't ship to users. Typical offenders
+          #   there are build tooling CVEs that can't exploit a prod
+          #   deploy. If we want to gate devDeps too, a separate
+          #   advisory-only step is the right shape.
+          # --audit-level=high: surface lows/moderates in the log but
+          #   only fail the job when something is actually shippable
+          #   and serious.
+          npm audit --omit=dev --audit-level=high
+
+  gitleaks:
+    name: gitleaks (committed secrets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history needed so gitleaks can scan the whole diff on
+          # pushes to main and not miss secrets that slipped in via a
+          # squash-merge of a long-lived branch.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the repo's gitleaks config if present, otherwise gitleaks'
+          # built-in ruleset. The built-in catches Stripe keys, AWS keys,
+          # GitHub tokens, and generic "private key" BEGIN blocks.
+          GITLEAKS_CONFIG: .gitleaks.toml
+
+  semgrep:
+    name: semgrep (SAST)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Advisory for now: Next.js and React rulesets churn between
+    # releases and we don't want unrelated PRs blocked by rule drift.
+    # Flip to continue-on-error: false once the ruleset baseline is
+    # quiet (no findings on main for a week).
+    continue-on-error: true
+    container:
+      image: semgrep/semgrep:latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Scan
+        # --error:                exit nonzero on any finding (caught by
+        #                         continue-on-error above for now)
+        # --sarif:                upload to GitHub Code Scanning so findings
+        #                         land in the Security tab, not just logs
+        # Rulesets:
+        #   p/owasp-top-ten       classic injection / authz / crypto issues
+        #   p/javascript          eval / document.write / dangerouslySet...
+        #   p/typescript          type-assertion footguns
+        #   p/nextjs              SSR-specific patterns
+        #   p/react               hooks / effect-dep XSS shapes
+        #   p/secrets             defence-in-depth with gitleaks
+        run: |
+          semgrep --error --sarif --output=semgrep.sarif \
+            --config=p/owasp-top-ten \
+            --config=p/javascript \
+            --config=p/typescript \
+            --config=p/nextjs \
+            --config=p/react \
+            --config=p/secrets
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  security-scan:
+    name: Security scan
+    # Aggregate status check — the single name to require in branch
+    # protection so the individual scanner jobs can be renamed /
+    # reshuffled without touching the protection rules.
+    runs-on: ubuntu-latest
+    needs:
+      - dep-audit
+      - gitleaks
+      # Intentionally NOT listing `semgrep` here while it's advisory:
+      # we don't want a semgrep-rule-update to take this aggregate red.
+    steps:
+      - run: echo "All blocking security scans passed"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,36 @@
+# gitleaks config.
+#
+# Starts from the bundled default ruleset (Stripe keys, AWS keys,
+# GitHub PATs, generic BEGIN blocks) and adds the project-specific
+# allowlist needed so test fixtures and dev placeholders don't flag.
+
+title = "marketplace gitleaks"
+
+[extend]
+# Inherit the community default rules from gitleaks' bundled set.
+# Override individual rules in the [[rules]] blocks below.
+useDefault = true
+
+[allowlist]
+description = "Project-wide allowlist for known non-secrets"
+
+# Files that genuinely store secret-shaped strings that are NOT secrets:
+#   - .env.example ships placeholders like "sk_test_..." for documentation
+#   - test fixtures use dev pepper / dev JWT values
+#   - generated Prisma client may embed binary-looking blobs
+paths = [
+  '''^\.env\.example$''',
+  '''^docs/''',
+  '''^test/''',
+  '''^e2e/''',
+  '''^src/generated/''',
+]
+
+# Hard-coded dev-only fallbacks used when AUTH_SECRET is unset in unit
+# tests. Intentionally committed so tests can derive a stable hash
+# without wiring env vars. The literal string is scoped to the token
+# pepper helpers in src/domains/auth/*.
+regexes = [
+  '''dev-only-fallback-do-not-use-in-prod''',
+  '''ci-secret-please-change''',
+]

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "lint": "eslint . --max-warnings=0",
     "audit:contracts": "node ./scripts/audit-domain-contracts.mjs",
+    "audit:deps": "npm audit --omit=dev --audit-level=high",
     "prisma:generate": "prisma generate",
     "db:migrate": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate dev",
     "db:seed": "node --env-file=.env --env-file-if-exists=.env.local --import tsx prisma/seed.ts",


### PR DESCRIPTION
## Summary

Three complementary CI scanners that catch classes the manual audit missed:

- **npm audit** (runtime deps, fails on high/critical) — blocks known-vuln shipped deps. Scoped to `--omit=dev`.
- **gitleaks** — detects committed secrets (Stripe, AWS, GitHub PAT, BEGIN blocks) on the full diff. Project allowlist in \`.gitleaks.toml\` for \`.env.example\`, test fixtures, and the dev-only token-pepper fallback.
- **semgrep** — SAST against \`p/owasp-top-ten\` + \`p/javascript\` + \`p/typescript\` + \`p/nextjs\` + \`p/react\` + \`p/secrets\`. Findings upload as SARIF to GitHub Code Scanning (Security tab).

**Blocking:** npm audit + gitleaks. The aggregate status check name is \`Security scan\`.
**Advisory:** semgrep (\`continue-on-error\`) — flip to blocking after a quiet week on main.

## Test plan

- [x] \`npm run audit:deps\` locally → 0 vulnerabilities
- [ ] First CI run on this PR is green
- [ ] After merge, add \`Security scan\` to branch protection required checks
- [ ] Review semgrep findings on main for a week; if < 5 false positives, flip to blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)