### PR TITLE
[codex] fix(ci): run required checks on docs PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,11 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
-      - 'docs/**'
       - '.vscode/**'
       - 'LICENSE'
       - '.gitignore'
   pull_request:
     paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
       - '.vscode/**'
       - 'LICENSE'
       - '.gitignore'

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -3,6 +3,9 @@ name: Doctor
 on:
   pull_request:
     paths:
+      # Docs-only PRs still need the blocking doctor gate because
+      # branch protection requires it on every mergeable PR.
+      - 'docs/**'
       # Schema and any code that can drift between schema.prisma and DB
       - 'prisma/**'
       # Any API route can 500 — broad filter keeps us safe


### PR DESCRIPTION
## What\n- Stop ignoring docs-only PRs in CI so required checks actually run.\n- Add docs PR coverage to the Doctor workflow so branch protection can be satisfied.\n\n## Why\nDocs PRs were getting stuck in `BLOCKED` because `Verify`, `Build And Migrate`, `Integration`, `E2E Smoke`, and `Doctor` were skipped by path filters even though branch protection requires them.\n\n## Validation\n- Reviewed workflow diffs locally.\n- Verified the patch is limited to workflow trigger paths only.