### PR TITLE
fix(home): hide quick-access block for authenticated users

### DIFF
--- a/src/app/(public)/HomePageClient.tsx
+++ b/src/app/(public)/HomePageClient.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { ProductCard } from '@/components/catalog/ProductCard'
@@ -35,6 +37,15 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
   const { locale } = useLocale()
   const t = useT()
   const portalLinks = getPublicPortalLinks(locale)
+
+  // Hide the "Entra según tu perfil" quick-access block for authenticated
+  // users — once they're signed in, the portal shortcuts are noise. SSR
+  // renders the block (public page is cached and session resolves only
+  // after hydration); we swap it out once `useSession` reports a user.
+  const { data: session, status } = useSession()
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+  const hideQuickAccess = mounted && status === 'authenticated' && !!session?.user
 
   const STEPS: { step: string; titleKey: TranslationKeys; descKey: TranslationKeys }[] = [
     { step: '01', titleKey: 'steps.01.title', descKey: 'steps.01.desc' },
@@ -184,6 +195,7 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
       </section>
 
       {/* ── Quick access ─────────────────────────────────────────────────── */}
+      {!hideQuickAccess && (
       <section className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
         <div className="rounded-3xl border border-[var(--border)] bg-gradient-to-br from-[var(--surface)] via-emerald-50/35 to-teal-50/20 p-6 shadow-sm dark:from-[var(--surface)] dark:via-emerald-950/20 dark:to-teal-950/10 sm:p-7">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
@@ -218,6 +230,7 @@ export function HomePageClient({ featured, categories, vendors, heroStats, publi
           </div>
         </div>
       </section>
+      )}
 
       {/* ── Categories ───────────────────────────────────────────────────── */}
       <section className="mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Once a user is signed in, the "Entra según tu perfil" block on the home page is noise — they already have a role and know where to go.
- Gate the block with client-side `useSession` + a `mounted` flag so SSR still renders it (page stays cached under `revalidate = 3600`) and authenticated sessions hide it after hydration.

## Test plan
- [ ] Anonymous: home still shows the quick-access block above categories.
- [ ] Signed in as vendor/buyer/admin: block is hidden after hydration; no flash on slow connections.
- [ ] `revalidate = 3600` still in effect on `/` (SSR HTML includes the block for CDN cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)