### PR TITLE
fix(security): trim public catalog reads to explicit DTOs (#590)

### DIFF
--- a/src/domains/catalog/public-selects.ts
+++ b/src/domains/catalog/public-selects.ts
@@ -1,0 +1,47 @@
+/**
+ * Issue #590: explicit DTOs for public catalog reads.
+ *
+ * Kept in a dependency-free module so the contract test
+ * (`test/integration/public-catalog-dto.test.ts`) can import the
+ * select maps without pulling the Prisma client or the request
+ * environment through `@/lib/db`.
+ *
+ * Prisma `include` without `select` pulls the whole row — including
+ * fields that are safe on admin/vendor surfaces but MUST NOT leak to
+ * buyers or anonymous visitors. For Vendor that set is:
+ *   - iban, bankAccountName      → payment PII
+ *   - stripeAccountId, stripeOnboarded → payout wiring
+ *   - commissionRate             → business-sensitive pricing
+ *   - userId                     → internal join, not needed publicly
+ *   - preferredShippingProvider  → internal operational config
+ *   - status                     → we already filter to ACTIVE
+ *
+ * Every field on these DTOs has a reason to be public. Adding one is a
+ * security decision — update the companion test alongside the change.
+ */
+export const PUBLIC_VENDOR_SELECT = {
+  id: true,
+  slug: true,
+  displayName: true,
+  description: true,
+  logo: true,
+  coverImage: true,
+  location: true,
+  category: true,
+  avgRating: true,
+  totalReviews: true,
+  orderCutoffTime: true,
+  preparationDays: true,
+  createdAt: true,
+} as const
+
+// ProductVariant: `sku` is an internal operational code (used by the
+// vendor panel and Sendcloud label workflow). Keep it off the public
+// catalog surface; buyers pick a variant by id/name.
+export const PUBLIC_VARIANT_SELECT = {
+  id: true,
+  name: true,
+  priceModifier: true,
+  stock: true,
+  isActive: true,
+} as const

--- a/src/domains/catalog/queries.ts
+++ b/src/domains/catalog/queries.ts
@@ -6,6 +6,12 @@ import { CACHE_TAGS } from '@/lib/cache-tags'
 import { getDemoProductImages } from '@/domains/catalog/demo-product-images'
 import { expandSearchQuery } from '@/domains/catalog/search-translation'
 
+// Issue #590: explicit DTOs for public reads. Selects live in the
+// dependency-free `public-selects` module so the audit test can pin
+// the allow-list without pulling Prisma.
+export { PUBLIC_VENDOR_SELECT, PUBLIC_VARIANT_SELECT } from '@/domains/catalog/public-selects'
+import { PUBLIC_VENDOR_SELECT, PUBLIC_VARIANT_SELECT } from '@/domains/catalog/public-selects'
+
 export interface ProductFilters {
   categorySlug?: string
   certifications?: string[]
@@ -253,21 +259,10 @@ async function getProductBySlugUncached(slug: string) {
       certifications: true,
       originRegion: true,
       createdAt: true,
-      vendor: {
-        select: {
-          id: true,
-          slug: true,
-          displayName: true,
-          description: true,
-          location: true,
-          logo: true,
-          avgRating: true,
-          totalReviews: true,
-        },
-      },
+      vendor: { select: PUBLIC_VENDOR_SELECT },
       categoryId: true,
       category: { select: { id: true, name: true, slug: true } },
-      variants: { where: { isActive: true } },
+      variants: { where: { isActive: true }, select: PUBLIC_VARIANT_SELECT },
       // Phase 4b-β: surface all active subscription plans for this
       // product (multi-cadence — one per WEEKLY/BIWEEKLY/MONTHLY). The
       // product detail page shows a single CTA that navigates to the
@@ -371,7 +366,8 @@ async function getVendorsUncached(limit = 12) {
     where: { status: 'ACTIVE' },
     orderBy: { avgRating: 'desc' },
     take: limit,
-    include: {
+    select: {
+      ...PUBLIC_VENDOR_SELECT,
       _count: { select: { products: { where: getAvailableProductWhere() } } },
     },
   })
@@ -431,7 +427,8 @@ export async function getHomeSnapshot() {
 async function getVendorBySlugUncached(slug: string) {
   const vendor = await db.vendor.findUnique({
     where: { slug, status: 'ACTIVE' },
-    include: {
+    select: {
+      ...PUBLIC_VENDOR_SELECT,
       products: {
         where: getAvailableProductWhere(),
         orderBy: { createdAt: 'desc' },
@@ -450,10 +447,7 @@ async function getVendorBySlugUncached(slug: string) {
           originRegion: true,
           createdAt: true,
           category: { select: { name: true, slug: true } },
-          variants: {
-            where: { isActive: true },
-            select: { id: true, name: true, priceModifier: true, stock: true, isActive: true },
-          },
+          variants: { where: { isActive: true }, select: PUBLIC_VARIANT_SELECT },
         },
       },
     },

--- a/src/domains/catalog/types.ts
+++ b/src/domains/catalog/types.ts
@@ -36,7 +36,27 @@ export type ProductDetail = Product & {
   variants: ProductVariant[]
 }
 
-export type VendorWithCount = Vendor & {
+// Public-vendor shape (#590). Must stay in sync with
+// PUBLIC_VENDOR_SELECT in src/domains/catalog/queries.ts — that
+// constant defines which fields are safe to expose on public reads.
+export type PublicVendor = Pick<
+  Vendor,
+  | 'id'
+  | 'slug'
+  | 'displayName'
+  | 'description'
+  | 'logo'
+  | 'coverImage'
+  | 'location'
+  | 'category'
+  | 'avgRating'
+  | 'totalReviews'
+  | 'orderCutoffTime'
+  | 'preparationDays'
+  | 'createdAt'
+>
+
+export type VendorWithCount = PublicVendor & {
   _count: { products: number }
 }
 

--- a/test/integration/public-catalog-dto.test.ts
+++ b/test/integration/public-catalog-dto.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PUBLIC_VENDOR_SELECT, PUBLIC_VARIANT_SELECT } from '@/domains/catalog/public-selects'
+
+/**
+ * Issue #590: public catalog queries must not leak sensitive vendor
+ * fields (iban, bankAccountName, stripeAccountId, commissionRate,
+ * etc.). PUBLIC_VENDOR_SELECT is the allow-list that
+ * getVendors / getVendorBySlug / getProductBySlug use to scope the
+ * Prisma select. This test pins that list so a future diff that
+ * adds, say, `iban: true` on the public surface will fail CI.
+ *
+ * If a new field is genuinely safe to expose publicly, update this
+ * test alongside the query in a single PR so the review is explicit.
+ */
+
+const FORBIDDEN_VENDOR_FIELDS = [
+  'userId',
+  'iban',
+  'bankAccountName',
+  'stripeAccountId',
+  'stripeOnboarded',
+  'commissionRate',
+  'preferredShippingProvider',
+  'status',
+  'updatedAt',
+] as const
+
+const FORBIDDEN_VARIANT_FIELDS = ['sku', 'productId', 'createdAt', 'updatedAt'] as const
+
+test('PUBLIC_VENDOR_SELECT contains no sensitive vendor fields', () => {
+  for (const field of FORBIDDEN_VENDOR_FIELDS) {
+    assert.equal(
+      (PUBLIC_VENDOR_SELECT as Record<string, unknown>)[field],
+      undefined,
+      `PUBLIC_VENDOR_SELECT leaks ${field}. This field would be serialized to any buyer / anon page that fetches a vendor. Remove it or move the caller behind an auth boundary.`,
+    )
+  }
+})
+
+test('PUBLIC_VENDOR_SELECT pins the expected field set', () => {
+  // Snapshot of the current public fields. Growing this set is a
+  // security decision — widen the snapshot AND document why in the
+  // PUBLIC_VENDOR_SELECT comment.
+  const expected = [
+    'id',
+    'slug',
+    'displayName',
+    'description',
+    'logo',
+    'coverImage',
+    'location',
+    'category',
+    'avgRating',
+    'totalReviews',
+    'orderCutoffTime',
+    'preparationDays',
+    'createdAt',
+  ].sort()
+  const actual = Object.keys(PUBLIC_VENDOR_SELECT).sort()
+  assert.deepEqual(
+    actual,
+    expected,
+    'PUBLIC_VENDOR_SELECT field set changed. If intentional, update this test and document why in src/domains/catalog/queries.ts.',
+  )
+})
+
+test('PUBLIC_VARIANT_SELECT keeps internal SKU off the public surface', () => {
+  for (const field of FORBIDDEN_VARIANT_FIELDS) {
+    assert.equal(
+      (PUBLIC_VARIANT_SELECT as Record<string, unknown>)[field],
+      undefined,
+      `PUBLIC_VARIANT_SELECT leaks ${field}. Buyers should not see internal variant plumbing.`,
+    )
+  }
+})


### PR DESCRIPTION
## Summary
Previously `getVendors` and `getVendorBySlug` used Prisma `include` without `select`, returning the full Vendor row on every public producer page and home snapshot. That row contains **iban, bankAccountName, stripeAccountId, stripeOnboarded, commissionRate, userId, preferredShippingProvider** — all serialized to anon visitors.

This PR:
- Adds `PUBLIC_VENDOR_SELECT` / `PUBLIC_VARIANT_SELECT` in a dependency-free module (`src/domains/catalog/public-selects.ts`).
- Re-exports them from `queries.ts` and applies them to `getVendors`, `getVendorBySlug`, and the vendor relation of `getProductBySlug`.
- Narrows the variant select on the product detail page to the same fields the catalog grid uses, dropping the internal SKU.
- Narrows `VendorWithCount` to a `Pick` of public fields instead of the full `Vendor` model.
- Adds `public-catalog-dto.test.ts`: fails CI if a forbidden field (iban, stripeAccountId, commissionRate, userId, SKU, etc.) reappears on the public select, or if the allow-listed field set changes without an explicit test update.

Closes #590.

## Test plan
- [x] `node --import tsx --test test/integration/public-catalog-dto.test.ts` — 3/3 pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] CI green
- [ ] Manual: `/productos/[slug]` and `/productores/[slug]` render unchanged; no request to these pages ships vendor PII in the HTML / RSC payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)