### PR TITLE
feat(payments): wire admin resolveIncident to real Stripe refunds (#269)

### DIFF
--- a/src/app/api/admin/incidents/[id]/resolve/route.ts
+++ b/src/app/api/admin/incidents/[id]/resolve/route.ts
@@ -4,10 +4,14 @@ import { db } from '@/lib/db'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { IncidentResolution } from '@/generated/prisma/enums'
+import { refundPaymentIntent } from '@/domains/payments/provider'
+import { logger } from '@/lib/logger'
 
 const schema = z.object({
   resolution:   z.nativeEnum(IncidentResolution),
   internalNote: z.string().max(2000).optional(),
+  refundAmount: z.coerce.number().min(0).max(1_000_000).optional(),
+  fundedBy:     z.enum(['PLATFORM', 'VENDOR']).optional(),
 })
 
 interface RouteParams {
@@ -23,11 +27,40 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params
 
   try {
-    const { resolution, internalNote } = schema.parse(await request.json())
+    const { resolution, internalNote, refundAmount, fundedBy } = schema.parse(await request.json())
+
+    // Refund-specific validation. If the admin filled in a non-zero
+    // amount, `fundedBy` becomes mandatory: downstream settlement and
+    // commission reports need to know whose P&L takes the hit.
+    if (refundAmount !== undefined && refundAmount > 0 && !fundedBy) {
+      return NextResponse.json(
+        { message: 'fundedBy es obligatorio cuando refundAmount > 0' },
+        { status: 400 },
+      )
+    }
 
     const incident = await db.incident.findUnique({
       where: { id },
-      select: { status: true },
+      select: {
+        id: true,
+        status: true,
+        type: true,
+        order: {
+          select: {
+            id: true,
+            orderNumber: true,
+            payments: {
+              where: { status: 'SUCCEEDED' },
+              orderBy: { createdAt: 'desc' },
+              select: {
+                id: true,
+                amount: true,
+                providerRef: true,
+              },
+            },
+          },
+        },
+      },
     })
     if (!incident) {
       return NextResponse.json({ message: 'Incidencia no encontrada' }, { status: 404 })
@@ -36,15 +69,86 @@ export async function POST(request: Request, { params }: RouteParams) {
       return NextResponse.json({ message: 'La incidencia ya está cerrada' }, { status: 400 })
     }
 
-    const updated = await db.incident.update({
-      where: { id },
-      data: {
-        status:       'RESOLVED',
-        resolution,
-        internalNote: internalNote ?? null,
-        resolvedAt:   new Date(),
-      },
-      select: { id: true, status: true, resolution: true, resolvedAt: true },
+    // Resolve the target Payment row if a refund is requested. We
+    // refund against the most recent SUCCEEDED Payment on the Order;
+    // multi-payment orders would need a richer UX but that's out of
+    // scope here (#269 is the MVP).
+    let payment: { id: string; amount: unknown; providerRef: string | null } | null = null
+    if (refundAmount && refundAmount > 0) {
+      payment = incident.order.payments[0] ?? null
+      if (!payment) {
+        return NextResponse.json(
+          { message: 'No hay pago confirmado en este pedido' },
+          { status: 400 },
+        )
+      }
+      if (refundAmount > Number(payment.amount)) {
+        return NextResponse.json(
+          { message: 'El importe del reembolso supera el pago original' },
+          { status: 400 },
+        )
+      }
+      if (!payment.providerRef) {
+        return NextResponse.json(
+          { message: 'El pago no tiene providerRef — imposible reembolsar' },
+          { status: 400 },
+        )
+      }
+    }
+
+    // Fire the provider refund BEFORE we mark the Incident RESOLVED
+    // so a Stripe failure leaves the incident in its original state
+    // and the admin sees a clear error. If this throws, the catch
+    // below re-raises — no partial success.
+    let providerRefundRef: string | null = null
+    if (payment && refundAmount && refundAmount > 0 && fundedBy) {
+      const refundResult = await refundPaymentIntent(
+        payment.providerRef!,
+        Math.round(refundAmount * 100),
+        {
+          incidentId: id,
+          orderId: incident.order.id,
+          orderNumber: incident.order.orderNumber,
+          fundedBy,
+        },
+      )
+      providerRefundRef = refundResult.id
+      logger.info('incident.refund.issued', {
+        incidentId: id,
+        orderId: incident.order.id,
+        providerRefundRef,
+        amountCents: Math.round(refundAmount * 100),
+        fundedBy,
+      })
+    }
+
+    const updated = await db.$transaction(async tx => {
+      const incidentUpdate = await tx.incident.update({
+        where: { id },
+        data: {
+          status:       'RESOLVED',
+          resolution,
+          internalNote: internalNote ?? null,
+          resolvedAt:   new Date(),
+          ...(refundAmount !== undefined && { refundAmount }),
+          ...(fundedBy && { fundedBy }),
+        },
+        select: { id: true, status: true, resolution: true, resolvedAt: true },
+      })
+
+      if (payment && refundAmount && refundAmount > 0 && fundedBy) {
+        await tx.refund.create({
+          data: {
+            paymentId: payment.id,
+            amount: refundAmount,
+            reason: `${incident.type} · ${resolution}`,
+            fundedBy,
+            providerRef: providerRefundRef,
+          },
+        })
+      }
+
+      return incidentUpdate
     })
 
     return NextResponse.json(updated)
@@ -52,7 +156,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (err instanceof z.ZodError) {
       return NextResponse.json({ message: 'Datos inválidos' }, { status: 400 })
     }
-    console.error('[POST /api/admin/incidents/[id]/resolve]', err)
+    logger.error('incident.resolve.failed', {
+      incidentId: id,
+      error: err,
+    })
     return NextResponse.json({ message: 'Error interno' }, { status: 500 })
   }
 }

--- a/src/domains/payments/provider.ts
+++ b/src/domains/payments/provider.ts
@@ -109,3 +109,64 @@ export async function confirmMockPayment(paymentIntentId: string): Promise<void>
     throw new Error('confirmMockPayment called with non-mock intent')
   }
 }
+
+declare global {
+  var __testRefundPaymentIntentOverride:
+    | ((providerRef: string, amountCents: number) => Promise<{ id: string }>)
+    | undefined
+}
+
+export function setTestRefundPaymentIntentOverride(
+  fn: ((providerRef: string, amountCents: number) => Promise<{ id: string }>) | undefined,
+): void {
+  globalThis.__testRefundPaymentIntentOverride = fn
+}
+
+/**
+ * Issues a refund against a previously-confirmed Payment Intent.
+ * Returns the provider's refund id so the caller can persist it on
+ * the local `Refund` row.
+ *
+ * Mock mode: produces a synthetic id, no external call — mirrors the
+ * createPaymentIntent mock contract so admin flows work end-to-end in
+ * dev + integration tests.
+ *
+ * Stripe mode: calls `stripe.refunds.create` with the integer cents
+ * amount. The caller is responsible for rolling back the local
+ * Incident / Refund rows if this throws.
+ */
+export async function refundPaymentIntent(
+  providerRef: string,
+  amountCents: number,
+  metadata: Record<string, string> = {},
+): Promise<{ id: string }> {
+  if (process.env.NODE_ENV === 'test' && globalThis.__testRefundPaymentIntentOverride) {
+    return globalThis.__testRefundPaymentIntentOverride(providerRef, amountCents)
+  }
+
+  const env = getServerEnv()
+
+  if (env.paymentProvider === 'mock') {
+    const id = `mock_re_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`
+    return { id }
+  }
+
+  if (!providerRef || providerRef.startsWith('mock_')) {
+    // Safety net: production mode should never receive a mock
+    // providerRef. If it does, the Incident payload is corrupt —
+    // throw loudly so the admin sees an error rather than silently
+    // creating a fake refund row.
+    throw new Error(
+      `refundPaymentIntent: refusing to call Stripe with mock-style providerRef=${providerRef}`,
+    )
+  }
+
+  const Stripe = (await import('stripe')).default
+  const stripe = new Stripe(env.stripeSecretKey!)
+  const refund = await stripe.refunds.create({
+    payment_intent: providerRef,
+    amount: amountCents,
+    metadata,
+  })
+  return { id: refund.id }
+}

--- a/test/integration/incident-refund.test.ts
+++ b/test/integration/incident-refund.test.ts
@@ -1,0 +1,204 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { POST as POST_RESOLVE } from '@/app/api/admin/incidents/[id]/resolve/route'
+import { setTestRefundPaymentIntentOverride } from '@/domains/payments/provider'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Admin `resolveIncident` + Stripe refund integration (#269).
+ * Covers the happy path, mock mode, Stripe failure rollback,
+ * over-refund rejection, and the fundedBy-required guard.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { NODE_ENV: 'test' })
+})
+
+afterEach(() => {
+  clearTestSession()
+  setTestRefundPaymentIntentOverride(undefined)
+})
+
+async function seedIncidentWithPaidOrder(opts: { amount?: number; providerRef?: string } = {}) {
+  const buyer = await createUser('CUSTOMER')
+  const admin = await db.user.create({
+    data: {
+      email: `admin-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@example.com`,
+      firstName: 'A',
+      lastName: 'T',
+      role: 'SUPERADMIN',
+      isActive: true,
+    },
+  })
+
+  const amount = opts.amount ?? 25
+  const order = await db.order.create({
+    data: {
+      orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      customerId: buyer.id,
+      status: 'DELIVERED',
+      paymentStatus: 'SUCCEEDED',
+      subtotal: amount,
+      shippingCost: 0,
+      taxAmount: 0,
+      grandTotal: amount,
+    },
+  })
+  const payment = await db.payment.create({
+    data: {
+      orderId: order.id,
+      amount,
+      currency: 'eur',
+      status: 'SUCCEEDED',
+      provider: 'stripe',
+      providerRef: opts.providerRef ?? `pi_test_${Math.random().toString(36).slice(2, 10)}`,
+    },
+  })
+  const incident = await db.incident.create({
+    data: {
+      orderId: order.id,
+      customerId: buyer.id,
+      type: 'WRONG_ITEM',
+      description: 'Wrong item',
+      status: 'OPEN',
+      slaDeadline: new Date(Date.now() + 72 * 60 * 60 * 1000),
+    },
+  })
+  return { buyer, admin, order, payment, incident }
+}
+
+function jsonRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+test('resolveIncident with refundAmount>0 in stripe mode issues the refund and persists the row', async () => {
+  const { admin, incident, payment } = await seedIncidentWithPaidOrder()
+  let refundCallPi: string | null = null
+  let refundCallAmount: number | null = null
+  setTestRefundPaymentIntentOverride(async (pi, cents) => {
+    refundCallPi = pi
+    refundCallAmount = cents
+    return { id: 're_test_123' }
+  })
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const res = await POST_RESOLVE(
+    jsonRequest(`http://localhost/api/admin/incidents/${incident.id}/resolve`, {
+      resolution: 'REFUND_FULL',
+      refundAmount: 25,
+      fundedBy: 'PLATFORM',
+    }),
+    { params: Promise.resolve({ id: incident.id }) },
+  )
+  assert.equal(res.status, 200)
+  assert.equal(refundCallPi, payment.providerRef)
+  assert.equal(refundCallAmount, 2500)
+
+  const resolved = await db.incident.findUnique({ where: { id: incident.id } })
+  assert.equal(resolved?.status, 'RESOLVED')
+  assert.equal(Number(resolved?.refundAmount), 25)
+  assert.equal(resolved?.fundedBy, 'PLATFORM')
+
+  const refunds = await db.refund.findMany({ where: { paymentId: payment.id } })
+  assert.equal(refunds.length, 1)
+  assert.equal(refunds[0]?.providerRef, 're_test_123')
+  assert.equal(Number(refunds[0]?.amount), 25)
+  assert.equal(refunds[0]?.fundedBy, 'PLATFORM')
+})
+
+test('resolveIncident rolls back when Stripe throws — incident stays OPEN, no Refund row', async () => {
+  const { admin, incident, payment } = await seedIncidentWithPaidOrder()
+  setTestRefundPaymentIntentOverride(async () => {
+    throw new Error('Stripe: card_network_unavailable')
+  })
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const res = await POST_RESOLVE(
+    jsonRequest(`http://localhost/api/admin/incidents/${incident.id}/resolve`, {
+      resolution: 'REFUND_FULL',
+      refundAmount: 25,
+      fundedBy: 'PLATFORM',
+    }),
+    { params: Promise.resolve({ id: incident.id }) },
+  )
+  assert.equal(res.status, 500)
+
+  const stillOpen = await db.incident.findUnique({ where: { id: incident.id } })
+  assert.equal(stillOpen?.status, 'OPEN', 'incident NOT marked resolved when Stripe fails')
+  assert.equal(stillOpen?.refundAmount, null)
+
+  const refunds = await db.refund.findMany({ where: { paymentId: payment.id } })
+  assert.equal(refunds.length, 0, 'no Refund row persisted when Stripe threw')
+})
+
+test('resolveIncident rejects refundAmount > payment total', async () => {
+  const { admin, incident } = await seedIncidentWithPaidOrder({ amount: 25 })
+  setTestRefundPaymentIntentOverride(async () => {
+    throw new Error('should not be called')
+  })
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const res = await POST_RESOLVE(
+    jsonRequest(`http://localhost/api/admin/incidents/${incident.id}/resolve`, {
+      resolution: 'REFUND_FULL',
+      refundAmount: 999,
+      fundedBy: 'PLATFORM',
+    }),
+    { params: Promise.resolve({ id: incident.id }) },
+  )
+  assert.equal(res.status, 400)
+  const body = await res.json()
+  assert.match(body.message, /supera el pago original/)
+
+  const stillOpen = await db.incident.findUnique({ where: { id: incident.id } })
+  assert.equal(stillOpen?.status, 'OPEN')
+})
+
+test('resolveIncident requires fundedBy when refundAmount > 0', async () => {
+  const { admin, incident } = await seedIncidentWithPaidOrder()
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const res = await POST_RESOLVE(
+    jsonRequest(`http://localhost/api/admin/incidents/${incident.id}/resolve`, {
+      resolution: 'REFUND_FULL',
+      refundAmount: 10,
+    }),
+    { params: Promise.resolve({ id: incident.id }) },
+  )
+  assert.equal(res.status, 400)
+  const body = await res.json()
+  assert.match(body.message, /fundedBy es obligatorio/)
+})
+
+test('resolveIncident with refundAmount=0 closes the incident without calling Stripe', async () => {
+  const { admin, incident, payment } = await seedIncidentWithPaidOrder()
+  let stripeCalled = false
+  setTestRefundPaymentIntentOverride(async () => {
+    stripeCalled = true
+    return { id: 'should-not-happen' }
+  })
+
+  useTestSession(buildSession(admin.id, 'SUPERADMIN'))
+  const res = await POST_RESOLVE(
+    jsonRequest(`http://localhost/api/admin/incidents/${incident.id}/resolve`, {
+      resolution: 'REJECTED',
+    }),
+    { params: Promise.resolve({ id: incident.id }) },
+  )
+  assert.equal(res.status, 200)
+  assert.equal(stripeCalled, false, 'Stripe refund NOT called when refundAmount omitted')
+
+  const refunds = await db.refund.findMany({ where: { paymentId: payment.id } })
+  assert.equal(refunds.length, 0)
+})


### PR DESCRIPTION
Closes #269.

Before this PR, \`POST /api/admin/incidents/[id]/resolve\` only flipped the Incident to RESOLVED. \`refundAmount\` + \`fundedBy\` columns already existed but nobody persisted them, and no money actually moved — ops ran refunds manually in Stripe.

Implemented Option A from the issue (synchronous refund inside the route). Multi-payment orders, automatic settlement deductions, and async queue workers are out of scope; volume is low and "mark resolved → money is back" matches support expectations.

## Summary
- **\`refundPaymentIntent(providerRef, cents, metadata)\`** helper in \`src/domains/payments/provider.ts\` — same mock / stripe / test-override pattern as \`createPaymentIntent\`. Refuses to forward mock-style refs to Stripe.
- **Route**: schema accepts optional \`refundAmount\` + \`fundedBy\`. \`fundedBy\` required when \`refundAmount > 0\` (settlement downstream). Validates SUCCEEDED Payment exists and amount ≤ payment.amount. Stripe call runs BEFORE the DB transaction so a failure leaves Incident OPEN and creates no Refund row. Logs \`incident.refund.issued\` / \`incident.resolve.failed\`.
- **5 integration tests**: happy path, Stripe failure rollback, over-refund rejected, fundedBy required guard, refund=0 skips Stripe.

## Test plan
- [x] \`npm run typecheck\` + \`npm run lint\`
- [x] 5/5 new integration tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)