### PR TITLE
feat(landing): pitch Telegram alerts + installable PWA on /como-vender

### DIFF
--- a/src/app/(public)/como-vender/page.tsx
+++ b/src/app/(public)/como-vender/page.tsx
@@ -7,12 +7,15 @@ import {
   UserGroupIcon,
   ShieldCheckIcon,
   ClockIcon,
+  BellAlertIcon,
+  DevicePhoneMobileIcon,
 } from '@heroicons/react/24/outline'
 import { buildPageMetadata } from '@/lib/seo'
 import { getPublicPageCopy } from '@/i18n/public-page-copy'
 import { getServerLocale } from '@/i18n/server'
 
 const benefitIcons = [BanknotesIcon, SparklesIcon, ClockIcon, UserGroupIcon, ShieldCheckIcon, CheckCircleIcon] as const
+const toolIcons = [BellAlertIcon, DevicePhoneMobileIcon] as const
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getServerLocale()
@@ -65,6 +68,37 @@ export default async function ComoVender() {
                   <Icon className="mb-4 h-8 w-8 text-accent" />
                   <h3 className="mb-2 font-semibold text-foreground">{benefit.title}</h3>
                   <p className="text-sm text-foreground-soft">{benefit.description}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-accent-soft px-4 py-16 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="mb-4 text-center text-3xl font-bold text-foreground">{copy.toolsTitle}</h2>
+          <p className="mb-12 text-center text-lg text-foreground-soft">{copy.toolsBody}</p>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            {copy.tools.map((tool, idx) => {
+              const Icon = toolIcons[idx] ?? toolIcons[0]
+              return (
+                <div
+                  key={`${tool.title}-${idx}`}
+                  className="rounded-lg border-2 border-accent bg-surface p-8"
+                >
+                  <Icon className="mb-4 h-10 w-10 text-accent" />
+                  <h3 className="mb-2 text-xl font-semibold text-foreground">{tool.title}</h3>
+                  <p className="mb-4 text-foreground-soft">{tool.description}</p>
+                  <ul className="space-y-2">
+                    {tool.bullets.map(bullet => (
+                      <li key={bullet} className="flex gap-2 text-sm text-foreground-soft">
+                        <CheckCircleIcon className="h-5 w-5 flex-shrink-0 text-accent" />
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               )
             })}

--- a/src/i18n/public-page-copy.ts
+++ b/src/i18n/public-page-copy.ts
@@ -111,6 +111,9 @@ type PublicPageCopy = {
     whyTitle: string
     whyBody: string
     benefits: Array<{ title: string; description: string }>
+    toolsTitle: string
+    toolsBody: string
+    tools: Array<{ title: string; description: string; bullets: string[] }>
     pricingTitle: string
     pricingBody: string
     pricingLabel: string
@@ -282,6 +285,14 @@ const publicPageCopy: Record<Locale, PublicPageCopy> = {
             {
               q: '¿Cómo empiezo a vender?',
               a: `Regístrate en nuestro portal de productores, completa la ${BRAND_CLAIMS.verificationProcess.text.toLowerCase()}, vincula tu cuenta bancaria y comienza a subir productos.`,
+            },
+            {
+              q: '¿Me avisáis de los nuevos pedidos por Telegram?',
+              a: 'Sí. Desde tus preferencias de notificaciones puedes vincular tu cuenta de Telegram y recibir alertas instantáneas de nuevos pedidos, pagos confirmados e incidencias. La vinculación se hace con un enlace seguro y puedes desconectarla o elegir qué eventos recibir en cualquier momento.',
+            },
+            {
+              q: '¿Puedo instalar Mercado Productor como app en el móvil?',
+              a: 'Sí. La plataforma es una app instalable (PWA): desde el navegador del móvil o la tablet puedes añadirla a la pantalla de inicio y abrirla como una app nativa, sin pasar por ninguna tienda. Carga rápido, consume pocos datos y se actualiza sola.',
             },
           ],
         },
@@ -469,6 +480,28 @@ const publicPageCopy: Record<Locale, PublicPageCopy> = {
         {
           title: 'Sin cuotas mensuales',
           description: 'Solo pagas comisión cuando vendes. Cero costes fijos.',
+        },
+      ],
+      toolsTitle: 'Herramientas que marcan la diferencia',
+      toolsBody: 'Tecnología pensada para productores: entérate de cada venta al instante y trabaja desde donde estés, también sin cobertura.',
+      tools: [
+        {
+          title: 'Avisos al instante en Telegram',
+          description: 'Vincula tu cuenta de Telegram y recibe una notificación en cuanto entra un pedido. Sin abrir el panel, sin refrescar el correo.',
+          bullets: [
+            'Alertas de nuevos pedidos, pagos confirmados e incidencias.',
+            'Configura qué eventos quieres recibir desde tus preferencias.',
+            'Vinculación en segundos con un enlace seguro; puedes desconectarlo cuando quieras.',
+          ],
+        },
+        {
+          title: 'App instalable en el móvil (PWA)',
+          description: 'Mercado Productor se instala como una app nativa en tu móvil o tablet, sin pasar por ninguna tienda. Rápida, ligera y lista para el día a día.',
+          bullets: [
+            'Icono en la pantalla de inicio y pantalla completa, sin barra del navegador.',
+            'Carga rápida y consumo mínimo de datos, incluso con conexión irregular.',
+            'Actualizaciones automáticas: siempre tienes la última versión sin reinstalar.',
+          ],
         },
       ],
       pricingTitle: 'Precios y comisiones',
@@ -669,6 +702,14 @@ const publicPageCopy: Record<Locale, PublicPageCopy> = {
               q: 'How do I start selling?',
               a: `Create your producer account, complete the ${BRAND_CLAIMS.verificationProcess.text.toLowerCase()}, connect your bank account, and start uploading products.`,
             },
+            {
+              q: 'Do you notify new orders via Telegram?',
+              a: 'Yes. From your notification preferences you can link your Telegram account and receive instant alerts for new orders, confirmed payments, and incidents. Linking happens through a secure link and you can disconnect it or pick which events to receive at any time.',
+            },
+            {
+              q: 'Can I install Mercado Productor as an app on my phone?',
+              a: 'Yes. The platform is an installable app (PWA): from your mobile or tablet browser you can add it to your home screen and open it like a native app, no app store required. It loads fast, uses little data, and updates itself.',
+            },
           ],
         },
         {
@@ -855,6 +896,28 @@ const publicPageCopy: Record<Locale, PublicPageCopy> = {
         {
           title: 'No monthly fees',
           description: 'You only pay commission when you sell. Zero fixed costs.',
+        },
+      ],
+      toolsTitle: 'Tools that make the difference',
+      toolsBody: 'Technology built for producers: know about every sale the moment it happens and work from anywhere, even on a patchy connection.',
+      tools: [
+        {
+          title: 'Instant Telegram alerts',
+          description: 'Link your Telegram account and get notified the moment an order comes in. No refreshing the dashboard, no checking email.',
+          bullets: [
+            'Alerts for new orders, confirmed payments, and incidents.',
+            'Choose which events you want to receive from your preferences.',
+            'Connect in seconds with a secure link; disconnect any time.',
+          ],
+        },
+        {
+          title: 'Installable mobile app (PWA)',
+          description: 'Mercado Productor installs on your phone or tablet like a native app, no app store required. Fast, lightweight, and ready for day-to-day use.',
+          bullets: [
+            'Home-screen icon and full-screen mode, no browser bar.',
+            'Fast loading and low data use, even on unstable connections.',
+            'Automatic updates: always on the latest version, no reinstall.',
+          ],
         },
       ],
       pricingTitle: 'Pricing and commission',


### PR DESCRIPTION
## Summary
- Add a new "Herramientas que marcan la diferencia" section on the vendor landing page (\`/como-vender\`) with two highlighted feature cards: instant Telegram alerts for new orders, and the installable PWA. Each card lists three concrete benefits.
- Extend the FAQ "Productores" category with two matching Q&As so buyers and prospective vendors find a consistent story from both entry points.
- Spanish + English copy in parity; section lives between the 6-benefits grid and the pricing block, styled with \`bg-accent-soft\` to distinguish it without breaking the existing surface alternation.

## Test plan
- [x] \`tsc --noEmit\` passes.
- [ ] Visit \`/como-vender\` (ES + EN) and confirm the new section renders with both cards, bullets, and icons.
- [ ] Visit \`/faq\` (ES + EN) and expand the "Productores" category — the two new Q&As appear after the existing four.
- [ ] Responsive: cards stack on mobile (1 col), side-by-side on ≥md (2 cols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)