### PR TITLE
fix(dev): add *.feldescloud.com to allowedDevOrigins

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -94,10 +94,12 @@ const nextConfig: NextConfig = {
   },
   // Allow LAN access to the dev server (e.g. testing on a phone via
   // http://192.168.x.y:3000). Without this, Next.js 16 blocks cross-origin
-  // requests to /_next/* dev resources, which breaks HMR and the dev overlay
+  // requests to /_next/* dev resources, which breaks HMR AND client hydration
+  // (dropdowns, theme toggle, cart, sidebar collapse all stop responding)
   // when the page is loaded from a non-localhost host.
-  // The pattern matches any host on a typical home/office private network.
-  allowedDevOrigins: ['192.168.*.*', '10.*.*.*', '*.local', '*.trycloudflare.com'],
+  // `*.feldescloud.com` covers the Cloudflare Tunnel (dev.feldescloud.com →
+  // localhost:3001, see docs/runbooks/dev-tunnel.md) and any future subdomain.
+  allowedDevOrigins: ['192.168.*.*', '10.*.*.*', '*.local', '*.trycloudflare.com', '*.feldescloud.com'],
   experimental: {
     staleTimes: {
       // Default is 300 s (matches revalidate = 300). That causes Link-navigation to serve


### PR DESCRIPTION
## Summary
- Widen Next 16 \`allowedDevOrigins\` to \`*.feldescloud.com\` so the Cloudflare Tunnel host (dev.feldescloud.com → localhost:3001) can load \`/_next/*\` dev resources.
- Without this, hydration silently dies when the page is reached via the tunnel: HTML renders but the cart button, theme toggle, language switcher, and vendor-sidebar collapse all become no-ops. Log symptom: \`Blocked cross-origin request to Next.js dev resource /_next/webpack-hmr from "dev.feldescloud.com"\`.
- Expanded the adjacent comment so the next person to touch this line sees what breaks if they remove it.

## Test plan
- [x] Verified locally: after adding the origin + restarting \`next dev -p 3001\`, dev.feldescloud.com regains full client-side interactivity.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)