### PR TITLE
[codex] fix(cart): clear merged session state on sign-out

### DIFF
--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { signOut } from 'next-auth/react'
 import { useState } from 'react'
 import { UserCircleIcon, ChevronDownIcon, Bars3Icon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
@@ -9,6 +8,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { useSidebar } from '@/components/layout/SidebarProvider'
 import { PortalSwitcher } from '@/components/layout/PortalSwitcher'
 import type { AvailablePortal } from '@/lib/portals'
+import { signOutAndClearCart } from '@/components/buyer/cart-session'
 
 interface Props {
   user: { name?: string | null; email?: string | null; role: string }
@@ -73,7 +73,7 @@ export function AdminHeader({ user, portals = [] }: Props) {
                 Ir a la tienda
               </Link>
               <button
-                onClick={() => signOut({ callbackUrl: '/login' })}
+                onClick={() => void signOutAndClearCart('/login')}
                 className="mt-1 w-full rounded-lg border-t border-[var(--border)] px-3 py-2.5 text-left text-sm text-red-600 transition hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/40 mx-1 pt-2"
               >
                 Cerrar sesión

--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { signOut } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
 import { useT } from '@/i18n'
+import { signOutAndClearCart } from '@/components/buyer/cart-session'
 
 interface SignOutButtonProps {
   compact?: boolean
@@ -15,7 +15,7 @@ export function SignOutButton({ compact = false }: SignOutButtonProps) {
       variant="ghost"
       size={compact ? 'sm' : 'md'}
       className="w-full justify-start text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300"
-      onClick={() => signOut({ callbackUrl: '/' })}
+      onClick={() => void signOutAndClearCart('/')}
     >
       {t('signOut')}
     </Button>

--- a/src/components/buyer/CartHydrationProvider.tsx
+++ b/src/components/buyer/CartHydrationProvider.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useRef } from 'react'
 import { useSession } from 'next-auth/react'
 import { useCartStore, type CartItem } from '@/domains/orders/cart-store'
-import { loadServerCart, mergeLocalIntoServerCart } from '@/domains/orders/cart-actions'
+import {
+  loadServerCart,
+  mergeLocalIntoServerCart,
+} from '@/domains/orders/cart-actions'
+import {
+  getCartHydrationAction,
+} from './cart-hydration-plan'
+import { CART_MERGED_FLAG_KEY } from './cart-session'
 
 /**
  * On login, merges the anonymous local-storage cart into the buyer's
@@ -11,42 +18,56 @@ import { loadServerCart, mergeLocalIntoServerCart } from '@/domains/orders/cart-
  *
  * Strategy:
  *   1. Wait for NextAuth session to become `authenticated`.
- *   2. Snapshot whatever is in local storage (items the buyer added
- *      while anonymous).
- *   3. Call `mergeLocalIntoServerCart(local)` — the helper sums
- *      quantities on overlapping (productId, variantId) and returns
- *      the combined server state.
- *   4. Hydrate the Zustand store from the server response so all
- *      tabs / devices converge on the same cart. No-op if the merge
- *      fails — keep the local cart untouched to avoid losing items.
- *
- * Runs exactly once per session. Logouts are handled by Zustand's
- * persist middleware (keeps local storage intact) and the next login
- * replays the merge from whatever state the user accumulated.
+ *   2. If the device has not yet merged for this user, snapshot the
+ *      anonymous cart and call `mergeLocalIntoServerCart(local)`.
+ *   3. Otherwise just `loadServerCart()`. The merged-user flag keeps
+ *      repeated reloads from replaying the same synchronized cart and
+ *      doubling server quantities.
+ *   4. Sign-out handlers clear the local cart and merge flag so the
+ *      next anonymous shopping session starts cleanly.
  */
 export function CartHydrationProvider() {
   const { data, status } = useSession()
   const hasHydratedRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (status !== 'authenticated') return
+    if (status !== 'authenticated') {
+      hasHydratedRef.current = null
+      return
+    }
     const userId = data?.user?.id
     if (!userId) return
     if (hasHydratedRef.current === userId) return
     hasHydratedRef.current = userId
 
-    const state = useCartStore.getState()
-    const localItems = state.items.map(item => ({
-      productId: item.productId,
-      variantId: item.variantId ?? undefined,
-      quantity: item.quantity,
-    }))
-
     void (async () => {
       try {
-        const merged = localItems.length > 0
-          ? await mergeLocalIntoServerCart(localItems)
-          : await loadServerCart()
+        const state = useCartStore.getState()
+        const alreadyMerged =
+          typeof window !== 'undefined' &&
+          window.localStorage.getItem(CART_MERGED_FLAG_KEY) === userId
+
+        const action = getCartHydrationAction({
+          status,
+          userId,
+          alreadyMergedForUser: alreadyMerged,
+          localItemCount: state.items.length,
+        })
+
+        const merged =
+          action === 'merge'
+            ? await mergeLocalIntoServerCart(
+                state.items.map(item => ({
+                  productId: item.productId,
+                  variantId: item.variantId ?? undefined,
+                  quantity: item.quantity,
+                })),
+              )
+            : await loadServerCart()
+
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(CART_MERGED_FLAG_KEY, userId)
+        }
 
         const hydrated: CartItem[] = merged.map(line => ({
           productId: line.productId,

--- a/src/components/buyer/cart-hydration-plan.ts
+++ b/src/components/buyer/cart-hydration-plan.ts
@@ -1,0 +1,21 @@
+export type CartHydrationStatus = 'authenticated' | 'unauthenticated' | 'loading'
+
+export type CartHydrationAction = 'clear' | 'load' | 'merge' | 'noop'
+
+export interface CartHydrationPlanInput {
+  status: CartHydrationStatus
+  userId?: string | null
+  alreadyMergedForUser: boolean
+  localItemCount: number
+}
+
+export function getCartHydrationAction({
+  status,
+  userId,
+  alreadyMergedForUser,
+  localItemCount,
+}: CartHydrationPlanInput): CartHydrationAction {
+  if (status !== 'authenticated' || !userId) return 'noop'
+  if (alreadyMergedForUser) return 'load'
+  return localItemCount > 0 ? 'merge' : 'load'
+}

--- a/src/components/buyer/cart-session.ts
+++ b/src/components/buyer/cart-session.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { signOut } from 'next-auth/react'
+import { useCartStore } from '@/domains/orders/cart-store'
+
+export const CART_MERGED_FLAG_KEY = 'cart-merged-user'
+
+export function clearCartSessionState() {
+  useCartStore.setState({ items: [] })
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(CART_MERGED_FLAG_KEY)
+  }
+}
+
+export async function signOutAndClearCart(callbackUrl: string) {
+  clearCartSessionState()
+  await signOut({ callbackUrl })
+}

--- a/src/components/vendor/VendorHeader.tsx
+++ b/src/components/vendor/VendorHeader.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { signOut } from 'next-auth/react'
 import { useState } from 'react'
 import { UserCircleIcon, ChevronDownIcon, Bars3Icon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
@@ -10,6 +9,7 @@ import { useT } from '@/i18n'
 import { useSidebar } from '@/components/layout/SidebarProvider'
 import { PortalSwitcher } from '@/components/layout/PortalSwitcher'
 import type { AvailablePortal } from '@/lib/portals'
+import { signOutAndClearCart } from '@/components/buyer/cart-session'
 
 interface Props {
   user: { name?: string | null; email?: string | null }
@@ -78,7 +78,7 @@ export function VendorHeader({ user, vendor, portals = [] }: Props) {
                 {t('vendor.header.goToStore')}
               </Link>
               <button
-                onClick={() => signOut({ callbackUrl: '/login' })}
+                onClick={() => void signOutAndClearCart('/login')}
                 className="mt-1 w-full rounded-lg border-t border-[var(--border)] px-3 py-2.5 text-left text-sm text-red-600 transition hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/40 mx-1 pt-2"
               >
                 {t('vendor.header.signOut')}

--- a/test/features/cart-hydration-plan.test.ts
+++ b/test/features/cart-hydration-plan.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { getCartHydrationAction } from '@/components/buyer/cart-hydration-plan'
+
+test('cart hydration loads server cart after the user has already merged once', () => {
+  assert.equal(
+    getCartHydrationAction({
+      status: 'authenticated',
+      userId: 'user-1',
+      alreadyMergedForUser: true,
+      localItemCount: 5,
+    }),
+    'load',
+  )
+})
+
+test('cart hydration merges only when an authenticated user still has fresh local items', () => {
+  assert.equal(
+    getCartHydrationAction({
+      status: 'authenticated',
+      userId: 'user-1',
+      alreadyMergedForUser: false,
+      localItemCount: 2,
+    }),
+    'merge',
+  )
+})
+
+test('cart hydration loads server cart when the authenticated cart is empty', () => {
+  assert.equal(
+    getCartHydrationAction({
+      status: 'authenticated',
+      userId: 'user-1',
+      alreadyMergedForUser: false,
+      localItemCount: 0,
+    }),
+    'load',
+  )
+})

--- a/test/features/cart-session.test.ts
+++ b/test/features/cart-session.test.ts
@@ -1,0 +1,64 @@
+import test, { afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { clearCartSessionState } from '@/components/buyer/cart-session'
+import { useCartStore } from '@/domains/orders/cart-store'
+
+class FakeStorage implements Storage {
+  private readonly store = new Map<string, string>()
+
+  get length() {
+    return this.store.size
+  }
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  key(index: number) {
+    return [...this.store.keys()][index] ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  clear() {
+    this.store.clear()
+  }
+}
+
+afterEach(() => {
+  useCartStore.setState({ items: [] })
+  delete (globalThis as unknown as { window?: unknown }).window
+})
+
+test('clearCartSessionState clears the cart store and merged flag', () => {
+  useCartStore.setState({
+    items: [
+      {
+        productId: 'prod-1',
+        name: 'Tomates',
+        slug: 'tomates',
+        price: 2,
+        unit: 'kg',
+        vendorId: 'vendor-1',
+        vendorName: 'Huerta',
+        quantity: 2,
+      },
+    ],
+  })
+
+  const storage = new FakeStorage()
+  storage.setItem('cart-merged-user', 'user-1')
+
+  ;(globalThis as unknown as { window: { localStorage: Storage } }).window = { localStorage: storage }
+
+  clearCartSessionState()
+
+  assert.equal(useCartStore.getState().items.length, 0)
+  assert.equal(storage.getItem('cart-merged-user'), null)
+})


### PR DESCRIPTION
## What\n- Clear the persisted cart and merged-user marker when users explicitly sign out.\n- Keep cart hydration focused on login-time merge/load behavior.\n- Add small unit coverage for the new cart-session helper and hydration decision logic.\n\n## Why\nZustand persists the cart across logout, so without clearing the local cart/session marker on sign-out, the next login can replay already-synced items and double quantities.\n\n## Validation\n- TAP version 13
# Subtest: cart hydration loads server cart after the user has already merged once
ok 1 - cart hydration loads server cart after the user has already merged once
  ---
  duration_ms: 0.537645
  ...
# Subtest: cart hydration merges only when an authenticated user still has fresh local items
ok 2 - cart hydration merges only when an authenticated user still has fresh local items
  ---
  duration_ms: 0.103333
  ...
# Subtest: cart hydration loads server cart when the authenticated cart is empty
ok 3 - cart hydration loads server cart when the authenticated cart is empty
  ---
  duration_ms: 0.077925
  ...
# Subtest: clearCartSessionState clears the cart store and merged flag
ok 4 - clearCartSessionState clears the cart store and merged flag
  ---
  duration_ms: 0.825934
  ...
1..4
# tests 4
# suites 0
# pass 4
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 183.155991\n-  on the touched cart/auth components and tests\n- Earlier repo-root typecheck and integration checks for the same files passed before the branch split; the temp worktree has repo-wide generated-type noise unrelated to this patch.