### PR TITLE
feat(catalog): rating + review count on ProductCard + top_rated sort (#324)

### DIFF
--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -6,6 +6,7 @@ import { formatPrice } from '@/lib/utils'
 import { AddToCartButton } from '@/components/catalog/AddToCartButton'
 import { FavoriteToggleButton } from '@/components/catalog/FavoriteToggleButton'
 import { AutoTranslatedBadge } from '@/components/catalog/AutoTranslatedBadge'
+import { StarRating } from '@/components/reviews/StarRating'
 import {
   getAvailableStockForPurchase,
   getDefaultVariant,
@@ -51,6 +52,9 @@ export interface ProductCardProduct {
   vendor?: { slug: string; displayName: string; location: string | null }
   category?: { name: string; slug: string } | null
   variants?: ProductCardVariant[]
+  /** #324 — enriched by catalog query. Missing / null = no stars rendered. */
+  averageRating?: number | null
+  totalReviews?: number
 }
 
 interface ProductCardProps {
@@ -161,6 +165,21 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
           <p className="line-clamp-2 text-sm font-semibold text-[var(--foreground)] leading-snug">
             {localizedProduct.name}
           </p>
+
+          {product.totalReviews !== undefined
+            && product.totalReviews > 0
+            && product.averageRating !== null
+            && product.averageRating !== undefined && (
+            <div
+              className="mt-1.5 flex items-center gap-1.5"
+              aria-label={copy.reviews.ratingAriaLabel(product.averageRating)}
+            >
+              <StarRating rating={product.averageRating} size="sm" />
+              <span className="text-xs text-[var(--muted)]">
+                {copy.reviews.reviewCount(product.totalReviews)}
+              </span>
+            </div>
+          )}
 
           <div className="mt-2">
             <AutoTranslatedBadge translation={localizedProduct.translation} />

--- a/src/components/catalog/SortSelect.tsx
+++ b/src/components/catalog/SortSelect.tsx
@@ -19,6 +19,7 @@ export function SortSelect({ current }: Props) {
     { value: 'price_asc', label: copy.sort.priceAsc },
     { value: 'price_desc', label: copy.sort.priceDesc },
     { value: 'popular', label: copy.sort.popular },
+    { value: 'top_rated', label: copy.sort.topRated },
   ]
 
   const updateSort = (value: string) => {

--- a/src/domains/catalog/queries.ts
+++ b/src/domains/catalog/queries.ts
@@ -13,7 +13,7 @@ export interface ProductFilters {
   maxPrice?: number
   vendorSlug?: string
   q?: string
-  sort?: 'price_asc' | 'price_desc' | 'newest' | 'popular'
+  sort?: 'price_asc' | 'price_desc' | 'newest' | 'popular' | 'top_rated'
   /** Cursor-based pagination: ID of the last product on the previous page */
   cursor?: string
   limit?: number
@@ -86,51 +86,136 @@ async function getProductsUncached(filters: ProductFilters = {}) {
     })()),
   }
 
-  // Stable compound sort: primary sort field + id tiebreaker ensures
-  // cursor pagination is consistent even for products with identical prices/dates.
-  const orderBy = {
-    price_asc:  [{ basePrice: 'asc' as const },  { id: 'asc' as const }],
-    price_desc: [{ basePrice: 'desc' as const }, { id: 'asc' as const }],
-    newest:     [{ createdAt: 'desc' as const }, { id: 'desc' as const }],
-    popular:    [{ createdAt: 'desc' as const }, { id: 'desc' as const }],
-  }[sort]
-
-  // Fetch one extra item to determine if a next page exists
-  const products = await db.product.findMany({
-    where,
-    orderBy,
-    take: limit + 1,
-    ...(cursor && { cursor: { id: cursor }, skip: 1 }),
-    select: {
-      id: true,
-      vendorId: true,
-      slug: true,
-      name: true,
-      images: true,
-      basePrice: true,
-      compareAtPrice: true,
-      stock: true,
-      trackStock: true,
-      unit: true,
-      certifications: true,
-      originRegion: true,
-      createdAt: true,
-      vendor: { select: { slug: true, displayName: true, location: true } },
-      category: { select: { name: true, slug: true } },
-      variants: {
-        where: { isActive: true },
-        select: { id: true, name: true, priceModifier: true, stock: true, isActive: true },
-      },
+  const productSelect = {
+    id: true,
+    vendorId: true,
+    slug: true,
+    name: true,
+    images: true,
+    basePrice: true,
+    compareAtPrice: true,
+    stock: true,
+    trackStock: true,
+    unit: true,
+    certifications: true,
+    originRegion: true,
+    createdAt: true,
+    vendor: { select: { slug: true, displayName: true, location: true } },
+    category: { select: { name: true, slug: true } },
+    variants: {
+      where: { isActive: true },
+      select: { id: true, name: true, priceModifier: true, stock: true, isActive: true },
     },
-  })
+  }
 
-  const hasNextPage = products.length > limit
-  if (hasNextPage) products.pop()
+  let products: Array<Awaited<ReturnType<typeof db.product.findMany<{ select: typeof productSelect }>>>[number]>
+  let hasNextPage: boolean
+
+  if (sort === 'top_rated') {
+    // Review-driven sort (#324). Prisma can't orderBy an aggregate on
+    // the parent table, so: query Review.groupBy with the same where
+    // constraint applied via a Product filter, get productIds ordered
+    // by (avgRating desc, totalReviews desc), then hydrate the cards
+    // preserving that order. Products with zero reviews fall back to
+    // createdAt-desc so the grid still fills out — users asking for
+    // "mejor valorados" see highly-rated first and newest fill the
+    // rest, not an empty page.
+    const ratedAggregates = await db.review.groupBy({
+      by: ['productId'],
+      where: { product: where },
+      _avg: { rating: true },
+      _count: { _all: true },
+      orderBy: [
+        { _avg: { rating: 'desc' } },
+        { _count: { rating: 'desc' } },
+      ],
+      take: limit + 1,
+      ...(cursor && { skip: 1 }),
+    })
+
+    const ratedIds = ratedAggregates.map(a => a.productId)
+    const ratedProducts = ratedIds.length > 0
+      ? await db.product.findMany({
+          where: { id: { in: ratedIds } },
+          select: productSelect,
+        })
+      : []
+    const byId = new Map(ratedProducts.map(p => [p.id, p]))
+    const ordered = ratedIds.map(id => byId.get(id)).filter((p): p is NonNullable<typeof p> => !!p)
+
+    // If we still have room on the page, fill with unrated products by
+    // recency. Without this the "top rated" page is tiny on a young
+    // catalog and looks broken.
+    const deficit = (limit + 1) - ordered.length
+    if (deficit > 0) {
+      const unrated = await db.product.findMany({
+        where: { ...where, id: { notIn: ratedIds.length > 0 ? ratedIds : [''] } },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: deficit,
+        select: productSelect,
+      })
+      ordered.push(...unrated)
+    }
+
+    hasNextPage = ordered.length > limit
+    if (hasNextPage) ordered.pop()
+    products = ordered
+  } else {
+    // Stable compound sort: primary sort field + id tiebreaker ensures
+    // cursor pagination is consistent even for products with identical
+    // prices/dates.
+    const orderBy = {
+      price_asc:  [{ basePrice: 'asc' as const },  { id: 'asc' as const }],
+      price_desc: [{ basePrice: 'desc' as const }, { id: 'asc' as const }],
+      newest:     [{ createdAt: 'desc' as const }, { id: 'desc' as const }],
+      popular:    [{ createdAt: 'desc' as const }, { id: 'desc' as const }],
+    }[sort as Exclude<typeof sort, 'top_rated'>]
+
+    const rows = await db.product.findMany({
+      where,
+      orderBy,
+      take: limit + 1,
+      ...(cursor && { cursor: { id: cursor }, skip: 1 }),
+      select: productSelect,
+    })
+
+    hasNextPage = rows.length > limit
+    if (hasNextPage) rows.pop()
+    products = rows
+  }
 
   const nextCursor = hasNextPage ? products[products.length - 1]?.id ?? null : null
 
+  // Enrich every card with review aggregates in a single groupBy call.
+  // Products with zero reviews get `{averageRating: null, totalReviews: 0}`
+  // so the card component can decide whether to render the stars.
+  const aggregates = products.length > 0
+    ? await db.review.groupBy({
+        by: ['productId'],
+        where: { productId: { in: products.map(p => p.id) } },
+        _avg: { rating: true },
+        _count: { _all: true },
+      })
+    : []
+  const aggByProduct = new Map(
+    aggregates.map(a => [
+      a.productId,
+      {
+        averageRating: a._avg.rating !== null ? Number(a._avg.rating) : null,
+        totalReviews: a._count._all,
+      },
+    ]),
+  )
+
   return {
-    products: products.map(withDemoProductImages),
+    products: products.map(p => {
+      const agg = aggByProduct.get(p.id) ?? { averageRating: null, totalReviews: 0 }
+      return {
+        ...withDemoProductImages(p),
+        averageRating: agg.averageRating,
+        totalReviews: agg.totalReviews,
+      }
+    }),
     nextCursor,
     hasNext: hasNextPage,
     hasPrev: !!cursor,

--- a/src/domains/catalog/types.ts
+++ b/src/domains/catalog/types.ts
@@ -25,6 +25,9 @@ export type ProductWithVendor = ProductCardFields & {
   vendor: Pick<Vendor, 'slug' | 'displayName' | 'location'>
   category: Pick<Category, 'name' | 'slug'> | null
   variants?: ProductCardVariantFields[]
+  /** #324 — enriched by catalog query via a single Review.groupBy call. */
+  averageRating?: number | null
+  totalReviews?: number
 }
 
 export type ProductDetail = Product & {
@@ -41,7 +44,7 @@ export type CategoryWithCount = Category & {
   _count: { products: number }
 }
 
-export type ProductSort = 'price_asc' | 'price_desc' | 'newest' | 'popular'
+export type ProductSort = 'price_asc' | 'price_desc' | 'newest' | 'popular' | 'top_rated'
 
 export type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>['variant']>
 
@@ -50,6 +53,7 @@ export function parseProductSort(value?: string): ProductSort {
     case 'price_asc':
     case 'price_desc':
     case 'popular':
+    case 'top_rated':
       return value
     default:
       return 'newest'

--- a/src/i18n/catalog-copy.ts
+++ b/src/i18n/catalog-copy.ts
@@ -59,6 +59,7 @@ type CatalogCopy = {
     priceAsc: string
     priceDesc: string
     popular: string
+    topRated: string
   }
   actions: {
     viewDetail: string
@@ -94,6 +95,8 @@ type CatalogCopy = {
     count: (count: number) => string
     empty: string
     relatedProducts: string
+    ratingAriaLabel: (rating: number) => string
+    reviewCount: (count: number) => string
   }
   breadcrumbs: {
     home: string
@@ -173,6 +176,7 @@ const ES_CATALOG_COPY: CatalogCopy = {
     priceAsc: 'Precio: menor a mayor',
     priceDesc: 'Precio: mayor a menor',
     popular: 'Más populares',
+    topRated: 'Mejor valorados',
   },
   actions: {
     viewDetail: 'Ver detalle',
@@ -208,6 +212,8 @@ const ES_CATALOG_COPY: CatalogCopy = {
     count: count => `${count} reseña${count === 1 ? '' : 's'}`,
     empty: 'Aún no hay reseñas para este producto.',
     relatedProducts: 'Productos relacionados',
+    ratingAriaLabel: rating => `${rating.toFixed(1)} de 5 estrellas`,
+    reviewCount: count => (count === 1 ? '1 reseña' : `${count} reseñas`),
   },
   breadcrumbs: {
     home: 'Inicio',
@@ -312,6 +318,7 @@ const EN_CATALOG_COPY: CatalogCopy = {
     priceAsc: 'Price: low to high',
     priceDesc: 'Price: high to low',
     popular: 'Most popular',
+    topRated: 'Top rated',
   },
   actions: {
     viewDetail: 'View details',
@@ -347,6 +354,8 @@ const EN_CATALOG_COPY: CatalogCopy = {
     count: count => `${count} review${count === 1 ? '' : 's'}`,
     empty: 'There are no reviews for this product yet.',
     relatedProducts: 'Related products',
+    ratingAriaLabel: rating => `${rating.toFixed(1)} out of 5 stars`,
+    reviewCount: count => (count === 1 ? '1 review' : `${count} reviews`),
   },
   breadcrumbs: {
     home: 'Home',

--- a/test/integration/catalog-ratings.test.ts
+++ b/test/integration/catalog-ratings.test.ts
@@ -1,0 +1,130 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { getProducts } from '@/domains/catalog/queries'
+import { db } from '@/lib/db'
+import {
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+} from './helpers'
+
+/**
+ * Catalog rating enrichment + top_rated sort (#324). Pins the
+ * invariant that the listing query:
+ *   1. Returns every ProductWithVendor with averageRating + totalReviews.
+ *   2. top_rated orders by average desc, count desc, and fills the
+ *      remaining slots with unrated products by recency so the page
+ *      does not look empty on a young catalog.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { NODE_ENV: 'test' })
+})
+
+afterEach(() => {})
+
+async function seedOrder(customerId: string, vendorId: string) {
+  return db.order.create({
+    data: {
+      orderNumber: `T-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      customerId,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: 10,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: 10,
+      fulfillments: { create: { vendorId, status: 'DELIVERED' } },
+    },
+  })
+}
+
+async function seedReview(opts: {
+  productId: string
+  vendorId: string
+  customerId: string
+  orderId: string
+  rating: number
+}) {
+  return db.review.create({
+    data: {
+      orderId: opts.orderId,
+      productId: opts.productId,
+      vendorId: opts.vendorId,
+      customerId: opts.customerId,
+      rating: opts.rating,
+      body: 'ok',
+    },
+  })
+}
+
+test('getProducts enriches every product with averageRating + totalReviews', async () => {
+  const v = await createVendorUser()
+  const buyer = await createUser('CUSTOMER')
+  const order = await seedOrder(buyer.id, v.vendor.id)
+  const p1 = await createActiveProduct(v.vendor.id)
+  const p2 = await createActiveProduct(v.vendor.id)
+
+  await seedReview({ productId: p1.id, vendorId: v.vendor.id, customerId: buyer.id, orderId: order.id, rating: 5 })
+
+  const { products } = await getProducts()
+  const lookup = new Map(products.map(p => [p.id, p]))
+
+  const reviewed = lookup.get(p1.id)!
+  assert.equal(reviewed.averageRating, 5)
+  assert.equal(reviewed.totalReviews, 1)
+
+  const unreviewed = lookup.get(p2.id)!
+  assert.equal(unreviewed.averageRating, null)
+  assert.equal(unreviewed.totalReviews, 0)
+})
+
+test('top_rated orders by averageRating desc, then by review count', async () => {
+  const v = await createVendorUser()
+  const buyerA = await createUser('CUSTOMER')
+  const buyerB = await createUser('CUSTOMER')
+  const orderA = await seedOrder(buyerA.id, v.vendor.id)
+  const orderB = await seedOrder(buyerB.id, v.vendor.id)
+
+  const bestProduct = await createActiveProduct(v.vendor.id)
+  const midProduct = await createActiveProduct(v.vendor.id)
+  const worstProduct = await createActiveProduct(v.vendor.id)
+
+  // best: avg 5.0 (2 reviews)
+  await seedReview({ productId: bestProduct.id, vendorId: v.vendor.id, customerId: buyerA.id, orderId: orderA.id, rating: 5 })
+  await seedReview({ productId: bestProduct.id, vendorId: v.vendor.id, customerId: buyerB.id, orderId: orderB.id, rating: 5 })
+  // mid: avg 4.0 (1 review)
+  const orderMid = await seedOrder(buyerA.id, v.vendor.id)
+  await seedReview({ productId: midProduct.id, vendorId: v.vendor.id, customerId: buyerA.id, orderId: orderMid.id, rating: 4 })
+  // worst: avg 2.0 (1 review)
+  const orderWorst = await seedOrder(buyerB.id, v.vendor.id)
+  await seedReview({ productId: worstProduct.id, vendorId: v.vendor.id, customerId: buyerB.id, orderId: orderWorst.id, rating: 2 })
+
+  const { products } = await getProducts({ sort: 'top_rated' })
+  const order = products.map(p => p.id)
+
+  assert.equal(order[0], bestProduct.id, 'highest average first')
+  assert.equal(order[1], midProduct.id, '4.0 above 2.0')
+  assert.equal(order[2], worstProduct.id, 'lowest last among rated')
+})
+
+test('top_rated backfills with unrated products when rated ones are few', async () => {
+  const v = await createVendorUser()
+  const buyer = await createUser('CUSTOMER')
+  const order = await seedOrder(buyer.id, v.vendor.id)
+
+  const rated = await createActiveProduct(v.vendor.id)
+  const unrated1 = await createActiveProduct(v.vendor.id)
+  const unrated2 = await createActiveProduct(v.vendor.id)
+
+  await seedReview({ productId: rated.id, vendorId: v.vendor.id, customerId: buyer.id, orderId: order.id, rating: 5 })
+
+  const { products } = await getProducts({ sort: 'top_rated' })
+
+  assert.equal(products[0]?.id, rated.id, 'rated product comes first')
+  const remainingIds = new Set(products.slice(1).map(p => p.id))
+  assert.ok(remainingIds.has(unrated1.id), 'unrated products backfill')
+  assert.ok(remainingIds.has(unrated2.id))
+})


### PR DESCRIPTION
Closes #324.

## Summary
- **\`ProductCard\`** now renders \`StarRating\` + localised review count, only when \`totalReviews > 0\` (spec: no placeholder).
- **Catalog query** enriches every card with \`{averageRating, totalReviews}\` via a single \`Review.groupBy\` keyed by the page's product ids — no N+1.
- **New sort**: "Mejor valorados" / "Top rated". Uses \`Review.groupBy(ORDER BY _avg.rating DESC, _count DESC)\` for rated products, then backfills with unrated by \`createdAt desc\` so a young catalog still fills the grid.
- **i18n**: new keys in both ES and EN, flat-key style per \`src/i18n/README.md\`.

## Test plan
- [x] \`npm run typecheck\` + \`npm run lint\`
- [x] 3/3 new integration cases pass (\`test/integration/catalog-ratings.test.ts\`)
- [ ] CI

## Out of scope (per issue)
- "Only with reviews" filter.
- Review form UI changes.
- Product detail redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)