### PR TITLE
fix(notifications): show shipping recipient name in order-created alerts

### DIFF
--- a/src/domains/notifications/telegram/handlers/order-view.ts
+++ b/src/domains/notifications/telegram/handlers/order-view.ts
@@ -44,6 +44,11 @@ export async function resolveOrderView(
 
   const shippingAddress = parseOrderAddressSnapshot(order.shippingAddressSnapshot)
   const city = shippingAddress?.city ?? order.address?.city ?? undefined
+  const buyerFirstName =
+    shippingAddress?.firstName ?? order.customer?.firstName ?? undefined
+  const buyerName = shippingAddress
+    ? `${shippingAddress.firstName} ${shippingAddress.lastName}`.trim()
+    : undefined
 
   const items = order.lines.map(line => {
     const name =
@@ -59,7 +64,8 @@ export async function resolveOrderView(
     city,
     items: items.length > 0 ? items : undefined,
     vendorFirstName: vendor?.user?.firstName ?? vendor?.displayName ?? undefined,
-    buyerFirstName: order.customer?.firstName ?? undefined,
+    buyerFirstName,
+    buyerName,
   }
 }
 

--- a/src/domains/notifications/telegram/templates.ts
+++ b/src/domains/notifications/telegram/templates.ts
@@ -69,6 +69,13 @@ export interface OrderMessageView {
   vendorFirstName?: string
   /** Buyer first name (used when we want to name-drop the customer). */
   buyerFirstName?: string
+  /**
+   * Full recipient name from the shipping address snapshot — i.e. the
+   * human the producer is actually sending the parcel to. Preferred over
+   * `payload.customerName` (which is the account holder's display name)
+   * whenever available.
+   */
+  buyerName?: string
 }
 
 /**
@@ -102,7 +109,7 @@ export function orderCreatedTemplate(
   view?: OrderMessageView,
 ): OutboundMessage {
   const id = orderIdentifierLink(payload, view)
-  const customer = escapeHtml(payload.customerName)
+  const customer = escapeHtml(view?.buyerName ?? payload.customerName)
   const total = formatMoney(payload.totalCents, payload.currency)
   const locationLine = view?.city ? ` desde ${escapeHtml(view.city)}` : ''
   const itemsBlock = renderItemsBlock(view)

--- a/src/domains/notifications/web-push/handlers/shared.ts
+++ b/src/domains/notifications/web-push/handlers/shared.ts
@@ -42,6 +42,11 @@ export async function resolveOrderPushView(
 
   const shippingAddress = parseOrderAddressSnapshot(order.shippingAddressSnapshot)
   const city = shippingAddress?.city ?? order.address?.city ?? undefined
+  const buyerFirstName =
+    shippingAddress?.firstName ?? order.customer?.firstName ?? undefined
+  const buyerName = shippingAddress
+    ? `${shippingAddress.firstName} ${shippingAddress.lastName}`.trim()
+    : undefined
 
   const items = order.lines.map(line => {
     const name =
@@ -57,7 +62,8 @@ export async function resolveOrderPushView(
     city,
     items: items.length > 0 ? items : undefined,
     vendorFirstName: vendor?.user?.firstName ?? vendor?.displayName ?? undefined,
-    buyerFirstName: order.customer?.firstName ?? undefined,
+    buyerFirstName,
+    buyerName,
   }
 }
 

--- a/src/domains/notifications/web-push/templates.ts
+++ b/src/domains/notifications/web-push/templates.ts
@@ -58,6 +58,12 @@ export interface OrderPushView {
   items?: string[]
   vendorFirstName?: string
   buyerFirstName?: string
+  /**
+   * Full recipient name from the shipping address snapshot — the human
+   * the parcel is going to. Preferred over `payload.customerName` (the
+   * account holder's display name) whenever available.
+   */
+  buyerName?: string
 }
 
 function orderIdLabel(payload: { orderId: string }, view?: OrderPushView): string {
@@ -71,9 +77,10 @@ export function orderCreatedPush(
   const total = formatMoney(payload.totalCents, payload.currency)
   const id = orderIdLabel(payload, view)
   const greet = firstWord(view?.vendorFirstName)
+  const buyer = view?.buyerName ?? payload.customerName
   const title = greet
-    ? `📦 ${greet}, nuevo pedido de ${payload.customerName}`
-    : `📦 Nuevo pedido de ${payload.customerName}`
+    ? `📦 ${greet}, nuevo pedido de ${buyer}`
+    : `📦 Nuevo pedido de ${buyer}`
   const itemsLine = joinItems(view?.items)
   const parts = [`${id} — ${total}`]
   if (view?.city) parts.push(view.city)


### PR DESCRIPTION
## Summary
- Telegram + web-push "nuevo pedido" now show the recipient on the shipping address (firstName+lastName from `shippingAddressSnapshot`) instead of `session.user.name` — which may differ when the buyer orders for someone else.
- Fallback to `customer.firstName` for legacy orders without snapshot.

## Test plan
- [x] `telegram-templates.test.ts` + `web-push-templates.test.ts` pass
- [ ] Smoke: place an order with a shipping address whose name differs from the account's, confirm producer's Telegram + browser push show the recipient

🤖 Generated with [Claude Code](https://claude.com/claude-code)