### PR TITLE
security: prefer cf-connecting-ip + under-attack runbook (#540)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - **Sentry error tracking (DSN, scrubber, correlation)** — see [`src/lib/sentry/`](src/lib/sentry/) + [`sentry.server.config.ts`](sentry.server.config.ts). Every new pattern added to `src/lib/sentry/scrubber.ts` MUST come with a test in `test/features/sentry-scrubber.test.ts` proving the PII class is caught. PII leak via Sentry is a GDPR exposure.
 - **Resource-level authorization (role + ownership checklist, guard helpers, cross-tenant negative-test registry)** — see [`docs/authz-audit.md`](docs/authz-audit.md). Read before adding any server action or route handler. Route-level gating is not enough; every sensitive mutation must scope its Prisma query by caller id and ship at least one cross-tenant negative test.
 - **Branch protection & required checks (canonical list, rules, audit command)** — see [`docs/branch-protection.md`](docs/branch-protection.md). Update alongside the GitHub ruleset when adding/renaming a blocking workflow job; a renamed job with no ruleset update silently disables the gate.
+- **Under-attack / WAF runbook (Cloudflare config, rate-limit rules, edge playbook)** — see [`docs/runbooks/under-attack.md`](docs/runbooks/under-attack.md). Read before touching `src/lib/ratelimit.ts` or `src/lib/audit.ts` client-IP resolution; both prefer `cf-connecting-ip` under the Cloudflare topology (#540) and getting that precedence wrong collapses per-IP buckets.
 
 ## Concurrent-agent safety
 

--- a/docs/runbooks/under-attack.md
+++ b/docs/runbooks/under-attack.md
@@ -1,0 +1,110 @@
+# Under attack runbook — Cloudflare WAF
+
+Playbook for responding to L7 DDoS, credential stuffing, scraper floods, or slowloris against production. Assumes Cloudflare (free tier is enough) in front of Traefik → Node. Walk top-to-bottom; each step is reversible.
+
+## Signals — when to open this runbook
+
+- `/api/auth/*` 4xx spikes over baseline (`ratelimit` metric with `action=login|register|password-reset`).
+- Sentry flood from `src/app/api/**` with distinct IPs but identical User-Agent.
+- Sustained 5xx rate > 1% on the origin (check Grafana or doctor's `Server ready` healthcheck in preview).
+- Node event loop lag > 500ms (pm2/systemd `top` shows Node at 100% CPU with hundreds of concurrent sockets).
+- Credential-stuffing pattern: `/api/auth/callback/credentials` traffic with wide username/password variety from a narrow IP range.
+
+## Step 0 — verify you're actually behind Cloudflare
+
+```bash
+curl -I https://<domain>/ | grep -iE "cf-ray|cf-cache-status|server"
+```
+
+Expect `server: cloudflare` and a `cf-ray:` header. If missing → DNS has been detached or TTL hasn't flipped; fix DNS first, everything below is useless otherwise.
+
+Also confirm origin IP is not reachable from the public internet:
+
+```bash
+# From outside the private network:
+curl -I https://<origin-ip>/   # should time out or return 444
+```
+
+If the origin IP answers, Cloudflare can be bypassed. Close the firewall to everything except Cloudflare's [IP ranges](https://www.cloudflare.com/ips/) before continuing.
+
+## Step 1 — enable "Under Attack" mode (soft)
+
+Cloudflare dashboard → **Security → WAF → Tools → Security Level: Under Attack**. Shows a 5-second JS challenge to every visitor.
+
+- Scope: entire zone, ~30 minutes TTL. Legitimate buyers see a spinner, not an error.
+- Cost: all traffic goes through JS challenge; bots without a JS engine drop.
+- Reversible: set level back to **High** or **Medium** when traffic normalises.
+
+## Step 2 — rate-limit `/api/auth/*` at the edge
+
+Cloudflare → **Security → WAF → Rate limiting rules**. Required rule:
+
+```
+When:  http.request.uri.path matches ^/api/auth/
+Action: Block | Period: 10s | Requests: 20
+```
+
+This must run BEFORE the "Under Attack" challenge so brute-force attempts don't consume challenge tokens. The app rate-limit (`src/lib/ratelimit.ts`) is the backstop — it now reads `cf-connecting-ip` when present so per-IP buckets work correctly behind Cloudflare (#540).
+
+## Step 3 — identify the attack signature
+
+Cloudflare → **Analytics → Security events**. Filter by the spiking status / path / country / ASN. Usual shapes:
+
+- **Single ASN / datacenter**: add a WAF custom rule to `Challenge` or `Block` that ASN.
+- **Residential botnet**: JS challenge alone rarely suffices; require proof-of-work (`Managed Challenge` in Cloudflare terms).
+- **Slowloris**: Cloudflare absorbs it by default. If it still reaches origin, check Traefik `readTimeout` (`--entrypoints.web.transport.respondingTimeouts.readTimeout=30s`).
+
+Export the event sample to JSON and attach to the incident ticket.
+
+## Step 4 — block obvious offenders
+
+```
+When:  ip.src in { <list of abusive IPs> }
+Action: Block
+```
+
+Prefer ASN/country rules to individual IPs (botnet IPs rotate in minutes). Keep the block active for 24h, then re-evaluate.
+
+## Step 5 — check the app is still healthy
+
+```bash
+curl -fsS https://<domain>/api/healthcheck | jq '.ok, .checks'
+# or run the full doctor:
+node scripts/doctor.mjs --base-url https://<domain> --auth
+```
+
+If `/api/healthcheck` is returning non-200 you have two problems (attack + origin broken); roll back any recent deploy suspected of contributing.
+
+## Step 6 — escalate if we're saturating Cloudflare's free tier
+
+Cloudflare free tier has [10M requests/month soft limits](https://www.cloudflare.com/plans/) for WAF rules. If the attack is sustained:
+
+1. Upgrade to **Pro** (~$20/month) for richer rules + longer rate-limit windows.
+2. Consider Cloudflare Tunnel to hide the origin IP permanently.
+3. Open an Abuse ticket with the offending ASN's provider.
+
+## Step 7 — document and close
+
+Append to `docs/runbooks/under-attack.md#incidents` (below) with:
+
+- Start / end timestamps (UTC)
+- Attack shape (rough RPS at peak, IP/ASN dominance, path focus)
+- Rules activated and their TTL
+- Whether any legitimate buyer impact was observed (from Sentry + support tickets)
+
+Remove the "Under Attack" mode once traffic is baseline for 1h. Rate-limit rules from step 2 stay on permanently.
+
+## Permanent hardening (pre-incident)
+
+- [x] `cf-connecting-ip` preferred over `x-forwarded-for` in `src/lib/ratelimit.ts` and `src/lib/audit.ts` (#540).
+- [ ] Cloudflare DNS cut over with orange-cloud on the apex + www records.
+- [ ] WAF rate-limit rule permanently active on `/api/auth/*` (20 req/10s per IP).
+- [ ] Traefik strict `Host()` matcher so requests missing the expected Host header return 444 instead of falling through to the app.
+- [ ] Firewall on the Proxmox host allows inbound 443 only from Cloudflare IP ranges.
+- [ ] (Optional) Cloudflare Tunnel so origin IP is never public.
+
+Items marked `[ ]` are ops work that lives outside this repo; tick them once executed and link to the infra commit/ticket.
+
+## Incidents
+
+_(Append below in reverse-chronological order as they happen.)_

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -57,6 +57,14 @@ export async function mutateWithAudit<T>(
 }
 
 export function extractAuditIp(headerStore: Pick<Headers, 'get'>) {
+  // Cloudflare is authoritative when present (#540). It strips any
+  // client-supplied copy and fills this header with the actual client IP.
+  // Under the CF → Traefik topology, x-forwarded-for's leftmost entry is
+  // only reliable if the origin IP isn't bypassable — which is exactly
+  // what we can't assume yet.
+  const cfConnectingIp = headerStore.get('cf-connecting-ip')
+  if (cfConnectingIp) return cfConnectingIp.trim()
+
   const forwardedFor = headerStore.get('x-forwarded-for')
   if (forwardedFor) {
     const firstIp = forwardedFor.split(',')[0]?.trim()
@@ -65,7 +73,6 @@ export function extractAuditIp(headerStore: Pick<Headers, 'get'>) {
 
   return (
     headerStore.get('x-real-ip')
-    ?? headerStore.get('cf-connecting-ip')
     ?? headerStore.get('x-vercel-forwarded-for')
     ?? null
   )

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -279,6 +279,15 @@ export function getClientIP(request: Request, options: ResolveClientIpOptions = 
     return UNTRUSTED_CLIENT_KEY
   }
 
+  // Cloudflare always sends cf-connecting-ip with the originating client IP
+  // and strips any client-supplied copy of the header (#540). Preferred over
+  // x-forwarded-for because behind Cloudflare → Traefik the XFF chain is
+  // ["client", "cf-edge-ip"] and the leftmost entry can be spoofed if
+  // Cloudflare is bypassed via the origin IP. Keep x-forwarded-for only for
+  // non-Cloudflare deployments (Vercel, local Docker behind nginx).
+  const cfConnectingIp = request.headers.get('cf-connecting-ip')
+  if (cfConnectingIp) return cfConnectingIp.trim()
+
   const forwarded = request.headers.get('x-forwarded-for')
   if (forwarded) {
     return forwarded.split(',')[0]!.trim()

--- a/test/features/audit.test.ts
+++ b/test/features/audit.test.ts
@@ -13,6 +13,22 @@ test('extractAuditIp prioritizes the first forwarded address', () => {
   assert.equal(ip, '203.0.113.10')
 })
 
+test('extractAuditIp prefers cf-connecting-ip over x-forwarded-for (#540)', () => {
+  // Behind Cloudflare → Traefik the XFF chain is "client, cf-edge-ip".
+  // The leftmost entry is only trustworthy when the origin can't be
+  // bypassed. cf-connecting-ip is filled by Cloudflare with the actual
+  // client IP and any client-supplied copy is stripped — authoritative.
+  const ip = extractAuditIp({
+    get(name: string) {
+      if (name === 'cf-connecting-ip') return '203.0.113.50'
+      if (name === 'x-forwarded-for') return '198.51.100.77, 10.0.0.1'
+      return null
+    },
+  })
+
+  assert.equal(ip, '203.0.113.50')
+})
+
 test('extractAuditIp falls back to x-real-ip when forwarding chain is absent', () => {
   const ip = extractAuditIp({
     get(name: string) {

--- a/test/features/ratelimit.test.ts
+++ b/test/features/ratelimit.test.ts
@@ -75,6 +75,21 @@ test('getClientIP honors x-forwarded-for only when proxy trust is on', () => {
   assert.equal(getClientIP(req, { trustProxy: true }), '203.0.113.1')
 })
 
+test('getClientIP prefers cf-connecting-ip over x-forwarded-for (#540)', () => {
+  // Behind Cloudflare → Traefik the leftmost XFF entry is cf-edge-ip,
+  // not the real client. cf-connecting-ip is Cloudflare-filled and the
+  // only header guaranteed to carry the actual client IP under that
+  // topology. Without this, per-IP rate limiting collapses every
+  // request into the same bucket (cf-edge-ip) and ceases to be useful.
+  const req = new Request('http://localhost', {
+    headers: {
+      'cf-connecting-ip': '203.0.113.88',
+      'x-forwarded-for': '198.51.100.0, 10.0.0.1',
+    },
+  })
+  assert.equal(getClientIP(req, { trustProxy: true }), '203.0.113.88')
+})
+
 test('getClientIP falls back to x-real-ip when proxy trust is on', () => {
   const req = new Request('http://localhost', {
     headers: { 'x-real-ip': '203.0.113.2' },


### PR DESCRIPTION
App-side half of #540. The ops half (DNS cutover to Cloudflare, WAF rules, Traefik tightening, Cloudflare Tunnel) lives in the issue and is not part of this PR — this is the code change required for those ops changes to do anything useful.

## Summary
- **`src/lib/ratelimit.ts` + `src/lib/audit.ts`**: prefer `cf-connecting-ip` over `x-forwarded-for`. Under Cloudflare → Traefik, XFF's leftmost entry is the CF edge IP, collapsing every request into one rate-limit bucket. `cf-connecting-ip` is Cloudflare-filled and the client-supplied copy stripped — the only authoritative source under that topology.
- **`docs/runbooks/under-attack.md`**: 7-step playbook for L7 DDoS, credential stuffing, scraper floods, slowloris. Includes "Under Attack" toggle, WAF rate-limit on `/api/auth/*`, escalation thresholds, and a permanent-hardening checklist separating done-here from still-ops-work.
- **AGENTS.md** pointer so future agents hit the runbook before touching IP resolution.
- **Tests**: new positives pin `cf-connecting-ip` precedence in both `getClientIP` and `extractAuditIp`.

## Test plan
- [x] `npm run typecheck` + `npm run lint`
- [x] Targeted tests (`audit.test.ts`, `ratelimit.test.ts` IP resolution) — all green
- [ ] CI full run

## Out of scope
- DNS cutover and Cloudflare account config (ops)
- Traefik `Host()` strict matcher (ops)
- Cloudflare Tunnel (ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)