### PR TITLE
fix(theme): prevent white flash on auth navigation in dark mode

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,6 +82,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       className={`${geist.variable} h-full antialiased`}
       suppressHydrationWarning
     >
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('marketplace-theme');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;var d=s==='dark'||((!s||s==='system')&&m);if(d)document.documentElement.classList.add('dark');document.documentElement.style.colorScheme=d?'dark':'light';}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body className="flex min-h-full flex-col bg-[var(--background)] text-[var(--foreground)]">
         <SessionProvider>
           <ThemeProvider>


### PR DESCRIPTION
## Summary
- Inject a sync script in `<head>` to apply `.dark` + `color-scheme` before the first paint, eliminating the white flash reported on sign-in / sign-out in dark mode.
- `next-themes` renders its anti-FOUC script inside `<body>`, so a full navigation can paint the light `:root` background briefly before the class is attached. Running the check in `<head>` closes that window.

Replaces #601 (stale branch history).

## Test plan
- [ ] On dev.feldescloud.com with dark mode active, sign in and sign out: no white flash on either transition.
- [ ] Light mode still renders light.
- [ ] System-theme users still follow OS preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)