### PR TITLE
push: notify buyer when their fulfillment ships (#570)

### DIFF
--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -357,7 +357,44 @@ export async function advanceFulfillment(
     }
   })
 
+  // #570 — notify the buyer that a parcel is on the way. First live
+  // push event in the app. Fire-and-forget so a broken push provider
+  // never blocks the vendor's UI. sendPushToUser is already a no-op
+  // when VAPID is unconfigured or the buyer has no subscription.
+  if (nextStatus === 'SHIPPED') {
+    void notifyBuyerFulfillmentShipped(fulfillment.orderId, {
+      trackingNumber: trackingNumber ?? null,
+    }).catch(() => {
+      /* logged inside the helper — ignore here so the outer UI is unaffected */
+    })
+  }
+
   safeRevalidatePath('/vendor/pedidos')
+}
+
+async function notifyBuyerFulfillmentShipped(
+  orderId: string,
+  extras: { trackingNumber: string | null },
+) {
+  try {
+    const order = await db.order.findUnique({
+      where: { id: orderId },
+      select: { customerId: true, orderNumber: true },
+    })
+    if (!order) return
+    const { sendPushToUser } = await import('@/lib/pwa/push-send')
+    await sendPushToUser(order.customerId, {
+      title: '📦 Tu pedido va en camino',
+      body: extras.trackingNumber
+        ? `Pedido ${order.orderNumber} · tracking ${extras.trackingNumber}`
+        : `Pedido ${order.orderNumber} enviado. Toca para ver el seguimiento.`,
+      url: `/cuenta/pedidos/${orderId}`,
+      tag: `order-shipped-${orderId}`,
+    })
+  } catch (err) {
+    const { logger } = await import('@/lib/logger')
+    logger.warn('push.notify.fulfillment_shipped.failed', { orderId, err })
+  }
 }
 
 /**

--- a/test/features/push-notifications-wiring.test.ts
+++ b/test/features/push-notifications-wiring.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Contract pin for the first live push-notification wiring (#570).
+ * Regression in any of these assertions silently breaks the buyer's
+ * "your parcel is on the way" push, which is the one event the
+ * subscribe-flow was shipped for.
+ */
+
+const ACTIONS_PATH = 'src/domains/vendors/actions.ts'
+
+function readActions(): string {
+  return readFileSync(join(process.cwd(), ACTIONS_PATH), 'utf-8')
+}
+
+test('advanceFulfillment fires a push when the transition lands on SHIPPED', () => {
+  const src = readActions()
+  // The helper must exist and the fire-and-forget callsite must
+  // reference it inside the `if (nextStatus === 'SHIPPED')` branch.
+  assert.match(src, /notifyBuyerFulfillmentShipped/, 'helper must be defined')
+  assert.match(
+    src,
+    /if\s*\(\s*nextStatus\s*===\s*'SHIPPED'\s*\)\s*\{[\s\S]*notifyBuyerFulfillmentShipped/,
+    'the push must be guarded by the SHIPPED transition — firing on every transition would spam buyers',
+  )
+})
+
+test('push helper is fire-and-forget — a failure never blocks the vendor UI', () => {
+  const src = readActions()
+  assert.match(
+    src,
+    /void notifyBuyerFulfillmentShipped[\s\S]*\.catch\(/,
+    'the call must be `void helper(...).catch(...)` so a web-push error does not throw out of advanceFulfillment',
+  )
+})
+
+test('push helper uses the official sendPushToUser API (graceful degradation)', () => {
+  const src = readActions()
+  assert.match(
+    src,
+    /import\(\s*['"]@\/lib\/pwa\/push-send['"]\s*\)/,
+    'the helper must import from src/lib/pwa/push-send so the `no VAPID → no-op` and stale-subscription cleanup behaviour is preserved',
+  )
+  assert.match(src, /sendPushToUser\s*\(/, 'must call sendPushToUser, not ad-hoc web-push')
+})
+
+test('push payload includes a deep-link to the buyer order detail', () => {
+  const src = readActions()
+  assert.match(
+    src,
+    /url:\s*`\/cuenta\/pedidos\/\$\{orderId\}`/,
+    'the push must deep-link into the buyer order detail so a tap lands on the tracking page',
+  )
+})
+
+test('push payload is tagged so repeat shipments of the same order collapse in the tray', () => {
+  const src = readActions()
+  assert.match(
+    src,
+    /tag:\s*`order-shipped-\$\{orderId\}`/,
+    'tag pins the notification to the order so multiple fulfillments in the same order don\'t pile up',
+  )
+})


### PR DESCRIPTION
Closes #570. First live push-notification event in the app.

## Summary
- \`advanceFulfillment(SHIPPED)\` now fires a push to the buyer — the single highest-value event for the first wave (every buyer's "where is my parcel?" question lands here).
- Guarded by the \`nextStatus === 'SHIPPED'\` branch so we don't spam buyers on intermediate states.
- Fire-and-forget: a web-push error can never throw out of \`advanceFulfillment\` and block the vendor UI.
- Uses \`sendPushToUser\` so graceful degradation (no VAPID / no subscription / stale subscription cleanup) is preserved.
- Payload: \`url: /cuenta/pedidos/{orderId}\` (deep-link to tracking) and \`tag: order-shipped-{orderId}\` (multi-vendor orders collapse in the tray instead of piling up).

## Test plan
- [x] 5/5 contract pins in \`test/features/push-notifications-wiring.test.ts\`
- [x] \`npm run typecheck\` + \`npm run lint\`
- [ ] CI

## Out of scope
- Order-state push (PLACED, PAYMENT_CONFIRMED, DELIVERED) — intentionally narrow first wave per spec.
- Admin/vendor-side push events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)