### PR TITLE
fix(security): hide demo creds + demo banner from public storefront

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -26,9 +26,14 @@ const demoConfig = [
   { key: 'FLAT_SHIPPING_COST', value: 4.95, description: 'Coste fijo de envío estándar' },
   { key: 'MAINTENANCE_MODE', value: false, description: 'Modo mantenimiento del storefront' },
   {
+    // Empty by default — the banner only renders when admin sets a value.
+    // Past leak: the demo text "Demo activa: catálogo ampliado…" was being
+    // shown on every fresh deploy because seed populated it; instances that
+    // never visited /admin/configuracion to clear it were exposing internal
+    // demo language to real users.
     key: 'HERO_BANNER_TEXT',
-    value: 'Demo activa: catálogo ampliado con productos, productores y reseñas de ejemplo.',
-    description: 'Texto principal del banner de home',
+    value: '',
+    description: 'Texto promocional principal mostrado en home (vacío = oculto)',
   },
 ]
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -194,14 +194,16 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
         </Button>
       </form>
 
-      <div className="mt-4 rounded-lg border border-dashed border-[var(--border-strong)] bg-[var(--surface-raised)] p-3">
-        <p className="text-xs font-medium text-[var(--muted)] mb-1">Credenciales de prueba:</p>
-        <div className="text-xs text-[var(--foreground-soft)] space-y-0.5">
-          <p>Admin: <code>admin@marketplace.com</code> / <code>admin1234</code></p>
-          <p>Productor: <code>productor@test.com</code> / <code>vendor1234</code></p>
-          <p>Cliente: <code>cliente@test.com</code> / <code>cliente1234</code></p>
+      {process.env.NEXT_PUBLIC_SHOW_DEMO_CREDS === 'true' && (
+        <div className="mt-4 rounded-lg border border-dashed border-[var(--border-strong)] bg-[var(--surface-raised)] p-3">
+          <p className="text-xs font-medium text-[var(--muted)] mb-1">Credenciales de prueba:</p>
+          <div className="text-xs text-[var(--foreground-soft)] space-y-0.5">
+            <p>Admin: <code>admin@marketplace.com</code> / <code>admin1234</code></p>
+            <p>Productor: <code>productor@test.com</code> / <code>vendor1234</code></p>
+            <p>Cliente: <code>cliente@test.com</code> / <code>cliente1234</code></p>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="mt-4 grid gap-2">
         {publicPortalLinks.slice(1).map(link => (

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -87,7 +87,7 @@ const en: Record<TranslationKeys, string> = {
   'hero.cta1': 'Explore products',
   'hero.cta2': 'Meet producers',
   'hero.quickAccess': 'Quick access',
-  'hero.loginCta': 'View demo credentials →',
+  'hero.loginCta': 'Log in →',
 
   // Home hero stats
   'home.stats.activeVendors': 'Active producers',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -85,7 +85,7 @@ const es = {
   'hero.cta1': 'Explorar productos',
   'hero.cta2': 'Conocer productores',
   'hero.quickAccess': 'Accesos rápidos',
-  'hero.loginCta': 'Ver credenciales demo →',
+  'hero.loginCta': 'Iniciar sesión →',
 
   // Home hero stats
   'home.stats.activeVendors': 'Productores activos',


### PR DESCRIPTION
## Summary

Three storefront leaks visible to any visitor — surfaced while putting a fresh deploy on a real domain (\`dev.feldescloud.com\`). None of them were behind a \`NODE_ENV\` check or any flag; they shipped on every fresh deploy of \`main\`.

## What was leaking

1. **\`/login\` showed seed credentials in plain text** — \`admin@marketplace.com / admin1234\`, \`productor@test.com / vendor1234\`, \`cliente@test.com / cliente1234\`. Anyone could log in as superadmin.
2. **Home page yellow banner** \"Demo activa: catálogo ampliado con productos, productores y reseñas de ejemplo.\" — internal demo language exposed as production copy. Came from \`prisma/seed.ts\` populating \`HERO_BANNER_TEXT\` with that string.
3. **Hero CTA text** \"Ver credenciales demo →\" / \"View demo credentials →\" — invited users to grab demo credentials.

The chain was: home banner reads \"demo\", CTA promises demo credentials, \`/login\` delivers them — full superadmin access in 3 clicks for any visitor.

## Fix

| File | Change |
|------|--------|
| \`src/components/auth/LoginForm.tsx\` | Wrap creds block in \`process.env.NEXT_PUBLIC_SHOW_DEMO_CREDS === 'true'\`. Opt-in via env var (absent in prod = hidden) |
| \`prisma/seed.ts\` | \`HERO_BANNER_TEXT\` default is now \`''\` (empty) so banner is hidden until an admin explicitly sets text via \`/admin/configuracion\`. Comment documents the past leak |
| \`src/i18n/locales/{es,en}.ts\` | \`hero.loginCta\` text → neutral \"Iniciar sesión →\" / \"Log in →\" |

## Migration note for existing instances

If your DB already has the demo banner text from an earlier seed, this PR alone won't clear it (data, not code). Run once after deploy:

\`\`\`sql
UPDATE \"MarketplaceConfig\" SET value = '\"\"'::jsonb WHERE key = 'HERO_BANNER_TEXT';
\`\`\`

Or use \`/admin/configuracion\` and save with the field empty (also invalidates the \`marketplace-config\` cache tag automatically).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [ ] Deploy + visit \`/\` → no \"Demo activa\" banner
- [ ] Visit \`/login\` → no credentials block
- [ ] Visit home → CTA reads \"Iniciar sesión →\"
- [ ] For local dev that wants creds back: \`NEXT_PUBLIC_SHOW_DEMO_CREDS=true\` in \`.env.local\` → block reappears

## Related

- Fixes the leak surface that #592 \"close login bypass and dev leaks\" did NOT cover (that PR closed other leaks but missed these three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)