### PR TITLE
test(e2e): stop cart-checkout @smoke from flaking on cold /checkout compile

### DIFF
--- a/e2e/smoke/cart-checkout.spec.ts
+++ b/e2e/smoke/cart-checkout.spec.ts
@@ -46,8 +46,18 @@ test.describe('cart and checkout @smoke', () => {
     await expect(page.getByText(/tomates cherry/i).first()).toBeVisible({ timeout: 5_000 })
 
     const toCheckout = page.getByRole('link', { name: /ir al checkout/i }).first()
-    await toCheckout.click()
-    await expect(page).toHaveURL(/\/checkout(?:\/|$|\?)/, { timeout: 10_000 })
+    // The shard's `next dev` server has to cold-compile `/checkout` the
+    // first time a test visits it (webpack + React server components),
+    // which on GitHub-hosted runners has been observed to exceed the old
+    // 10s timeout — triggering the full Playwright retry cycle
+    // (27s + 16s + 9s instead of a single ~10s run). Arm the navigation
+    // waiter BEFORE the click to avoid the race where the URL changes
+    // between click dispatch and the assertion being installed, and
+    // bump the ceiling to 25s to absorb dev-mode compile spikes.
+    await Promise.all([
+      page.waitForURL(/\/checkout(?:\/|$|\?)/, { timeout: 25_000 }),
+      toCheckout.click(),
+    ])
 
     // --- CHECKOUT ---
     // The seeded customer has a default address (`Calle Mayor 18`, Madrid).


### PR DESCRIPTION
## Problem
PR #581 diagnostic run caught the flake we've seen in E2E smoke, in shard 2:
\`\`\`
✘ 4 buyer adds a product ... (27.6s)
✘ 5 buyer adds a product ... (retry #1) (16.0s)
✓ 6 buyer adds a product ... (retry #2) (9.0s)
\`\`\`
Retry #2 succeeded on a warm next-dev compile — the original failure was a 10s \`toHaveURL(/\\/checkout/)\` that fired before the shard's first visit to \`/checkout\` finished its cold webpack + RSC compile. The retry wasted ~35s per hit and made the \"E2E shard 2 is suspiciously slow\" signal ambiguous.

## Fix
- Install the navigation waiter **before** the click via \`Promise.all\`, so the waiter exists before any navigation event fires — Playwright's documented race-free navigation pattern.
- Bump the ceiling from 10s → 25s to absorb dev-mode compile spikes (matches the rest of this spec's timeouts).

## Impact
- When the flake would have hit: saves ~35s on that shard.
- When it wouldn't have: no behavior change; \`waitForURL\` returns immediately once the new URL is committed.
- Eliminates the \"retry succeeded after red\" noise that hides real regressions.

## Test plan
- [ ] CI green
- [ ] \`E2E Smoke (shard 1|2)\` pass on first try — no retry lines in the job log

🤖 Generated with [Claude Code](https://claude.com/claude-code)