### PR TITLE
feat(cart): login hydration + post-checkout server clear (#270)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { THEME_COLORS } from '@/lib/theme'
 import { SITE_METADATA_BASE } from '@/lib/seo'
 import { SessionProvider } from '@/components/SessionProvider'
 import { LanguageProvider } from '@/i18n'
+import { CartHydrationProvider } from '@/components/buyer/CartHydrationProvider'
 import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
 import OfflineIndicator from '@/components/pwa/OfflineIndicator'
@@ -91,6 +92,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <PostHogProvider />
               <PwaRegister />
               <OfflineIndicator />
+              <CartHydrationProvider />
               {children}
             </LanguageProvider>
           </ThemeProvider>

--- a/src/components/buyer/CartHydrationProvider.tsx
+++ b/src/components/buyer/CartHydrationProvider.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useSession } from 'next-auth/react'
+import { useCartStore, type CartItem } from '@/domains/orders/cart-store'
+import { loadServerCart, mergeLocalIntoServerCart } from '@/domains/orders/cart-actions'
+
+/**
+ * On login, merges the anonymous local-storage cart into the buyer's
+ * server cart and replaces the client state with the union (#270).
+ *
+ * Strategy:
+ *   1. Wait for NextAuth session to become `authenticated`.
+ *   2. Snapshot whatever is in local storage (items the buyer added
+ *      while anonymous).
+ *   3. Call `mergeLocalIntoServerCart(local)` — the helper sums
+ *      quantities on overlapping (productId, variantId) and returns
+ *      the combined server state.
+ *   4. Hydrate the Zustand store from the server response so all
+ *      tabs / devices converge on the same cart. No-op if the merge
+ *      fails — keep the local cart untouched to avoid losing items.
+ *
+ * Runs exactly once per session. Logouts are handled by Zustand's
+ * persist middleware (keeps local storage intact) and the next login
+ * replays the merge from whatever state the user accumulated.
+ */
+export function CartHydrationProvider() {
+  const { data, status } = useSession()
+  const hasHydratedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    const userId = data?.user?.id
+    if (!userId) return
+    if (hasHydratedRef.current === userId) return
+    hasHydratedRef.current = userId
+
+    const state = useCartStore.getState()
+    const localItems = state.items.map(item => ({
+      productId: item.productId,
+      variantId: item.variantId ?? undefined,
+      quantity: item.quantity,
+    }))
+
+    void (async () => {
+      try {
+        const merged = localItems.length > 0
+          ? await mergeLocalIntoServerCart(localItems)
+          : await loadServerCart()
+
+        const hydrated: CartItem[] = merged.map(line => ({
+          productId: line.productId,
+          variantId: line.variantId ?? undefined,
+          name: line.product.name,
+          slug: line.product.slug,
+          image: line.product.images[0],
+          price:
+            Number(line.product.basePrice) + (line.variant ? Number(line.variant.priceModifier) : 0),
+          unit: line.product.unit,
+          vendorId: line.product.vendor.id,
+          vendorName: line.product.vendor.displayName,
+          quantity: line.quantity,
+          ...(line.variant?.name && { variantName: line.variant.name }),
+        }))
+
+        useCartStore.setState({ items: hydrated })
+      } catch {
+        // Network / server error — leave local cart as is. Next page
+        // load or navigation will retry via the same effect.
+        hasHydratedRef.current = null
+      }
+    })()
+  }, [data?.user?.id, status])
+
+  return null
+}

--- a/src/components/buyer/CheckoutPageClient.tsx
+++ b/src/components/buyer/CheckoutPageClient.tsx
@@ -250,6 +250,15 @@ export function CheckoutPageClient({
     if (!completedOrderNumber) return
 
     clearCart()
+    // #270 — if the buyer was authenticated, their cart is also
+    // persisted server-side. Wipe it so the next login on any device
+    // doesn't bring back the purchased items. Fire-and-forget: the
+    // redirect below is the user-visible success path; a transient
+    // failure just leaves a stale server cart that the next login
+    // merge will reconcile.
+    void import('@/domains/orders/cart-actions')
+      .then(mod => mod.clearMyServerCart())
+      .catch(() => {})
     router.replace(`/checkout/confirmacion?orderNumber=${encodeURIComponent(completedOrderNumber)}`)
     router.refresh()
   }, [clearCart, completedOrderNumber, router])

--- a/src/domains/orders/cart-actions.ts
+++ b/src/domains/orders/cart-actions.ts
@@ -1,0 +1,64 @@
+'use server'
+
+/**
+ * Server-action wrappers over `cart-persistence.ts` (#270).
+ *
+ * The persistence layer takes `userId` directly because the domain
+ * actions that already use it (checkout, admin ops) have it in scope.
+ * The client, on the other hand, must not pass the id — it comes from
+ * the session — so these wrappers resolve the session server-side and
+ * reject any unauthenticated caller.
+ *
+ * Kept in a separate file so `cart-persistence.ts` stays a pure
+ * domain module with no Next.js request-scope dependencies.
+ */
+
+import {
+  clearServerCart,
+  getServerCart,
+  mergeLocalCartIntoServer,
+  removeServerCartItem,
+  setServerCartItem,
+  type CartLineInput,
+  type PersistedCartLine,
+} from '@/domains/orders/cart-persistence'
+import { getActionSession } from '@/lib/action-session'
+
+/** Empty-array on anonymous callers — a non-auth UI can render nothing. */
+export async function loadServerCart(): Promise<PersistedCartLine[]> {
+  const session = await getActionSession()
+  if (!session) return []
+  return getServerCart(session.user.id)
+}
+
+export async function setCartItem(input: CartLineInput): Promise<void> {
+  const session = await getActionSession()
+  if (!session) return
+  await setServerCartItem(session.user.id, input)
+}
+
+export async function removeCartItem(productId: string, variantId: string | null | undefined): Promise<void> {
+  const session = await getActionSession()
+  if (!session) return
+  await removeServerCartItem(session.user.id, productId, variantId ?? undefined)
+}
+
+export async function clearMyServerCart(): Promise<void> {
+  const session = await getActionSession()
+  if (!session) return
+  await clearServerCart(session.user.id)
+}
+
+/**
+ * Called once on login: merge the caller's local-storage cart into
+ * their server cart, return the combined state so the client can
+ * replace its local copy. The server helper sums quantities on
+ * overlapping (productId, variantId).
+ */
+export async function mergeLocalIntoServerCart(
+  localItems: CartLineInput[],
+): Promise<PersistedCartLine[]> {
+  const session = await getActionSession()
+  if (!session) return []
+  return mergeLocalCartIntoServer(session.user.id, localItems)
+}

--- a/test/integration/cart-hydration.test.ts
+++ b/test/integration/cart-hydration.test.ts
@@ -1,0 +1,122 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  clearMyServerCart,
+  loadServerCart,
+  mergeLocalIntoServerCart,
+  setCartItem,
+} from '@/domains/orders/cart-actions'
+import { setServerCartItem } from '@/domains/orders/cart-persistence'
+import { db } from '@/lib/db'
+import {
+  buildSession,
+  clearTestSession,
+  createActiveProduct,
+  createUser,
+  createVendorUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+
+/**
+ * Server-action wrappers over cart-persistence (#270). The persistence
+ * layer is already covered end-to-end; these tests pin the identity
+ * gate at the server-action boundary so the client can't forge a
+ * cross-tenant cart write.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  Object.assign(process.env, { NODE_ENV: 'test' })
+})
+
+afterEach(() => {
+  clearTestSession()
+})
+
+test('loadServerCart returns [] for anonymous callers and the buyer cart otherwise', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id)
+
+  await setServerCartItem(buyer.id, { productId: product.id, quantity: 2 })
+
+  useTestSession(null)
+  const anon = await loadServerCart()
+  assert.equal(anon.length, 0, 'anonymous → empty')
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const own = await loadServerCart()
+  assert.equal(own.length, 1)
+  assert.equal(own[0]?.productId, product.id)
+  assert.equal(own[0]?.quantity, 2)
+})
+
+test('setCartItem ignores calls from anonymous callers (no-op, no cart created)', async () => {
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id)
+
+  useTestSession(null)
+  await setCartItem({ productId: product.id, quantity: 3 })
+
+  const carts = await db.cart.count()
+  assert.equal(carts, 0, 'no Cart row persisted for an anonymous setCartItem call')
+})
+
+test('mergeLocalIntoServerCart sums quantities on overlapping (productId, variantId)', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const p1 = await createActiveProduct(vendor.id)
+  const p2 = await createActiveProduct(vendor.id)
+
+  // Buyer already had p1×1 on the server from another device.
+  await setServerCartItem(buyer.id, { productId: p1.id, quantity: 1 })
+
+  // Anonymous cart contained p1×2 + p2×3.
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  const merged = await mergeLocalIntoServerCart([
+    { productId: p1.id, quantity: 2 },
+    { productId: p2.id, quantity: 3 },
+  ])
+
+  const byProduct = new Map(merged.map(line => [line.productId, line.quantity]))
+  assert.equal(byProduct.get(p1.id), 3, 'server 1 + local 2 = 3')
+  assert.equal(byProduct.get(p2.id), 3, 'only-local item joined as 3')
+
+  // Persisted state matches the returned view.
+  const fromServer = await loadServerCart()
+  assert.equal(fromServer.length, 2)
+  const persisted = new Map(fromServer.map(line => [line.productId, line.quantity]))
+  assert.equal(persisted.get(p1.id), 3)
+  assert.equal(persisted.get(p2.id), 3)
+})
+
+test('mergeLocalIntoServerCart is anonymous-safe (returns [] without touching DB)', async () => {
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id)
+
+  useTestSession(null)
+  const result = await mergeLocalIntoServerCart([{ productId: product.id, quantity: 5 }])
+
+  assert.deepEqual(result, [])
+  const carts = await db.cart.count()
+  assert.equal(carts, 0)
+})
+
+test('clearMyServerCart wipes items but leaves the Cart shell so future writes succeed', async () => {
+  const buyer = await createUser('CUSTOMER')
+  const { vendor } = await createVendorUser()
+  const product = await createActiveProduct(vendor.id)
+  await setServerCartItem(buyer.id, { productId: product.id, quantity: 2 })
+
+  useTestSession(buildSession(buyer.id, 'CUSTOMER'))
+  await clearMyServerCart()
+
+  const after = await loadServerCart()
+  assert.equal(after.length, 0, 'cart emptied')
+
+  // A subsequent setCartItem re-populates it without a Cart-missing error.
+  await setCartItem({ productId: product.id, quantity: 1 })
+  const after2 = await loadServerCart()
+  assert.equal(after2.length, 1)
+})


### PR DESCRIPTION
Partial close of #270 — 3 of 3 primary acceptance criteria covered.

## Summary
Bridges the Zustand client store and the existing \`cart-persistence\` domain layer.

- **\`src/domains/orders/cart-actions.ts\`**: \`"use server"\` wrappers that resolve the session server-side (no-op on anonymous callers — no way to forge cross-tenant writes).
- **\`CartHydrationProvider\`**: mounted under \`SessionProvider\`. On login, merges localStorage → server cart and replaces the Zustand state with the union. Ref-guarded to run once per user session. Failures leave the local cart untouched so buyers never lose items.
- **CheckoutPageClient**: after a successful order, \`clearMyServerCart()\` runs alongside the existing local \`clearCart()\` so the next login on any device doesn't resurrect purchased items.
- **5 integration tests** pin the identity gate at the server-action boundary.

## Deferred to a follow-up
Runtime fire-and-forget sync on every cart mutation while authenticated. Not strictly required by the issue's primary acceptance criteria — login-time merge + post-checkout clear already deliver cross-device sync in the common flow. Will open a follow-up if product wants real-time cross-tab sync.

## Test plan
- [x] \`npm run typecheck\` + \`npm run lint\`
- [x] 5/5 new cases green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)