### PR TITLE
fix(theme): move anti-FOUC script out of manual <head>

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,14 +82,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       className={`${geist.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <head>
+      <body className="flex min-h-full flex-col bg-[var(--background)] text-[var(--foreground)]">
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var s=localStorage.getItem('marketplace-theme');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;var d=s==='dark'||((!s||s==='system')&&m);if(d)document.documentElement.classList.add('dark');document.documentElement.style.colorScheme=d?'dark':'light';}catch(e){}})();`,
           }}
         />
-      </head>
-      <body className="flex min-h-full flex-col bg-[var(--background)] text-[var(--foreground)]">
         <SessionProvider>
           <ThemeProvider>
             <LanguageProvider initialLocale={locale}>


### PR DESCRIPTION
## Summary
- #602 introduced a literal `<head>` in the root layout to host the theme-init script. That element fights Next.js App Router metadata injection and was reported to break client-side functionality (language switcher, login flow).
- Move the script to the first child of `<body>` — still runs synchronously before any body content paints, without clobbering `<head>` management.

## Test plan
- [ ] On dev.feldescloud.com: language switcher works, sign-in / sign-out flow works.
- [ ] Dark mode: flash is not worse than pre-#602 (ideally still suppressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)