### PR TITLE
payments(ops): reconciliation sweeper for orphan/stuck PaymentIntents (#405)

### DIFF
--- a/docs/runbooks/payment-incidents.md
+++ b/docs/runbooks/payment-incidents.md
@@ -136,7 +136,38 @@ you the `correlationId` → grep the logs with it per scenarios below.
    "DLQ operations" section below):
      npm run dlq:list
      npm run dlq:list -- --json
+6. If the local Payment row is stuck PENDING because the webhook was
+   genuinely lost (Stripe delivered succeeded but our edge dropped it),
+   sweep it explicitly:
+     npm run reconcile:payments
+   See "Payment reconciliation sweep" below.
 ```
+
+## Payment reconciliation sweep (#405)
+
+Operator-triggered sweeper. Pulls Stripe's current state for every
+PENDING `Payment` row older than the cutoff and applies the matching
+transition locally. Safe to re-run — every update is guarded by the
+current status.
+
+| Command | Purpose |
+|---|---|
+| `npm run reconcile:payments` | Default 60-min cutoff. Stripe mode only; mock exits no-op. |
+| `npm run reconcile:payments -- --older-than 120` | 2-hour cutoff (less aggressive). |
+| `npm run reconcile:payments -- --dry-run` | Query + log decisions without writing. |
+| `npm run reconcile:payments -- --limit 100` | Cap per-invocation (default 500). |
+
+Decision matrix — [`src/domains/payments/reconcile.ts`](../../src/domains/payments/reconcile.ts):
+
+| Stripe PI status | Local action |
+|---|---|
+| `succeeded` + matching amount/currency | `Payment.status = SUCCEEDED`, `Order` → `PAYMENT_CONFIRMED`, `OrderEvent: PAYMENT_CONFIRMED` with `source: "reconcile-script"`. |
+| `succeeded` + amount/currency mismatch | **Skip + log** `payments.reconcile.mismatch_amount`. Matches the webhook's `stripe.webhook.payment_mismatch` guard — operator escalates, script does not paper over tampering. |
+| `canceled` | `Payment.status = FAILED`, `Order.paymentStatus = FAILED`, `OrderEvent: PAYMENT_FAILED`. |
+| `requires_payment_method` | Same as canceled. Buyer declined; PI will not recover. |
+| `processing` / `requires_action` / `requires_confirmation` / `requires_capture` | **Skip** — log `payments.reconcile.still_pending`, leave for next sweep. |
+
+Output is JSON (`reviewed / markedSucceeded / markedFailed / skipped / errors`) so it can be piped to a dashboard. Run after a webhook delivery incident, before a Stripe-mode cutover, or weekly as part of operational health.
 
 ## DLQ operations (#419)
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "db:studio": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js studio",
     "db:reset": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate reset --force && npm run db:seed",
     "dlq:list": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/dlq-list.ts",
-    "dlq:resolve": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/dlq-mark-resolved.ts"
+    "dlq:resolve": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/dlq-mark-resolved.ts",
+    "reconcile:payments": "node --env-file=.env --env-file-if-exists=.env.local --import tsx scripts/reconcile-payments.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/scripts/reconcile-payments.ts
+++ b/scripts/reconcile-payments.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Operator-triggered reconciliation sweep (#405). Compares stale
+ * PENDING Payment rows against Stripe and applies the corresponding
+ * state transition.
+ *
+ * Usage:
+ *   npm run reconcile:payments                       # default: 60-minute cutoff
+ *   npm run reconcile:payments -- --older-than 120   # 2-hour cutoff
+ *   npm run reconcile:payments -- --dry-run          # query + log, no writes
+ *
+ * Safe to re-run — every transition is guarded by current status.
+ * Mock mode exits cleanly with a no-op (no Stripe, nothing to
+ * reconcile).
+ */
+
+import { db } from '@/lib/db'
+import { getServerEnv } from '@/lib/env'
+import { logger } from '@/lib/logger'
+import {
+  makeStripeFetcher,
+  reconcilePendingPayments,
+} from '@/domains/payments/reconcile'
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  let olderThanMinutes = 60
+  let dryRun = false
+  let limit = 500
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i]
+    if (a === '--older-than') {
+      olderThanMinutes = Number(args[i + 1])
+      i += 1
+    } else if (a === '--dry-run') {
+      dryRun = true
+    } else if (a === '--limit') {
+      limit = Number(args[i + 1])
+      i += 1
+    }
+  }
+  if (!Number.isFinite(olderThanMinutes) || olderThanMinutes < 1) {
+    throw new Error('--older-than must be a positive number of minutes')
+  }
+  return { olderThanMinutes, dryRun, limit }
+}
+
+async function main() {
+  const { olderThanMinutes, dryRun, limit } = parseArgs()
+  const env = getServerEnv()
+
+  if (env.paymentProvider !== 'stripe') {
+    logger.info('payments.reconcile.skipped_mock', {
+      reason: 'PAYMENT_PROVIDER=mock — nothing to reconcile against Stripe',
+    })
+    process.stdout.write('mock mode: nothing to reconcile. exit.\n')
+    return
+  }
+
+  const stripe = await makeStripeFetcher()
+  if (!stripe) {
+    process.stderr.write(
+      'reconcile: expected stripe fetcher but got null — check STRIPE_SECRET_KEY.\n',
+    )
+    process.exit(1)
+  }
+
+  if (dryRun) {
+    process.stdout.write(
+      `reconcile (DRY RUN): olderThan=${olderThanMinutes}m limit=${limit}\n`,
+    )
+    // Wrap every write in a noop so the core loop runs unchanged.
+    const originalTx = db.$transaction.bind(db)
+    ;(db as { $transaction: typeof db.$transaction }).$transaction = (async (
+      arg: unknown,
+    ) => {
+      if (typeof arg === 'function') {
+        process.stdout.write('[dry-run] would open a transaction, skipping\n')
+        return undefined
+      }
+      return originalTx(arg as never)
+    }) as never
+  }
+
+  const report = await reconcilePendingPayments({
+    db,
+    stripe,
+    olderThanMinutes,
+    limit,
+  })
+
+  process.stdout.write(JSON.stringify(report, null, 2) + '\n')
+
+  if (report.errors > 0) process.exit(1)
+}
+
+main().catch(err => {
+  logger.error('payments.reconcile.fatal', { error: err })
+  process.stderr.write(`reconcile fatal: ${err?.message ?? err}\n`)
+  process.exit(1)
+})

--- a/src/domains/payments/reconcile.ts
+++ b/src/domains/payments/reconcile.ts
@@ -1,0 +1,311 @@
+/**
+ * Reconcile Stripe PaymentIntents against local Payment rows (#405).
+ *
+ * Rationale: persist-first (#404) eliminated the orphan-PI window for
+ * new checkouts, but we can still end up with stale PENDING Payment
+ * rows whose webhook was never delivered — network partition between
+ * Stripe and our webhook endpoint, edge outage, a paused Stripe
+ * account, etc. Without this sweeper those rows sit PENDING forever
+ * and the matching Stripe PI expires silently after 24h.
+ *
+ * The sweeper is operator-triggered (`npm run reconcile:payments`),
+ * not a cron, and idempotent — re-running is always safe because every
+ * state transition is guarded (status: {not: target}).
+ *
+ * Mock-mode callers get a no-op with a log line: mock PIs never touch
+ * Stripe so there's nothing to reconcile.
+ */
+
+import type { PrismaClient } from '@/generated/prisma/client'
+import { getServerEnv } from '@/lib/env'
+import { logger } from '@/lib/logger'
+
+export type StripePaymentIntentStatus =
+  | 'requires_payment_method'
+  | 'requires_confirmation'
+  | 'requires_action'
+  | 'processing'
+  | 'requires_capture'
+  | 'canceled'
+  | 'succeeded'
+
+export interface StripePaymentIntentSnapshot {
+  id: string
+  status: StripePaymentIntentStatus
+  amount: number
+  currency: string
+}
+
+/**
+ * Minimal Stripe client surface we need, carved out so unit tests can
+ * inject a fake without mocking the whole SDK.
+ */
+export interface StripePaymentIntentFetcher {
+  retrieve(id: string): Promise<StripePaymentIntentSnapshot>
+}
+
+export type ReconcileDecision =
+  | { action: 'mark_succeeded' }
+  | { action: 'mark_failed'; reason: 'canceled' | 'requires_payment_method' }
+  | { action: 'skip'; reason: 'still_pending' | 'mismatch_amount' }
+
+export interface LocalPaymentSnapshot {
+  providerRef: string
+  amount: number
+  currency: string
+}
+
+/**
+ * Pure decision function — given what Stripe says vs. what we store,
+ * pick the reconciliation action. Tested in isolation.
+ *
+ * `mismatch_amount` intentionally falls under `skip` rather than
+ * `mark_failed`: this is exactly the same signal the webhook handler
+ * flags as `stripe.webhook.payment_mismatch` and refuses to act on,
+ * because an amount divergence suggests tampering or data drift — the
+ * sweeper should NOT paper over that. The operator sees the warning in
+ * the script output and escalates by hand.
+ */
+export function decideReconcileAction(
+  local: LocalPaymentSnapshot,
+  remote: StripePaymentIntentSnapshot,
+): ReconcileDecision {
+  if (remote.status === 'succeeded') {
+    if (
+      remote.amount !== Math.round(local.amount * 100)
+      || remote.currency.toLowerCase() !== local.currency.toLowerCase()
+    ) {
+      return { action: 'skip', reason: 'mismatch_amount' }
+    }
+    return { action: 'mark_succeeded' }
+  }
+
+  if (remote.status === 'canceled') {
+    return { action: 'mark_failed', reason: 'canceled' }
+  }
+
+  // requires_payment_method after a failed auth is Stripe's way of
+  // saying "the card declined, please try again". From our perspective
+  // this PI will never succeed; treat it as FAILED so the Order stops
+  // sitting in PAYMENT_PENDING and the buyer can retry with a new
+  // checkout attempt.
+  if (remote.status === 'requires_payment_method') {
+    return { action: 'mark_failed', reason: 'requires_payment_method' }
+  }
+
+  return { action: 'skip', reason: 'still_pending' }
+}
+
+export interface ReconcileCandidate {
+  id: string
+  providerRef: string
+  orderId: string
+  amount: number
+  currency: string
+  createdAt: Date
+}
+
+export interface ReconcileReport {
+  reviewed: number
+  markedSucceeded: number
+  markedFailed: number
+  skipped: number
+  errors: number
+}
+
+/**
+ * Run the sweeper. Safe to re-run; each state transition is guarded by
+ * the current status so a concurrent webhook can't be double-applied.
+ *
+ * `olderThanMinutes` defaults to 60 — matches the Stripe PI "requires
+ * confirmation" grace window and avoids racing with real-time webhook
+ * delivery that might still be on its way.
+ */
+export async function reconcilePendingPayments({
+  db,
+  stripe,
+  olderThanMinutes = 60,
+  now = new Date(),
+  limit = 500,
+}: {
+  db: PrismaClient
+  stripe: StripePaymentIntentFetcher
+  olderThanMinutes?: number
+  now?: Date
+  limit?: number
+}): Promise<ReconcileReport> {
+  const cutoff = new Date(now.getTime() - olderThanMinutes * 60 * 1000)
+
+  const candidates = (await db.payment.findMany({
+    where: {
+      status: 'PENDING',
+      providerRef: { not: null },
+      createdAt: { lt: cutoff },
+    },
+    orderBy: { createdAt: 'asc' },
+    take: limit,
+    select: {
+      id: true,
+      providerRef: true,
+      orderId: true,
+      amount: true,
+      currency: true,
+      createdAt: true,
+    },
+  })) as Array<{
+    id: string
+    providerRef: string | null
+    orderId: string
+    amount: unknown
+    currency: string
+    createdAt: Date
+  }>
+
+  const report: ReconcileReport = {
+    reviewed: candidates.length,
+    markedSucceeded: 0,
+    markedFailed: 0,
+    skipped: 0,
+    errors: 0,
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate.providerRef) continue
+    const local: LocalPaymentSnapshot = {
+      providerRef: candidate.providerRef,
+      amount: Number(candidate.amount),
+      currency: candidate.currency,
+    }
+    try {
+      const remote = await stripe.retrieve(candidate.providerRef)
+      const decision = decideReconcileAction(local, remote)
+
+      if (decision.action === 'mark_succeeded') {
+        await db.$transaction(async tx => {
+          const pay = await tx.payment.updateMany({
+            where: { id: candidate.id, status: { not: 'SUCCEEDED' } },
+            data: { status: 'SUCCEEDED' },
+          })
+          const ord = await tx.order.updateMany({
+            where: {
+              id: candidate.orderId,
+              OR: [
+                { paymentStatus: { not: 'SUCCEEDED' } },
+                { status: { not: 'PAYMENT_CONFIRMED' } },
+              ],
+            },
+            data: { status: 'PAYMENT_CONFIRMED', paymentStatus: 'SUCCEEDED' },
+          })
+          if (pay.count > 0 || ord.count > 0) {
+            await tx.orderEvent.create({
+              data: {
+                orderId: candidate.orderId,
+                type: 'PAYMENT_CONFIRMED',
+                payload: {
+                  recordedAt: now.toISOString(),
+                  providerRef: candidate.providerRef,
+                  source: 'reconcile-script',
+                  note: 'Confirmed by reconciliation sweep (#405), not webhook',
+                },
+              },
+            })
+          }
+        })
+        report.markedSucceeded += 1
+        logger.info('payments.reconcile.marked_succeeded', {
+          paymentId: candidate.id,
+          orderId: candidate.orderId,
+          providerRef: candidate.providerRef,
+          ageMinutes: Math.round(
+            (now.getTime() - candidate.createdAt.getTime()) / 60_000,
+          ),
+        })
+        continue
+      }
+
+      if (decision.action === 'mark_failed') {
+        await db.$transaction(async tx => {
+          await tx.payment.updateMany({
+            where: { id: candidate.id, status: 'PENDING' },
+            data: { status: 'FAILED' },
+          })
+          await tx.order.updateMany({
+            where: { id: candidate.orderId, paymentStatus: 'PENDING' },
+            data: { paymentStatus: 'FAILED' },
+          })
+          await tx.orderEvent.create({
+            data: {
+              orderId: candidate.orderId,
+              type: 'PAYMENT_FAILED',
+              payload: {
+                recordedAt: now.toISOString(),
+                providerRef: candidate.providerRef,
+                source: 'reconcile-script',
+                reason: decision.reason,
+              },
+            },
+          })
+        })
+        report.markedFailed += 1
+        logger.info('payments.reconcile.marked_failed', {
+          paymentId: candidate.id,
+          orderId: candidate.orderId,
+          providerRef: candidate.providerRef,
+          reason: decision.reason,
+        })
+        continue
+      }
+
+      report.skipped += 1
+      if (decision.reason === 'mismatch_amount') {
+        logger.error('payments.reconcile.mismatch_amount', {
+          paymentId: candidate.id,
+          orderId: candidate.orderId,
+          providerRef: candidate.providerRef,
+          localAmount: local.amount,
+          localCurrency: local.currency,
+          remoteAmount: remote.amount,
+          remoteCurrency: remote.currency,
+        })
+      } else {
+        logger.info('payments.reconcile.still_pending', {
+          paymentId: candidate.id,
+          orderId: candidate.orderId,
+          providerRef: candidate.providerRef,
+          remoteStatus: remote.status,
+        })
+      }
+    } catch (err) {
+      report.errors += 1
+      logger.error('payments.reconcile.error', {
+        paymentId: candidate.id,
+        providerRef: candidate.providerRef,
+        error: err,
+      })
+    }
+  }
+
+  return report
+}
+
+/**
+ * Build a fetcher backed by the real Stripe SDK. Separate factory so
+ * tests can skip the SDK import entirely.
+ */
+export async function makeStripeFetcher(): Promise<StripePaymentIntentFetcher | null> {
+  const env = getServerEnv()
+  if (env.paymentProvider !== 'stripe') return null
+  const Stripe = (await import('stripe')).default
+  const client = new Stripe(env.stripeSecretKey!)
+  return {
+    async retrieve(id) {
+      const pi = await client.paymentIntents.retrieve(id)
+      return {
+        id: pi.id,
+        status: pi.status as StripePaymentIntentStatus,
+        amount: pi.amount,
+        currency: pi.currency,
+      }
+    },
+  }
+}

--- a/test/features/reconcile-payments-decision.test.ts
+++ b/test/features/reconcile-payments-decision.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  decideReconcileAction,
+  type LocalPaymentSnapshot,
+  type StripePaymentIntentSnapshot,
+} from '@/domains/payments/reconcile'
+
+/**
+ * Pure-decision tests for the reconciliation sweep (#405). The sweeper
+ * itself is exercised end-to-end in an integration test; this file
+ * pins the matrix so renaming a Stripe status or flipping a decision
+ * breaks loudly.
+ */
+
+const LOCAL: LocalPaymentSnapshot = {
+  providerRef: 'pi_test',
+  amount: 12.34,
+  currency: 'eur',
+}
+
+function remote(
+  status: StripePaymentIntentSnapshot['status'],
+  overrides: Partial<StripePaymentIntentSnapshot> = {},
+): StripePaymentIntentSnapshot {
+  return {
+    id: 'pi_test',
+    status,
+    amount: Math.round(12.34 * 100),
+    currency: 'eur',
+    ...overrides,
+  }
+}
+
+test('succeeded + matching amount → mark_succeeded', () => {
+  const d = decideReconcileAction(LOCAL, remote('succeeded'))
+  assert.deepEqual(d, { action: 'mark_succeeded' })
+})
+
+test('succeeded + amount mismatch → skip (operator must investigate)', () => {
+  const d = decideReconcileAction(LOCAL, remote('succeeded', { amount: 999 }))
+  assert.deepEqual(d, { action: 'skip', reason: 'mismatch_amount' })
+})
+
+test('succeeded + currency mismatch → skip (operator must investigate)', () => {
+  const d = decideReconcileAction(LOCAL, remote('succeeded', { currency: 'usd' }))
+  assert.deepEqual(d, { action: 'skip', reason: 'mismatch_amount' })
+})
+
+test('succeeded + currency casing difference is fine', () => {
+  // Stripe returns lowercase, our column might be upper in test data.
+  const d = decideReconcileAction(
+    { ...LOCAL, currency: 'EUR' },
+    remote('succeeded', { currency: 'eur' }),
+  )
+  assert.deepEqual(d, { action: 'mark_succeeded' })
+})
+
+test('canceled → mark_failed (reason: canceled)', () => {
+  const d = decideReconcileAction(LOCAL, remote('canceled'))
+  assert.deepEqual(d, { action: 'mark_failed', reason: 'canceled' })
+})
+
+test('requires_payment_method → mark_failed (buyer declined, will not recover)', () => {
+  const d = decideReconcileAction(LOCAL, remote('requires_payment_method'))
+  assert.deepEqual(d, {
+    action: 'mark_failed',
+    reason: 'requires_payment_method',
+  })
+})
+
+test('processing → skip (still pending, real-time webhook may yet arrive)', () => {
+  const d = decideReconcileAction(LOCAL, remote('processing'))
+  assert.deepEqual(d, { action: 'skip', reason: 'still_pending' })
+})
+
+test('requires_action → skip (buyer is still on Stripe 3DS page)', () => {
+  const d = decideReconcileAction(LOCAL, remote('requires_action'))
+  assert.deepEqual(d, { action: 'skip', reason: 'still_pending' })
+})
+
+test('requires_confirmation → skip', () => {
+  const d = decideReconcileAction(LOCAL, remote('requires_confirmation'))
+  assert.deepEqual(d, { action: 'skip', reason: 'still_pending' })
+})
+
+test('requires_capture → skip (captured amount not yet settled)', () => {
+  const d = decideReconcileAction(LOCAL, remote('requires_capture'))
+  assert.deepEqual(d, { action: 'skip', reason: 'still_pending' })
+})

--- a/test/integration/reconcile-payments.test.ts
+++ b/test/integration/reconcile-payments.test.ts
@@ -1,0 +1,178 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { db } from '@/lib/db'
+import {
+  reconcilePendingPayments,
+  type StripePaymentIntentFetcher,
+  type StripePaymentIntentSnapshot,
+} from '@/domains/payments/reconcile'
+import {
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+} from './helpers'
+
+/**
+ * End-to-end reconciliation sweep (#405): seeds a PENDING Payment
+ * older than the cutoff, injects a fake Stripe fetcher, asserts the
+ * local state transitions.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { NODE_ENV: 'test' })
+})
+
+afterEach(() => {})
+
+async function seedPendingOrderAndPayment(ageMinutes: number) {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const pastCreatedAt = new Date(Date.now() - ageMinutes * 60 * 1000)
+
+  const order = await db.order.create({
+    data: {
+      orderNumber: `R-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      customerId: buyer.id,
+      status: 'PLACED',
+      paymentStatus: 'PENDING',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+      fulfillments: { create: { vendorId: vendor.id, status: 'CONFIRMED' } },
+    },
+  })
+
+  const payment = await db.payment.create({
+    data: {
+      orderId: order.id,
+      amount: 10,
+      currency: 'eur',
+      status: 'PENDING',
+      provider: 'stripe',
+      providerRef: `pi_test_${Math.random().toString(36).slice(2, 10)}`,
+      createdAt: pastCreatedAt,
+    },
+  })
+
+  return { buyer, vendor, order, payment }
+}
+
+function fakeStripe(
+  byRef: Record<string, StripePaymentIntentSnapshot>,
+): StripePaymentIntentFetcher {
+  return {
+    async retrieve(id) {
+      const pi = byRef[id]
+      if (!pi) throw new Error(`fakeStripe: no snapshot for ${id}`)
+      return pi
+    },
+  }
+}
+
+test('sweeper marks PENDING Payment SUCCEEDED when Stripe says succeeded', async () => {
+  const { order, payment } = await seedPendingOrderAndPayment(120)
+  const stripe = fakeStripe({
+    [payment.providerRef!]: {
+      id: payment.providerRef!,
+      status: 'succeeded',
+      amount: 1000,
+      currency: 'eur',
+    },
+  })
+
+  const report = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+
+  assert.equal(report.reviewed, 1)
+  assert.equal(report.markedSucceeded, 1)
+  assert.equal(report.markedFailed, 0)
+  assert.equal(report.skipped, 0)
+
+  const fresh = await db.payment.findUnique({ where: { id: payment.id } })
+  assert.equal(fresh?.status, 'SUCCEEDED')
+  const freshOrder = await db.order.findUnique({ where: { id: order.id } })
+  assert.equal(freshOrder?.paymentStatus, 'SUCCEEDED')
+  assert.equal(freshOrder?.status, 'PAYMENT_CONFIRMED')
+
+  const events = await db.orderEvent.findMany({ where: { orderId: order.id } })
+  const confirmedEvent = events.find(e => e.type === 'PAYMENT_CONFIRMED')
+  assert.ok(confirmedEvent, 'PAYMENT_CONFIRMED OrderEvent recorded')
+})
+
+test('sweeper marks PENDING Payment FAILED when Stripe says canceled', async () => {
+  const { order, payment } = await seedPendingOrderAndPayment(120)
+  const stripe = fakeStripe({
+    [payment.providerRef!]: {
+      id: payment.providerRef!,
+      status: 'canceled',
+      amount: 1000,
+      currency: 'eur',
+    },
+  })
+
+  const report = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+
+  assert.equal(report.markedFailed, 1)
+  const fresh = await db.payment.findUnique({ where: { id: payment.id } })
+  assert.equal(fresh?.status, 'FAILED')
+  const freshOrder = await db.order.findUnique({ where: { id: order.id } })
+  assert.equal(freshOrder?.paymentStatus, 'FAILED')
+})
+
+test('sweeper skips recent (< cutoff) PENDING Payments', async () => {
+  const { payment } = await seedPendingOrderAndPayment(10) // only 10 min old
+  const stripe = fakeStripe({
+    [payment.providerRef!]: {
+      id: payment.providerRef!,
+      status: 'succeeded',
+      amount: 1000,
+      currency: 'eur',
+    },
+  })
+
+  const report = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+
+  assert.equal(report.reviewed, 0)
+  const fresh = await db.payment.findUnique({ where: { id: payment.id } })
+  assert.equal(fresh?.status, 'PENDING', 'too-young payment untouched')
+})
+
+test('sweeper skips and logs when Stripe amount mismatches local', async () => {
+  const { order, payment } = await seedPendingOrderAndPayment(120)
+  const stripe = fakeStripe({
+    [payment.providerRef!]: {
+      id: payment.providerRef!,
+      status: 'succeeded',
+      amount: 50_000, // local says 1000 cents, Stripe says 50000 cents
+      currency: 'eur',
+    },
+  })
+
+  const report = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+
+  assert.equal(report.skipped, 1)
+  assert.equal(report.markedSucceeded, 0)
+  const fresh = await db.payment.findUnique({ where: { id: payment.id } })
+  assert.equal(fresh?.status, 'PENDING', 'mismatched payment NOT confirmed')
+  const freshOrder = await db.order.findUnique({ where: { id: order.id } })
+  assert.equal(freshOrder?.paymentStatus, 'PENDING')
+})
+
+test('sweeper is idempotent — re-running does not double-apply', async () => {
+  const { payment } = await seedPendingOrderAndPayment(120)
+  const stripe = fakeStripe({
+    [payment.providerRef!]: {
+      id: payment.providerRef!,
+      status: 'succeeded',
+      amount: 1000,
+      currency: 'eur',
+    },
+  })
+
+  const first = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+  const second = await reconcilePendingPayments({ db, stripe, olderThanMinutes: 60 })
+
+  assert.equal(first.markedSucceeded, 1)
+  assert.equal(second.reviewed, 0, 'second pass sees no PENDING candidates')
+})


### PR DESCRIPTION
Closes #405.

## Summary
Operator-triggered CLI that pulls Stripe's current state for every PENDING \`Payment\` row older than N minutes (default 60) and applies the matching transition locally. Closes the last gap after persist-first (#404): when a webhook delivery is genuinely lost (edge outage, partition, paused Stripe account), the local Payment rots PENDING and the Stripe PI expires after 24h.

- \`src/domains/payments/reconcile.ts\` — pure decision fn + orchestrator. Decision matrix mirrors the webhook handler, including the refusal to act on amount mismatches.
- \`scripts/reconcile-payments.ts\` — \`npm run reconcile:payments\` with \`--older-than\` / \`--limit\` / \`--dry-run\`. Mock mode is a no-op.
- Tests: 10 decision-matrix unit cases + 5 integration cases (succeeded, canceled, too-young, mismatch, idempotency).
- Runbook: new "Payment reconciliation sweep" section + Scenario 3 pointer.

## Test plan
- [x] \`npm run typecheck\` + \`npm run lint\`
- [x] Unit (10/10) + integration (5/5) green locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)