### PR TITLE
fix(auth): force __Secure- session cookie in API route handlers

### DIFF
--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -3,7 +3,25 @@
 import type { NextAuthConfig } from 'next-auth'
 import { coerceUserRole, isAdmin, isVendor } from '@/lib/roles'
 
+// Behind the Cloudflare Tunnel (dev) / HTTPS terminator (prod), the
+// Next.js server sees requests as http://localhost internally. Auth.js
+// v5 derives `useSecureCookies` from `url.protocol` and, in Route
+// Handlers, that URL is the internal http:// one — so it falls back to
+// the non-prefixed `authjs.session-token` cookie name while the login
+// callback actually wrote `__Secure-authjs.session-token`. That leaves
+// `auth()` in /api/* route handlers unable to read a valid session
+// (server components read via next/headers and are unaffected).
+// Forcing useSecureCookies based on AUTH_URL matches the proxy fix in
+// #597 and keeps dev (http) working when AUTH_URL is unset.
+export function resolveUseSecureCookies(
+  env: { AUTH_URL?: string; NEXTAUTH_URL?: string } = process.env
+): boolean {
+  const authUrl = env.AUTH_URL ?? env.NEXTAUTH_URL
+  return authUrl?.startsWith('https://') ?? false
+}
+
 export const authConfig: NextAuthConfig = {
+  useSecureCookies: resolveUseSecureCookies(),
   pages: {
     signIn: '/login',
     error: '/login',

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -14,7 +14,7 @@ import { coerceUserRole, isAdmin, isVendor } from '@/lib/roles'
 // Forcing useSecureCookies based on AUTH_URL matches the proxy fix in
 // #597 and keeps dev (http) working when AUTH_URL is unset.
 export function resolveUseSecureCookies(
-  env: { AUTH_URL?: string; NEXTAUTH_URL?: string } = process.env
+  env: Record<string, string | undefined> = process.env
 ): boolean {
   const authUrl = env.AUTH_URL ?? env.NEXTAUTH_URL
   return authUrl?.startsWith('https://') ?? false

--- a/test/features/auth-config.test.ts
+++ b/test/features/auth-config.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { authConfig } from '@/lib/auth-config'
+import { authConfig, resolveUseSecureCookies } from '@/lib/auth-config'
 import { UserRole } from '@/generated/prisma/enums'
 
 const callbacks = authConfig.callbacks!
@@ -73,6 +73,25 @@ test('jwt callback persists id and role onto the token', async () => {
   assert.ok(token)
   assert.equal(token.id, 'user_123')
   assert.equal(token.role, 'SUPERADMIN')
+})
+
+// Regression (auth enroll 403 behind Cloudflare Tunnel): in Route Handlers
+// Next.js sees the request as http://localhost while the login callback set
+// `__Secure-authjs.session-token` because AUTH_URL is https. Auth.js derives
+// the expected cookie name from `url.protocol` unless `useSecureCookies` is
+// explicit, which would leave `auth()` searching for the non-prefixed cookie
+// name and return null. The config must force secure cookies when AUTH_URL
+// announces an HTTPS origin.
+test('useSecureCookies follows AUTH_URL / NEXTAUTH_URL scheme', () => {
+  assert.equal(resolveUseSecureCookies({ AUTH_URL: 'https://dev.feldescloud.com' }), true)
+  assert.equal(resolveUseSecureCookies({ AUTH_URL: 'http://localhost:3001' }), false)
+  assert.equal(resolveUseSecureCookies({}), false)
+  assert.equal(resolveUseSecureCookies({ NEXTAUTH_URL: 'https://prod.example.com' }), true)
+  // AUTH_URL takes precedence over NEXTAUTH_URL.
+  assert.equal(
+    resolveUseSecureCookies({ AUTH_URL: 'http://a', NEXTAUTH_URL: 'https://b' }),
+    false
+  )
 })
 
 test('session callback copies token identity onto the session user', async () => {


### PR DESCRIPTION
## Summary
- Admins hitting `/admin/security/enroll` saw **"No se pudo iniciar la configuración"** because `POST /api/admin/2fa/enroll` returned 403 even with a valid `SUPERADMIN` session.
- Root cause: behind the Cloudflare Tunnel (dev) / HTTPS terminator (prod), Next.js receives requests as `http://localhost` internally. Auth.js v5 derives `useSecureCookies` from `url.protocol`, so in Route Handlers `auth()` looked for `authjs.session-token` while the login callback set `__Secure-authjs.session-token`. Server components read cookies via `next/headers` and were unaffected — which is why the page rendered but the mutating API call under it failed.
- Fix: pin `useSecureCookies` on `AUTH_URL` / `NEXTAUTH_URL` scheme in `authConfig`. Mirrors the proxy fix in #597.

## Test plan
- [x] New unit test `useSecureCookies follows AUTH_URL / NEXTAUTH_URL scheme` covers https/http/unset/fallback/precedence.
- [x] End-to-end curl through `https://dev.feldescloud.com`: credentials login → `POST /api/admin/2fa/enroll` → **200** with QR and `otpauthUrl` (was 403 before the fix).
- [ ] Manual: admin logs in to `/admin/security/enroll`, sees the QR, enrolls, is redirected to `/login`, and logs back in with TOTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)