### PR TITLE
fix(security): block src/app/dev/** in production + audit test (#589)

### DIFF
--- a/src/lib/dev-routes.ts
+++ b/src/lib/dev-routes.ts
@@ -1,0 +1,21 @@
+/**
+ * Allow-list of dev-only routes under `src/app/dev/**`. Kept in its own
+ * dependency-free module so the contract test
+ * (`test/integration/dev-routes-audit.test.ts`) can import it without
+ * pulling the Prisma client or the Edge runtime through `src/proxy.ts`.
+ *
+ * Every entry is a security decision — document WHY it exists and what
+ * it would leak if it rendered in production. The edge proxy 404s the
+ * whole `/dev/*` subtree in production (see src/proxy.ts) but each
+ * page must ALSO self-gate on NODE_ENV.
+ */
+export const DEV_ROUTES_ALLOWLIST: ReadonlyArray<{ path: string; why: string }> = [
+  {
+    path: 'src/app/dev/mock-shipment/[ref]/page.tsx',
+    why: 'Fake carrier label + tracking rendered when MockShippingProvider is active in dev/local. Reads toAddressSnapshot/fromAddressSnapshot — would leak buyer PII if it rendered in prod. Gated at proxy AND inline NODE_ENV check.',
+  },
+]
+
+export function isDevRoute(pathname: string) {
+  return pathname === '/dev' || pathname.startsWith('/dev/')
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,8 @@ import { type UserRole } from '@/generated/prisma/enums'
 import { getPrimaryPortalHref, sanitizeCallbackUrl } from '@/lib/portals'
 import { isRequestOnAdminHost, hostMatchesAdmin, ADMIN_HOST_ENV_VAR } from '@/lib/admin-host'
 import { buildContentSecurityPolicy } from '@/lib/security-headers'
+import { isDevRoute } from '@/lib/dev-routes'
+export { DEV_ROUTES_ALLOWLIST } from '@/lib/dev-routes'
 
 // Exported so test/integration/proxy-protected-prefixes.test.ts can
 // reflect the live list back against the actual src/app route tree
@@ -15,6 +17,10 @@ export const PROTECTED_PREFIXES = ['/admin', '/vendor', '/carrito', '/checkout',
 function isProtectedPath(pathname: string) {
   return PROTECTED_PREFIXES.some(prefix => pathname === prefix || pathname.startsWith(`${prefix}/`))
 }
+
+// Issue #589: DEV_ROUTES_ALLOWLIST + isDevRoute live in
+// `src/lib/dev-routes.ts` so the structural audit test can import
+// them without pulling the Edge runtime / Prisma through this file.
 
 // Defense-in-depth CSRF check for mutating /api/* JSON endpoints (#543).
 // NextAuth session cookies are SameSite=Lax, which blocks most cross-site
@@ -101,6 +107,15 @@ export async function proxy(request: NextRequest) {
   // addition to the role check below, so a stolen non-admin cookie on
   // the public host cannot pivot into the admin panel.
   // ------------------------------------------------------------------
+  // Issue #589: hard 404 any /dev/** path in production as defense-in-
+  // depth. Individual dev pages already self-gate on NODE_ENV, but a
+  // newly added one that forgets the check would be exposed. This
+  // block is independent of that and runs before any auth or admin
+  // host logic so nothing else can accidentally let it through.
+  if (process.env.NODE_ENV === 'production' && isDevRoute(pathname)) {
+    return new NextResponse(null, { status: 404 })
+  }
+
   const adminHost = process.env[ADMIN_HOST_ENV_VAR]
   if (adminHost) {
     const onAdminHost = isRequestOnAdminHost(request)

--- a/test/integration/dev-routes-audit.test.ts
+++ b/test/integration/dev-routes-audit.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { DEV_ROUTES_ALLOWLIST } from '@/lib/dev-routes'
+
+/**
+ * Issue #589: every file under `src/app/dev/**` must appear on
+ * DEV_ROUTES_ALLOWLIST. A dev-only route that ships to production
+ * would expose internal snapshots (carrier labels, fulfillment data,
+ * PII from address snapshots, etc.). The edge proxy 404s the whole
+ * `/dev/*` subtree in production, but this test is the structural
+ * check that nobody silently adds a new dev route without an explicit
+ * decision documented on the allow-list.
+ *
+ * Adding a route here is a security decision — document WHY.
+ */
+
+const DEV_ROOT = path.join(process.cwd(), 'src', 'app', 'dev')
+
+const ROUTE_FILE_NAMES = new Set(['page.tsx', 'page.ts', 'route.ts', 'route.tsx'])
+
+function listRouteFiles(dir: string, out: string[] = []): string[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return out
+  }
+  for (const name of entries) {
+    const full = path.join(dir, name)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      listRouteFiles(full, out)
+    } else if (ROUTE_FILE_NAMES.has(name)) {
+      out.push(path.relative(process.cwd(), full))
+    }
+  }
+  return out
+}
+
+test('every route file under src/app/dev/** is on DEV_ROUTES_ALLOWLIST', () => {
+  const discovered = listRouteFiles(DEV_ROOT).sort()
+  const allowed = new Set(DEV_ROUTES_ALLOWLIST.map(entry => entry.path))
+  const undeclared = discovered.filter(file => !allowed.has(file))
+
+  assert.deepEqual(
+    undeclared,
+    [],
+    `New dev-only route(s) detected without an entry on DEV_ROUTES_ALLOWLIST
+(src/proxy.ts). Either add an entry documenting WHY the route exists and
+what it would leak in production, or delete / relocate the route:\n` +
+      undeclared.map(f => `  - ${f}`).join('\n'),
+  )
+})
+
+test('DEV_ROUTES_ALLOWLIST entries point at real files', () => {
+  const missing: string[] = []
+  for (const entry of DEV_ROUTES_ALLOWLIST) {
+    const full = path.join(process.cwd(), entry.path)
+    try {
+      statSync(full)
+    } catch {
+      missing.push(entry.path)
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `DEV_ROUTES_ALLOWLIST references files that do not exist. Remove the
+stale entry or restore the file:\n` + missing.map(p => `  - ${p}`).join('\n'),
+  )
+})
+
+test('DEV_ROUTES_ALLOWLIST entries carry a non-trivial rationale', () => {
+  for (const entry of DEV_ROUTES_ALLOWLIST) {
+    assert.ok(
+      entry.why && entry.why.trim().length >= 40,
+      `Entry for ${entry.path} must document WHY in at least 40 chars. Got: ${entry.why}`,
+    )
+  }
+})
+
+test('every allow-listed dev route has an inline NODE_ENV === "production" self-gate', () => {
+  // Defense in depth: the edge proxy 404s /dev/* in production, but we
+  // also want each page to fail closed on its own so a hand-crafted
+  // request that somehow bypasses the proxy (local preview server,
+  // unit test harness, misconfigured deployment) still notFound()s.
+  const ungated: string[] = []
+  for (const entry of DEV_ROUTES_ALLOWLIST) {
+    const source = readFileSync(path.join(process.cwd(), entry.path), 'utf8')
+    const hasGate =
+      /process\.env\.NODE_ENV\s*===\s*['"]production['"]/.test(source) ||
+      /NODE_ENV\s*!==\s*['"]production['"]/.test(source)
+    if (!hasGate) ungated.push(entry.path)
+  }
+  assert.deepEqual(
+    ungated,
+    [],
+    `Dev routes must self-gate on NODE_ENV. Add a production check that
+returns notFound() / 404:\n` + ungated.map(p => `  - ${p}`).join('\n'),
+  )
+})


### PR DESCRIPTION
## Summary
- Edge proxy now returns 404 for any `/dev/*` path when `NODE_ENV === 'production'`, regardless of whether the individual page self-gates.
- Extracts the allow-list of permitted dev routes to `src/lib/dev-routes.ts` (dependency-free module) so a structural audit test can import it without pulling Prisma / the Edge runtime.
- Adds `test/integration/dev-routes-audit.test.ts` which fails CI if:
  - a new route file appears under `src/app/dev/**` without an allow-list entry
  - an allow-list entry points at a missing file
  - an entry lacks a rationale (≥40 chars)
  - an allow-listed page drops its inline `NODE_ENV === 'production'` self-gate

Only existing dev route is `src/app/dev/mock-shipment/[ref]/page.tsx` (already self-gated).

Closes #589.

## Test plan
- [x] `node --import tsx --test test/integration/dev-routes-audit.test.ts` — 4/4 pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)