### PR TITLE
feat(ops): visible build version (badge + update-available banner)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,18 @@ STRIPE_WEBHOOK_SECRET="whsec_..."
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 
 # ===========================
+# BUILD IDENTITY (auto-detected from git, override only if needed)
+# ===========================
+# next.config.ts auto-stamps these from `git rev-parse` at build/dev time.
+# Override when running outside a git checkout (e.g. Docker COPY-only),
+# or to pin a specific value in CI:
+# NEXT_PUBLIC_COMMIT_SHA="abc1234"
+# NEXT_PUBLIC_GIT_BRANCH="main"
+# NEXT_PUBLIC_BUILD_TIME="2026-04-19T00:00:00Z"
+# Hide the floating build badge in production:
+# NEXT_PUBLIC_HIDE_BUILD_BADGE="true"
+
+# ===========================
 # EMAILS (optional)
 # ===========================
 # Uses Resend API for transactional emails

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,30 @@
 import type { NextConfig } from 'next'
+import { execSync } from 'node:child_process'
 import { getSecurityHeaders } from '@/lib/security-headers'
 
 type HeaderRule = {
   source: string
   headers: Array<{ key: string; value: string }>
 }
+
+// Build identity stamped into client + server bundles. Surfaces via
+// process.env.NEXT_PUBLIC_COMMIT_SHA / NEXT_PUBLIC_BUILD_TIME /
+// NEXT_PUBLIC_GIT_BRANCH for the floating <BuildBadge /> and the
+// <UpdateAvailableBanner /> polling client. Falls back to 'unknown'
+// outside a git checkout (Docker COPY-only builds, etc.); override
+// with the matching env var to pin a value in CI.
+function readGitOutput(cmd: string, fallback: string): string {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || fallback
+  } catch {
+    return fallback
+  }
+}
+const BUILD_SHA =
+  process.env.NEXT_PUBLIC_COMMIT_SHA ?? readGitOutput('git rev-parse --short HEAD', 'unknown')
+const BUILD_BRANCH =
+  process.env.NEXT_PUBLIC_GIT_BRANCH ?? readGitOutput('git rev-parse --abbrev-ref HEAD', 'unknown')
+const BUILD_TIME = process.env.NEXT_PUBLIC_BUILD_TIME ?? new Date().toISOString()
 
 const NO_STORE_CACHE_HEADER = {
   key: 'Cache-Control',
@@ -65,6 +85,13 @@ export function buildHeaderRules(isDevelopment = process.env.NODE_ENV === 'devel
 }
 
 const nextConfig: NextConfig = {
+  // Build identity baked into both server and client bundles. See the
+  // helpers above for fallback behaviour outside git checkouts.
+  env: {
+    NEXT_PUBLIC_COMMIT_SHA: BUILD_SHA,
+    NEXT_PUBLIC_BUILD_TIME: BUILD_TIME,
+    NEXT_PUBLIC_GIT_BRANCH: BUILD_BRANCH,
+  },
   // Allow LAN access to the dev server (e.g. testing on a phone via
   // http://192.168.x.y:3000). Without this, Next.js 16 blocks cross-origin
   // requests to /_next/* dev resources, which breaks HMR and the dev overlay

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * Reports the running build identity. Powers <UpdateAvailableBanner />:
+ * the client captures the SHA on first load, polls this endpoint every
+ * minute, and prompts the user to reload when the SHA returned here
+ * differs from what it captured. Also useful for ops health checks
+ * ("which version is prod actually serving?") and bug reports.
+ *
+ * Public on purpose: the SHA + build time + branch tell anyone the
+ * deploy state, which is the same information already visible in
+ * <BuildBadge />. No secrets, no PII.
+ */
+export async function GET(): Promise<Response> {
+  return NextResponse.json(
+    {
+      sha: process.env.NEXT_PUBLIC_COMMIT_SHA ?? 'unknown',
+      buildTime: process.env.NEXT_PUBLIC_BUILD_TIME ?? null,
+      branch: process.env.NEXT_PUBLIC_GIT_BRANCH ?? 'unknown',
+    },
+    {
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+      },
+    },
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,8 @@ import { CartHydrationProvider } from '@/components/buyer/CartHydrationProvider'
 import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
 import OfflineIndicator from '@/components/pwa/OfflineIndicator'
+import { BuildBadge } from '@/components/system/BuildBadge'
+import { UpdateAvailableBanner } from '@/components/system/UpdateAvailableBanner'
 
 const geist = Geist({
   variable: '--font-geist-sans',
@@ -98,7 +100,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <PwaRegister />
               <OfflineIndicator />
               <CartHydrationProvider />
+              <UpdateAvailableBanner />
               {children}
+              <BuildBadge />
             </LanguageProvider>
           </ThemeProvider>
         </SessionProvider>

--- a/src/components/system/BuildBadge.tsx
+++ b/src/components/system/BuildBadge.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Floating pill in the bottom-right corner that shows the running build
+ * identity (commit SHA + build time + branch). Click to expand for the
+ * full timestamp and branch name. Click again to collapse.
+ *
+ * Visible to everyone — same surface area as /api/version, no secrets.
+ * Hide with NEXT_PUBLIC_HIDE_BUILD_BADGE=true if you want it off in prod.
+ */
+export function BuildBadge() {
+  const [expanded, setExpanded] = useState(false)
+
+  if (process.env.NEXT_PUBLIC_HIDE_BUILD_BADGE === 'true') return null
+
+  const sha = process.env.NEXT_PUBLIC_COMMIT_SHA ?? 'dev'
+  const buildTime = process.env.NEXT_PUBLIC_BUILD_TIME ?? null
+  const branch = process.env.NEXT_PUBLIC_GIT_BRANCH ?? null
+
+  const shortTime = buildTime
+    ? new Date(buildTime).toLocaleString(undefined, {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null
+
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded(v => !v)}
+      aria-label={`Versión ${sha}${branch ? ` en ${branch}` : ''}`}
+      className="fixed bottom-2 right-2 z-50 select-none rounded-full bg-black/55 px-2.5 py-1 text-[10px] font-mono leading-none text-white/75 shadow-sm backdrop-blur-sm transition hover:bg-black/75 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+    >
+      {expanded ? (
+        <span className="flex flex-col items-end gap-0.5 text-right">
+          <span>{sha}</span>
+          {branch && <span className="opacity-70">{branch}</span>}
+          {buildTime && <span className="opacity-70">{new Date(buildTime).toISOString().slice(0, 16).replace('T', ' ')}</span>}
+        </span>
+      ) : (
+        <span>
+          {sha}
+          {shortTime && <span className="opacity-60"> · {shortTime}</span>}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/src/components/system/UpdateAvailableBanner.tsx
+++ b/src/components/system/UpdateAvailableBanner.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+const POLL_INTERVAL_MS = 60_000
+
+/**
+ * Captures the build SHA the page loaded with, then polls /api/version
+ * once a minute. If the server starts reporting a different SHA (i.e. a
+ * deploy landed), shows a banner letting the user reload.
+ *
+ * Renders nothing when:
+ *   - The current SHA is "unknown"/"dev" (no useful comparison possible)
+ *   - The fetch fails (server may be momentarily down — silent retry)
+ *   - The server SHA matches the loaded SHA (the common case)
+ *
+ * The banner sticks until the user reloads or dismisses it. After
+ * dismissal the polling continues but the banner stays hidden until the
+ * SHA changes again.
+ */
+export function UpdateAvailableBanner() {
+  const loadedSha = process.env.NEXT_PUBLIC_COMMIT_SHA ?? 'unknown'
+  const [serverSha, setServerSha] = useState<string | null>(null)
+  const [dismissedSha, setDismissedSha] = useState<string | null>(null)
+  const lastSeenRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (loadedSha === 'unknown' || loadedSha === 'dev') return
+    let cancelled = false
+
+    async function check() {
+      try {
+        const res = await fetch('/api/version', { cache: 'no-store' })
+        if (!res.ok) return
+        const data = (await res.json()) as { sha?: string }
+        if (cancelled || !data.sha) return
+        if (data.sha !== lastSeenRef.current) {
+          lastSeenRef.current = data.sha
+          setServerSha(data.sha)
+        }
+      } catch {
+        // network blip — try again next tick
+      }
+    }
+
+    void check()
+    const id = setInterval(check, POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [loadedSha])
+
+  const updateAvailable = serverSha !== null && serverSha !== loadedSha && serverSha !== dismissedSha
+
+  if (!updateAvailable) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-x-0 top-0 z-[60] flex items-center justify-between gap-3 border-b border-emerald-300 bg-emerald-50/95 px-4 py-2 text-sm text-emerald-900 shadow-sm backdrop-blur-sm dark:border-emerald-800 dark:bg-emerald-950/90 dark:text-emerald-100"
+    >
+      <p className="flex-1 text-center sm:text-left">
+        Nueva versión disponible. Recarga para ver los últimos cambios.
+      </p>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-emerald-700"
+        >
+          Recargar
+        </button>
+        <button
+          type="button"
+          onClick={() => setDismissedSha(serverSha)}
+          aria-label="Descartar aviso"
+          className="rounded-md px-2 py-1 text-xs text-emerald-700 transition hover:bg-emerald-100 dark:text-emerald-300 dark:hover:bg-emerald-900/50"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/test/integration/api-route-auth-audit.test.ts
+++ b/test/integration/api-route-auth-audit.test.ts
@@ -78,6 +78,10 @@ const PUBLIC_API_ROUTES: ReadonlyArray<{ path: string; why: string }> = [
     path: 'src/app/api/healthcheck/route.ts',
     why: 'Synthetic health probe. Public by design — external monitors and the marketplace-pwa-server doctor script hit it without credentials. Returns only boolean + model name + error message; no user data.',
   },
+  {
+    path: 'src/app/api/version/route.ts',
+    why: 'Public build identity (commit SHA + build time + branch) for the floating BuildBadge and the UpdateAvailableBanner polling client. Same surface area as the visible badge — no secrets, no PII.',
+  },
 ]
 
 const SESSION_KEYWORDS = [


### PR DESCRIPTION
## Why

A debugging session today exposed a recurring pain: server, browser tab, and cookie state can each be on a different version of \`main\` — and **none of them is visible**. You only notice when something starts behaving weirdly (login loop, stale demo banner, dead button) and then you spend 20 minutes figuring out which layer is stale.

This PR makes the running version always visible and prompts the user to reload when a deploy lands.

## What you see

**Build pill, bottom-right of every page** (click to expand for full time + branch):

\`\`\`
579e3e0 · 04/19 01:23
\`\`\`

**Update banner, top of every page** (only when server SHA ≠ tab's loaded SHA):

\`\`\`
Nueva versión disponible. Recarga para ver los últimos cambios.   [Recargar] [✕]
\`\`\`

**`/api/version` endpoint** — JSON for ops health-checks and bug reports:

\`\`\`json
{ \"sha\": \"579e3e0\", \"buildTime\": \"2026-04-19T01:23:00.000Z\", \"branch\": \"main\" }
\`\`\`

## How

- \`next.config.ts\` reads \`git rev-parse --short HEAD\` and \`git rev-parse --abbrev-ref HEAD\` at build/dev start, baked into both server and client bundles via \`env\` config. Falls back to \`unknown\` outside a git checkout (Docker COPY-only builds, etc.); \`NEXT_PUBLIC_COMMIT_SHA\` / \`NEXT_PUBLIC_GIT_BRANCH\` / \`NEXT_PUBLIC_BUILD_TIME\` env vars override.
- \`/api/version/route.ts\` is the smallest possible handler: returns the three values, \`Cache-Control: no-store\`. Public on purpose — same surface area as the visible pill, no secrets, no PII. Allowlisted in \`api-route-auth-audit\` with documented reason.
- \`<BuildBadge />\` — fixed bottom-right pill, monospace, click to expand. Hides if \`NEXT_PUBLIC_HIDE_BUILD_BADGE=true\` so a prod deploy can opt out.
- \`<UpdateAvailableBanner />\` — captures the loaded SHA on mount, fetches \`/api/version\` once + every 60s. Shows banner when server SHA diverges. Dismiss button suppresses the banner for that specific SHA so the prompt doesn't reappear immediately if the user explicitly chose to defer; it'll show again on the next deploy.

Both wired in \`src/app/layout.tsx\` so they appear globally.

## Why it ships in main, not behind a flag

- Pure observability surface — zero functional risk
- Public-storefront hide opt-out via env var
- 1 request per minute per tab is unmeasurable cost
- Removing later = one PR if it ever stops being useful

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`api-route-auth-audit\` test passes (5/5) — \`/api/version\` correctly added to PUBLIC_API_ROUTES
- [ ] Visit any page → pill appears bottom-right with \`<sha> · <date>\`
- [ ] Click pill → expands to show full ISO timestamp + branch
- [ ] Hit \`/api/version\` → returns JSON with same SHA
- [ ] Manually change \`NEXT_PUBLIC_COMMIT_SHA\` env, restart server → open page in another tab, original tab shows banner within 60s
- [ ] Click Recargar → new SHA loads, banner gone
- [ ] Click ✕ → banner dismissed, doesn't reappear until SHA changes again

🤖 Generated with [Claude Code](https://claude.com/claude-code)