### PR TITLE
perf: phase B structural — server-render addresses, parallelise vendor layout, lazy Recharts

### DIFF
--- a/src/app/(admin)/admin/analytics/page.tsx
+++ b/src/app/(admin)/admin/analytics/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { formatPrice } from '@/lib/utils'
 import { getAdminDailyRevenue, getAdminStats } from '@/domains/admin-stats/queries'
-import { AdminAnalyticsCharts } from '@/components/admin/AdminAnalyticsCharts'
+import { AdminAnalyticsChartsLazy } from '@/components/admin/AdminAnalyticsChartsLazy'
 
 export const metadata: Metadata = { title: 'Analytics — Admin' }
 export const revalidate = 60
@@ -64,7 +64,7 @@ export default async function AdminAnalyticsPage() {
         ))}
       </section>
 
-      <AdminAnalyticsCharts series={dailySeries} />
+      <AdminAnalyticsChartsLazy series={dailySeries} />
 
       <p className="text-xs text-[var(--muted)]">
         Datos recalculados cada 60 segundos. APIs:{' '}

--- a/src/app/(buyer)/checkout/page.tsx
+++ b/src/app/(buyer)/checkout/page.tsx
@@ -1,6 +1,7 @@
 import { CheckoutPageClient } from '@/components/buyer/CheckoutPageClient'
 import { getShippingConfigurationSnapshot } from '@/domains/shipping/calculator'
 import { generateCheckoutAttemptId } from '@/domains/orders/checkout-token'
+import type { SavedCheckoutAddress } from '@/domains/orders/checkout'
 import { getServerEnv } from '@/lib/env'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
@@ -12,19 +13,50 @@ import { db } from '@/lib/db'
 export const dynamic = 'force-dynamic'
 
 export default async function CheckoutPage() {
-  const shippingConfig = await getShippingConfigurationSnapshot()
+  // All work outside the session is safe to kick off in parallel. The
+  // user + addresses queries, by contrast, gate on `auth()` and only run
+  // for authenticated sessions.
+  const [shippingConfig, session] = await Promise.all([
+    getShippingConfigurationSnapshot(),
+    auth(),
+  ])
   const { paymentProvider } = getServerEnv()
-  const session = await auth()
+
   let userFirstName = ''
   let userLastName = ''
+  let initialAddresses: SavedCheckoutAddress[] | undefined
   if (session?.user?.id) {
-    const user = await db.user.findUnique({
-      where: { id: session.user.id },
-      select: { firstName: true, lastName: true },
-    })
+    // Batch user + addresses so the checkout critical path loses one
+    // round-trip — the CheckoutPageClient previously refetched addresses
+    // from the browser in a useEffect, adding 100–300 ms of "Loading…"
+    // before the buyer could pick one.
+    const [user, addresses] = await Promise.all([
+      db.user.findUnique({
+        where: { id: session.user.id },
+        select: { firstName: true, lastName: true },
+      }),
+      db.address.findMany({
+        where: { userId: session.user.id },
+        orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          line1: true,
+          line2: true,
+          city: true,
+          province: true,
+          postalCode: true,
+          phone: true,
+          isDefault: true,
+        },
+      }),
+    ])
     userFirstName = user?.firstName ?? ''
     userLastName = user?.lastName ?? ''
+    initialAddresses = addresses
   }
+
   // #410/#524: server-issued idempotency token for this render. Passed
   // to the client which submits it with createCheckoutOrder. The
   // backend uses it to dedupe double-submits and concurrent races.
@@ -39,6 +71,7 @@ export default async function CheckoutPage() {
       userFirstName={userFirstName}
       userLastName={userLastName}
       checkoutAttemptId={checkoutAttemptId}
+      initialAddresses={initialAddresses}
     />
   )
 }

--- a/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/DireccionesClient.tsx
@@ -39,14 +39,25 @@ const SPANISH_PROVINCES = [
 interface DireccionesClientProps {
   userFirstName?: string
   userLastName?: string
+  /**
+   * Addresses pre-fetched on the server. Seeding the store from props
+   * avoids the mount-time `fetch('/api/direcciones')` round trip and the
+   * "blink to Loading…" that came with it: the list is visible from the
+   * first paint. Left optional so existing call sites keep working.
+   */
+  initialAddresses?: Address[]
 }
 
 export function DireccionesClient({
   userFirstName = '',
   userLastName = '',
+  initialAddresses,
 }: DireccionesClientProps = {}) {
-  const [addresses, setAddresses] = useState<Address[]>([])
-  const [loading, setLoading] = useState(true)
+  const [addresses, setAddresses] = useState<Address[]>(initialAddresses ?? [])
+  // If the page already passed server-rendered addresses we can paint
+  // immediately; otherwise preserve the old behaviour of showing a
+  // loading indicator while the `useEffect` fetches.
+  const [loading, setLoading] = useState(initialAddresses === undefined)
   const [showForm, setShowForm] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -66,8 +77,13 @@ export function DireccionesClient({
     },
   })
 
-  // Load addresses on mount
+  // Only fetch on mount when the caller did NOT pre-seed addresses. When
+  // the server-rendered page passes `initialAddresses`, the list is
+  // already visible on first paint and a second fetch would just cause
+  // a visible flash. Mutations further down keep local state in sync
+  // without needing a refetch.
   useEffect(() => {
+    if (initialAddresses !== undefined) return
     const loadAddresses = async () => {
       try {
         const res = await fetch('/api/direcciones', { cache: 'no-store' })
@@ -81,7 +97,7 @@ export function DireccionesClient({
       }
     }
     loadAddresses()
-  }, [])
+  }, [initialAddresses])
 
   const onSubmit = async (data: AddressForm) => {
     try {

--- a/src/app/(buyer)/cuenta/direcciones/page.tsx
+++ b/src/app/(buyer)/cuenta/direcciones/page.tsx
@@ -15,11 +15,33 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Direcciones() {
   const session = await requireAuth()
-  const user = await db.user.findUnique({
-    where: { id: session.user.id },
-    select: { firstName: true, lastName: true },
-  })
-  const t = await getServerT()
+
+  // Pre-fetch what the client needs in a single parallel burst so the
+  // page paints with real content on first render. Previously the
+  // client did a mount-time `fetch('/api/direcciones')` that flashed
+  // "loading" even though the server already had the data in hand.
+  const [user, addresses, t] = await Promise.all([
+    db.user.findUnique({
+      where: { id: session.user.id },
+      select: { firstName: true, lastName: true },
+    }),
+    db.address.findMany({
+      where: { userId: session.user.id },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+    }),
+    getServerT(),
+  ])
+
+  // The client component's Address type keeps createdAt/updatedAt as
+  // strings (it was written against the JSON-over-HTTP response), so
+  // serialise dates before handing them over.
+  const initialAddresses = addresses.map(a => ({
+    ...a,
+    label: a.label ?? undefined,
+    line2: a.line2 ?? undefined,
+    createdAt: a.createdAt.toISOString(),
+    updatedAt: a.updatedAt.toISOString(),
+  }))
 
   return (
     <main className="space-y-6 max-w-3xl mx-auto px-4 py-10 sm:px-6 lg:px-8">
@@ -34,6 +56,7 @@ export default async function Direcciones() {
         <DireccionesClient
           userFirstName={user?.firstName ?? ''}
           userLastName={user?.lastName ?? ''}
+          initialAddresses={initialAddresses}
         />
       </div>
     </main>

--- a/src/app/(vendor)/layout.tsx
+++ b/src/app/(vendor)/layout.tsx
@@ -12,31 +12,42 @@ import { IMPERSONATION_COOKIE, verifyImpersonationToken } from '@/lib/impersonat
 export default async function VendorLayout({ children }: { children: React.ReactNode }) {
   const session = await requireVendor()
 
-  const vendor = await db.vendor.findUnique({
-    where: { userId: session.user.id },
-    select: { id: true, displayName: true, status: true, slug: true },
-  })
+  // Two independent lookups once the session is known: the vendor record
+  // (needed for sidebar + fulfillment badge) and the impersonation cookie
+  // (needed for the banner). Kicked off in parallel so the layout's
+  // critical path is dominated by a single round-trip rather than the
+  // old sequential chain of ~4 queries.
+  const [vendor, cookieStore] = await Promise.all([
+    db.vendor.findUnique({
+      where: { userId: session.user.id },
+      select: { id: true, displayName: true, status: true, slug: true },
+    }),
+    cookies(),
+  ])
 
-  // Count fulfillments that still need vendor action (same 'active' filter
-  // used by `getMyFulfillments`). Feeds the installed-app icon badge so a
-  // vendor sees pending work even when the app window is in the background.
-  const pendingFulfillments = vendor
-    ? await db.vendorFulfillment.count({
-        where: {
-          vendorId: vendor.id,
-          status: { in: ['PENDING', 'CONFIRMED', 'PREPARING', 'READY'] },
-        },
-      })
-    : 0
-
-  const portals = getAvailablePortals(session.user.role)
-
-  const cookieStore = await cookies()
   const impersonationCookie = cookieStore.get(IMPERSONATION_COOKIE)?.value
   const impersonation = verifyImpersonationToken(impersonationCookie)
-  const impersonatingAdminEmail = impersonation
-    ? (await db.user.findUnique({ where: { id: impersonation.adminId }, select: { email: true } }))?.email ?? null
-    : null
+  const portals = getAvailablePortals(session.user.role)
+
+  // Second parallel wave: fulfillment count depends on the vendor id, and
+  // the impersonating admin's email depends on the verified impersonation
+  // token. Both are cheap point lookups — run them together so the layout
+  // doesn't wait on each sequentially.
+  const [pendingFulfillments, impersonatingAdminEmail] = await Promise.all([
+    vendor
+      ? db.vendorFulfillment.count({
+          where: {
+            vendorId: vendor.id,
+            status: { in: ['PENDING', 'CONFIRMED', 'PREPARING', 'READY'] },
+          },
+        })
+      : Promise.resolve(0),
+    impersonation
+      ? db.user
+          .findUnique({ where: { id: impersonation.adminId }, select: { email: true } })
+          .then(u => u?.email ?? null)
+      : Promise.resolve(null),
+  ])
 
   return (
     <SidebarProvider>

--- a/src/components/admin/AdminAnalyticsChartsLazy.tsx
+++ b/src/components/admin/AdminAnalyticsChartsLazy.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+/**
+ * Lazy wrapper for the Recharts-based admin analytics panel.
+ *
+ * The chart module pulls in the full Recharts tree (~150 KB gzipped) plus
+ * its D3 dependencies. Importing it eagerly means every admin page that
+ * shares the same top-level chunk pays that cost — including pages that
+ * never render a chart. `ssr: false` also skips server rendering for the
+ * chart markup, which Recharts can't hydrate cleanly anyway because
+ * ResponsiveContainer measures the DOM on mount.
+ *
+ * The dynamic() helper can only live in a client component in Next.js 15+
+ * (the `ssr: false` option is no longer valid in server components), so
+ * this file is the required `'use client'` boundary around the import.
+ */
+const AdminAnalyticsCharts = dynamic(
+  () => import('./AdminAnalyticsCharts').then(m => m.AdminAnalyticsCharts),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="h-[336px] rounded-2xl border border-[var(--border)] bg-[var(--surface)] animate-pulse" />
+        <div className="h-[336px] rounded-2xl border border-[var(--border)] bg-[var(--surface)] animate-pulse" />
+      </div>
+    ),
+  }
+)
+
+interface DailyPoint {
+  date: string
+  revenue: number
+  orders: number
+  newUsers: number
+}
+
+export function AdminAnalyticsChartsLazy({ series }: { series: DailyPoint[] }) {
+  return <AdminAnalyticsCharts series={series} />
+}

--- a/src/components/buyer/CheckoutPageClient.tsx
+++ b/src/components/buyer/CheckoutPageClient.tsx
@@ -51,6 +51,14 @@ interface Props {
    * dedupe double-clicks, tab refreshes, and concurrent races.
    */
   checkoutAttemptId: string
+  /**
+   * Addresses pre-fetched by the server component. When provided, the
+   * client skips the mount-time `fetch('/api/direcciones')` — which on
+   * the critical checkout path used to add 100–300 ms of "Loading…"
+   * before the buyer could pick an address. Optional so existing call
+   * sites fall back to the legacy client-fetch path.
+   */
+  initialAddresses?: SavedCheckoutAddress[]
 }
 
 export function CheckoutPageClient({
@@ -61,14 +69,22 @@ export function CheckoutPageClient({
   userFirstName = '',
   userLastName = '',
   checkoutAttemptId,
+  initialAddresses,
 }: Props) {
   const router = useRouter()
   const { items, subtotal, clearCart } = useCartStore()
   const [step, setStep] = useState<'address' | 'payment' | 'processing'>('address')
   const [serverError, setServerError] = useState<string | null>(null)
-  const [savedAddresses, setSavedAddresses] = useState<SavedCheckoutAddress[]>([])
-  const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null)
-  const [loadingAddresses, setLoadingAddresses] = useState(true)
+  const hasInitialAddresses = initialAddresses !== undefined
+  const [savedAddresses, setSavedAddresses] = useState<SavedCheckoutAddress[]>(
+    initialAddresses ?? [],
+  )
+  const [selectedAddressId, setSelectedAddressId] = useState<string | null>(() => {
+    if (!hasInitialAddresses) return null
+    return getPreferredCheckoutAddress(initialAddresses!)?.id ?? null
+  })
+  // If the server supplied addresses there is nothing to load.
+  const [loadingAddresses, setLoadingAddresses] = useState(!hasInitialAddresses)
   const [addressLoadError, setAddressLoadError] = useState<string | null>(null)
   const [showNewAddressForm, setShowNewAddressForm] = useState(false)
   const [completedOrderNumber, setCompletedOrderNumber] = useState<string | null>(null)
@@ -207,6 +223,20 @@ export function CheckoutPageClient({
   useEffect(() => {
     let cancelled = false
 
+    // Fast path: the server already handed us the address list, so we
+    // just seed the form from the preferred address and skip the
+    // network round-trip. The slow path keeps the previous behaviour
+    // intact for callers that don't pre-fetch.
+    if (hasInitialAddresses) {
+      const preferredAddress = getPreferredCheckoutAddress(initialAddresses!)
+      if (preferredAddress) {
+        reset(toCheckoutFormAddress(preferredAddress))
+      } else {
+        setShowNewAddressForm(true)
+      }
+      return
+    }
+
     async function loadSavedAddresses() {
       try {
         setLoadingAddresses(true)
@@ -244,7 +274,7 @@ export function CheckoutPageClient({
     return () => {
       cancelled = true
     }
-  }, [reset])
+  }, [reset, hasInitialAddresses, initialAddresses])
 
   useEffect(() => {
     if (!completedOrderNumber) return


### PR DESCRIPTION
## Summary

Second slice of the runtime-performance plan. Three structural fixes from `docs/audits/runtime-performance-audit.md` Phase B, bundled because none is standalone-large but together they cover the meaningful "server does work, client then re-does the same work" cases.

1. **`perf(admin)`** — Lazy-load Recharts on `/admin/analytics`. New `AdminAnalyticsChartsLazy.tsx` wraps the existing chart with `next/dynamic({ ssr: false })` + a skeleton. Recharts (~150 KB gz + D3 subtree) no longer sits in the admin-shared chunk.
2. **`perf(vendor)`** — Parallelise vendor layout queries. Was `session → vendor → fulfillment count → impersonation admin`; now two `Promise.all` waves. Same reads, same JSX, fewer awaits on critical render.
3. **`perf(buyer)`** — Kill the `useEffect` address-fetch flash on `/cuenta/direcciones` and `/checkout`. Both pages now fetch addresses server-side (in parallel with their other queries, so no extra wall-clock). Clients accept optional `initialAddresses` and skip the mount-time `fetch('/api/direcciones')`. Checkout also pre-selects the preferred address, removing the 100–300 ms "Loading…" on the critical path. Legacy client-fetch preserved for callers that don't pre-seed.

## Not in this PR

**P0-6 Header memoise** deferred. 440 LOC `'use client'` + `usePathname()` = separate PR with its own test plan.

## Risk — low to medium

- Recharts: pure additive indirection; admin-only.
- Vendor layout: mechanical rewrite — same graph, different topology.
- Buyer addresses: widest diff. Both clients keep their legacy fetch path when `initialAddresses === undefined`, so nothing else changes. Direcciones page serialises `createdAt`/`updatedAt` to strings to preserve the client's existing type shape.

## Test plan

- [x] `npm run typecheck` clean for this branch's files.
- [x] `npm run test` — 989 pass / 21 fail. The 21 failures reproduce on clean `origin/main`; pre-existing.
- [ ] Manual smoke after merge:
  - `/cuenta/direcciones` paints with list on first frame (no Loading flash). Edit/delete still work.
  - `/checkout` loads with preferred address pre-selected. Add-new-address still works.
  - `/admin/analytics` shows skeleton → charts; network panel shows Recharts loaded on demand.
  - Vendor pages navigate normally; impersonation banner still shows when active.

## Remaining plan

- P0-6 Header memoise (separate PR)
- Phase C: Web Vitals → PostHog, mutation→UI smoke spec, Lighthouse on `/checkout` and `/productos/[slug]`, promote `audit:contracts` to blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)