### PR TITLE
fix(vendor): make 'origin address missing' error a clickable CTA

### DIFF
--- a/src/app/(vendor)/vendor/perfil/page.tsx
+++ b/src/app/(vendor)/vendor/perfil/page.tsx
@@ -30,7 +30,7 @@ export default async function VendorPerfilPage() {
         <StripeConnectUI onboarded={profile.stripeOnboarded} />
       </section>
 
-      <section className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+      <section id="shipping-address" className="space-y-4 scroll-mt-20 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
         <div>
           <h2 className="font-semibold text-[var(--foreground)]">{t('vendor.shippingAddress.title')}</h2>
           <p className="text-sm text-[var(--muted)] mt-0.5">{t('vendor.shippingAddress.subtitle')}</p>

--- a/src/components/vendor/FulfillmentActions.tsx
+++ b/src/components/vendor/FulfillmentActions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import {
@@ -22,15 +23,18 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
   const router = useRouter()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [addressMissing, setAddressMissing] = useState(false)
 
   async function handlePrepare() {
     setLoading(true)
     setError(null)
+    setAddressMissing(false)
     try {
       const result = await prepareFulfillment(fulfillmentId)
       if (!result.ok) {
         if (result.code === 'VENDOR_ADDRESS_MISSING') {
           setError(t('vendor.fulfillment.addressMissing'))
+          setAddressMissing(true)
         } else {
           setError(result.message || t('vendor.fulfillment.labelFailed'))
         }
@@ -42,6 +46,21 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
     } finally {
       setLoading(false)
     }
+  }
+
+  function renderError() {
+    if (!error) return null
+    if (addressMissing) {
+      return (
+        <Link
+          href="/vendor/perfil#shipping-address"
+          className="text-right text-xs font-medium text-red-600 underline underline-offset-2 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+        >
+          {error} →
+        </Link>
+      )
+    }
+    return <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
   }
 
   async function handleIncident() {
@@ -79,7 +98,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
   if (['PENDING', 'CONFIRMED', 'PREPARING'].includes(status)) {
     return (
       <div className="flex flex-col items-end gap-1">
-        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+        {renderError()}
         <Button size="sm" isLoading={loading} onClick={handlePrepare}>
           {loading ? t('vendor.fulfillment.preparing') : t('vendor.fulfillment.prepare')}
         </Button>
@@ -104,7 +123,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
   if (status === 'LABEL_FAILED') {
     return (
       <div className="flex flex-col items-end gap-1">
-        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+        {renderError()}
         <Button size="sm" variant="secondary" isLoading={loading} onClick={handlePrepare}>
           {t('vendor.fulfillment.retryLabel')}
         </Button>
@@ -119,7 +138,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
   if (['READY', 'SHIPPED', 'DELIVERED'].includes(status)) {
     return (
       <div className="flex flex-col items-end gap-1">
-        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+        {renderError()}
         <div className="flex flex-wrap justify-end gap-2">
           {labelUrl && (
             <a
@@ -159,7 +178,7 @@ export function FulfillmentActions({ fulfillmentId, status, labelUrl, trackingUr
   if (status === 'INCIDENT') {
     return (
       <div className="flex flex-col items-end gap-1">
-        {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+        {renderError()}
         <div className="flex flex-wrap justify-end gap-2">
           {labelUrl && (
             <a

--- a/src/domains/notifications/telegram/actions/prepare-fulfillment.ts
+++ b/src/domains/notifications/telegram/actions/prepare-fulfillment.ts
@@ -2,7 +2,12 @@ import type { ActionContext } from './registry'
 import {
   answerCallbackQuery,
   editMessageRemoveKeyboard,
+  sendRawMessage,
 } from '../service'
+
+function appUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') ?? ''
+}
 
 // Deferred import — shipping imports notifications for transition events,
 // and this callback only fires on user interaction, so the lazy import
@@ -19,6 +24,14 @@ export async function prepareFulfillmentAction(ctx: ActionContext): Promise<void
           ? 'Configura tu dirección de origen en el portal antes de generar etiquetas'
           : result.message
     await answerCallbackQuery(ctx.callbackQueryId, message)
+    if (result.code === 'VENDOR_ADDRESS_MISSING') {
+      await sendRawMessage(ctx.chatId, {
+        text: '📦 Configura tu dirección de origen antes de generar etiquetas.',
+        inline_keyboard: [
+          [{ text: '🏠 Configurar dirección', url: `${appUrl()}/vendor/perfil#shipping-address` }],
+        ],
+      }).catch(() => undefined)
+    }
     return
   }
 


### PR DESCRIPTION
## Summary
- On the vendor order detail, when `prepareFulfillment` returns `VENDOR_ADDRESS_MISSING`, the red warning text itself is now a link (underlined + `→`) to `/vendor/perfil#shipping-address`, instead of a dead-end error message.
- The Telegram "Generar etiqueta" callback mirrors it: after the toast, we send a follow-up message with an inline URL button "🏠 Configurar dirección" pointing to the same anchor.
- Added `id="shipping-address"` + `scroll-mt-20` to the origin-address section of `/vendor/perfil` so the link lands directly on the form.

## Test plan
- [ ] Vendor order with unset origin address: click "Generar etiqueta de envío" → red warning renders as a link, navigates to the address section.
- [ ] Same flow from the Telegram bot: tap "🏷️ Generar etiqueta" on the pending-order reminder → receive follow-up with "🏠 Configurar dirección" URL button that opens the vendor portal.
- [ ] Non-address errors still render as plain red text (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)