### PR TITLE
feat(admin): two-step login + 30-day trusted-device cookie

### DIFF
--- a/src/app/api/auth/login-precheck/route.ts
+++ b/src/app/api/auth/login-precheck/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Two-step admin login — step 1 (password precheck).
+ *
+ * Drives the UX split between "email + password" and "TOTP" forms.
+ * The client POSTs credentials here; if the password is valid AND the
+ * user has 2FA enrolled AND no trusted-device cookie is present, we
+ * respond `{ ok: true, needs2fa: true }` so the client can reveal the
+ * TOTP field. A wrong password, inactive account, or unverified email
+ * all collapse into the same `{ ok: false }` response so the endpoint
+ * never leaks which accounts exist or are under attack.
+ *
+ * Rate-limited per-IP and per-identity on the same order of magnitude
+ * as the login flow itself, so turning this endpoint into a password
+ * oracle gains an attacker nothing over hammering `/api/auth/callback/
+ * credentials` directly.
+ *
+ * Deliberately NOT session-authenticated — must be callable when
+ * logged out. Listed in test/integration/api-route-auth-audit.test.ts
+ * PUBLIC_API_ROUTES allow-list with the reason above.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { checkRateLimit, getClientIP } from '@/lib/ratelimit'
+import { isTwoFactorEnabled } from '@/domains/auth/two-factor'
+import { verifyTrustedDeviceCookie } from '@/domains/auth/trusted-device'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+})
+
+const PER_IP_LIMIT = 20
+const PER_IP_WINDOW = 15 * 60
+const PER_IDENTITY_LIMIT = 10
+const PER_IDENTITY_WINDOW = 15 * 60
+
+export async function POST(req: NextRequest) {
+  try {
+    const clientIP = getClientIP(req)
+    const ipLimit = await checkRateLimit(
+      'login-precheck-ip',
+      clientIP,
+      PER_IP_LIMIT,
+      PER_IP_WINDOW,
+      { failClosed: true }
+    )
+    if (!ipLimit.success) {
+      return NextResponse.json({ ok: false }, { status: 429 })
+    }
+
+    const body = await req.json().catch(() => null)
+    const parsed = schema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false }, { status: 200 })
+    }
+
+    const normalizedEmail = parsed.data.email.trim().toLowerCase()
+
+    const identityLimit = await checkRateLimit(
+      'login-precheck-identity',
+      normalizedEmail,
+      PER_IDENTITY_LIMIT,
+      PER_IDENTITY_WINDOW,
+      { failClosed: true }
+    )
+    if (!identityLimit.success) {
+      return NextResponse.json({ ok: false }, { status: 200 })
+    }
+
+    const user = await db.user.findUnique({ where: { email: normalizedEmail } })
+    if (!user || !user.passwordHash || !user.isActive || !user.emailVerified) {
+      return NextResponse.json({ ok: false }, { status: 200 })
+    }
+
+    const valid = await bcrypt.compare(parsed.data.password, user.passwordHash)
+    if (!valid) {
+      return NextResponse.json({ ok: false }, { status: 200 })
+    }
+
+    const has2fa = await isTwoFactorEnabled(user.id)
+    if (!has2fa) {
+      return NextResponse.json({ ok: true, needs2fa: false }, { status: 200 })
+    }
+
+    const trusted = await verifyTrustedDeviceCookie(user.id, user.passwordHash)
+    return NextResponse.json(
+      { ok: true, needs2fa: !trusted },
+      { status: 200 }
+    )
+  } catch (err) {
+    console.error('[login-precheck]', err)
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { useState } from 'react'
 import { useT } from '@/i18n'
 import {
+  ArrowLeftIcon,
   BuildingStorefrontIcon,
   EyeIcon,
   EyeSlashIcon,
@@ -26,6 +27,8 @@ interface LoginFormProps {
   callbackUrl?: string
 }
 
+type Step = 'credentials' | 'totp'
+
 export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
   const router = useRouter()
   const safeCallbackUrl = sanitizeCallbackUrl(callbackUrl) ?? STOREFRONT_PATH
@@ -33,12 +36,16 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [showPass, setShowPass] = useState(false)
-  // The TOTP field is only shown for the admin portal. Buyers and
-  // vendors currently have no 2FA pathway, so rendering it globally
-  // would only confuse them. Admins always see it; if their account
-  // hasn't enrolled yet they leave it blank and hit the forced-
-  // enrollment redirect after login.
+  // Admin-only two-step flow (#: two-step admin login). Step 1 collects
+  // email+password and pings /api/auth/login-precheck to learn whether
+  // 2FA is required (false when the trusted-device cookie is valid or
+  // the admin hasn't enrolled yet). Step 2, when needed, collects the
+  // TOTP code plus an opt-in "remember this device 30 days" checkbox.
+  const [step, setStep] = useState<Step>('credentials')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [totpCode, setTotpCode] = useState('')
+  const [rememberDevice, setRememberDevice] = useState(true)
   const t = useT()
 
   const portalContent = {
@@ -76,23 +83,12 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
 
   const currentPortal = portalContent[portalMode]
   const PortalIcon = currentPortal.icon
+  const isAdminPortal = portalMode === 'admin'
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setError(null)
-    setLoading(true)
-
-    const data = new FormData(e.currentTarget)
-    // Only include totpCode when the admin filled it. NextAuth's
-    // Credentials provider serialises every passed key; a raw
-    // `undefined` arrives at authorize() as the literal string
-    // "undefined", which fails the zod \d{6,10} regex and rejects
-    // even password-only logins.
-    const credentials: Record<string, string> = {
-      email: data.get('email') as string,
-      password: data.get('password') as string,
-    }
-    if (totpCode) credentials.totpCode = totpCode
+  async function completeSignIn(opts: { totp?: string; remember?: boolean }) {
+    const credentials: Record<string, string> = { email, password }
+    if (opts.totp) credentials.totpCode = opts.totp
+    if (opts.remember) credentials.rememberDevice = '1'
 
     const result = await signIn('credentials', {
       ...credentials,
@@ -100,19 +96,83 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
       callbackUrl: safeCallbackUrl,
     })
 
-    setLoading(false)
-
     if (result?.error) {
-      setError('Email o contraseña incorrectos')
-    } else {
-      const destination = normalizeAuthRedirectUrl(result?.url) ?? safeCallbackUrl
-      const nextUrl = destination.startsWith('/')
-        ? new URL(destination, window.location.origin).toString()
-        : destination
-
-      window.location.assign(nextUrl)
-      router.refresh()
+      setError(t('login.error.invalidCredentials'))
+      setLoading(false)
+      return
     }
+
+    const destination = normalizeAuthRedirectUrl(result?.url) ?? safeCallbackUrl
+    const nextUrl = destination.startsWith('/')
+      ? new URL(destination, window.location.origin).toString()
+      : destination
+    window.location.assign(nextUrl)
+    router.refresh()
+  }
+
+  async function handleCredentialsSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    // Buyer / vendor portals have no 2FA surface — go straight to
+    // signIn and let authorize() do its thing.
+    if (!isAdminPortal) {
+      await completeSignIn({})
+      return
+    }
+
+    try {
+      const res = await fetch('/api/auth/login-precheck', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+
+      if (res.status === 429) {
+        setError(t('login.error.tooManyAttempts'))
+        setLoading(false)
+        return
+      }
+
+      const data = (await res.json().catch(() => null)) as
+        | { ok: boolean; needs2fa?: boolean }
+        | null
+
+      if (!data || !data.ok) {
+        setError(t('login.error.invalidCredentials'))
+        setLoading(false)
+        return
+      }
+
+      if (data.needs2fa) {
+        setStep('totp')
+        setLoading(false)
+        return
+      }
+
+      // Password is valid and no 2FA step is required (either the
+      // admin hasn't enrolled yet — in which case the proxy will
+      // redirect to /admin/security/enroll — or a trusted-device
+      // cookie is still valid).
+      await completeSignIn({})
+    } catch {
+      setError(t('login.error.generic'))
+      setLoading(false)
+    }
+  }
+
+  async function handleTotpSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    await completeSignIn({ totp: totpCode, remember: rememberDevice })
+  }
+
+  function backToCredentials() {
+    setStep('credentials')
+    setTotpCode('')
+    setError(null)
   }
 
   return (
@@ -132,69 +192,118 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-        <Input
-          name="email"
-          type="email"
-          label="Email"
-          placeholder="tu@email.com"
-          autoComplete="email"
-          required
-        />
-        <div className="relative">
+      {step === 'credentials' && (
+        <form onSubmit={handleCredentialsSubmit} className="mt-6 space-y-4">
           <Input
-            name="password"
-            type={showPass ? 'text' : 'password'}
-            label="Contraseña"
-            placeholder="••••••••"
-            autoComplete="current-password"
+            name="email"
+            type="email"
+            label="Email"
+            placeholder="tu@email.com"
+            autoComplete="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
             required
           />
+          <div className="relative">
+            <Input
+              name="password"
+              type={showPass ? 'text' : 'password'}
+              label="Contraseña"
+              placeholder="••••••••"
+              autoComplete="current-password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+            <button
+              type="button"
+              onClick={() => setShowPass(v => !v)}
+              className="absolute right-3 top-8 rounded-md p-1 text-[var(--muted)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+            >
+              {showPass ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {error && (
+            <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/35 dark:text-red-300">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end">
+            <Link
+              href="/forgot-password"
+              className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm font-medium text-emerald-600 hover:underline dark:text-emerald-400"
+            >
+              ¿Olvidaste tu contraseña?
+            </Link>
+          </div>
+
+          <Button type="submit" className="w-full" isLoading={loading} size="lg">
+            {isAdminPortal ? t('login.continue') : 'Iniciar sesión'}
+          </Button>
+        </form>
+      )}
+
+      {step === 'totp' && (
+        <form onSubmit={handleTotpSubmit} className="mt-6 space-y-4">
           <button
             type="button"
-            onClick={() => setShowPass(v => !v)}
-            className="absolute right-3 top-8 rounded-md p-1 text-[var(--muted)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+            onClick={backToCredentials}
+            className="inline-flex items-center gap-1 text-sm text-[var(--muted)] hover:text-[var(--foreground)]"
           >
-            {showPass ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+            <ArrowLeftIcon className="h-4 w-4" />
+            {t('login.back')}
           </button>
-        </div>
 
-        {portalMode === 'admin' && (
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 text-sm text-[var(--foreground-soft)]">
+            {t('login.totp.description')}
+          </div>
+
           <Input
             name="totpCode"
             type="text"
             inputMode="numeric"
-            label="Código 2FA"
+            label={t('login.totp.label')}
             placeholder="000000"
             autoComplete="one-time-code"
             pattern="\d{6,10}"
             value={totpCode}
             onChange={e => setTotpCode(e.target.value.replace(/\D/g, ''))}
-            hint="Déjalo en blanco si aún no has configurado 2FA."
+            autoFocus
+            required
           />
-        )}
 
-        {error && (
-          <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/35 dark:text-red-300">
-            {error}
-          </p>
-        )}
+          <label className="flex items-start gap-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={rememberDevice}
+              onChange={e => setRememberDevice(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-[var(--border-strong)] text-emerald-600 focus:ring-emerald-500"
+            />
+            <span>
+              <span className="font-medium text-[var(--foreground)]">
+                {t('login.totp.rememberDevice')}
+              </span>
+              <span className="mt-0.5 block text-xs text-[var(--muted)]">
+                {t('login.totp.rememberDeviceHint')}
+              </span>
+            </span>
+          </label>
 
-        <div className="flex justify-end">
-          <Link
-            href="/forgot-password"
-            className="inline-flex min-h-11 items-center rounded-md px-2 py-2 text-sm font-medium text-emerald-600 hover:underline dark:text-emerald-400"
-          >
-            ¿Olvidaste tu contraseña?
-          </Link>
-        </div>
+          {error && (
+            <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/35 dark:text-red-300">
+              {error}
+            </p>
+          )}
 
-        <Button type="submit" className="w-full" isLoading={loading} size="lg">
-          Iniciar sesión
-        </Button>
-      </form>
+          <Button type="submit" className="w-full" isLoading={loading} size="lg">
+            {t('login.totp.submit')}
+          </Button>
+        </form>
+      )}
 
-      {process.env.NEXT_PUBLIC_SHOW_DEMO_CREDS === 'true' && (
+      {process.env.NEXT_PUBLIC_SHOW_DEMO_CREDS === 'true' && step === 'credentials' && (
         <div className="mt-4 rounded-lg border border-dashed border-[var(--border-strong)] bg-[var(--surface-raised)] p-3">
           <p className="text-xs font-medium text-[var(--muted)] mb-1">Credenciales de prueba:</p>
           <div className="text-xs text-[var(--foreground-soft)] space-y-0.5">
@@ -205,31 +314,35 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
         </div>
       )}
 
-      <div className="mt-4 grid gap-2">
-        {publicPortalLinks.slice(1).map(link => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className={`rounded-xl border px-4 py-3 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] ${
-              link.href.includes('/vendor') && portalMode === 'vendor'
-                ? 'border-emerald-300 bg-emerald-50 text-emerald-950 shadow-sm dark:border-emerald-700 dark:bg-emerald-950/45 dark:text-emerald-100'
-                : link.href.includes('/admin') && portalMode === 'admin'
-                  ? 'border-amber-300 bg-amber-50 text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/45 dark:text-amber-100'
-                  : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground-soft)] hover:border-emerald-200 hover:bg-emerald-50/40 dark:hover:border-emerald-800 dark:hover:bg-emerald-950/20'
-            }`}
-          >
-            <span className="block font-medium">{link.label}</span>
-            <span className="block text-xs text-[var(--muted)]">{link.description}</span>
-          </Link>
-        ))}
-      </div>
+      {step === 'credentials' && (
+        <div className="mt-4 grid gap-2">
+          {publicPortalLinks.slice(1).map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`rounded-xl border px-4 py-3 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] ${
+                link.href.includes('/vendor') && portalMode === 'vendor'
+                  ? 'border-emerald-300 bg-emerald-50 text-emerald-950 shadow-sm dark:border-emerald-700 dark:bg-emerald-950/45 dark:text-emerald-100'
+                  : link.href.includes('/admin') && portalMode === 'admin'
+                    ? 'border-amber-300 bg-amber-50 text-amber-950 shadow-sm dark:border-amber-700 dark:bg-amber-950/45 dark:text-amber-100'
+                    : 'border-[var(--border)] bg-[var(--surface)] text-[var(--foreground-soft)] hover:border-emerald-200 hover:bg-emerald-50/40 dark:hover:border-emerald-800 dark:hover:bg-emerald-950/20'
+              }`}
+            >
+              <span className="block font-medium">{link.label}</span>
+              <span className="block text-xs text-[var(--muted)]">{link.description}</span>
+            </Link>
+          ))}
+        </div>
+      )}
 
-      <p className="mt-6 text-center text-sm text-[var(--muted)]">
-        ¿No tienes cuenta?{' '}
-        <Link href="/register" className="font-semibold text-emerald-600 hover:underline dark:text-emerald-400">
-          Regístrate gratis
-        </Link>
-      </p>
+      {step === 'credentials' && (
+        <p className="mt-6 text-center text-sm text-[var(--muted)]">
+          ¿No tienes cuenta?{' '}
+          <Link href="/register" className="font-semibold text-emerald-600 hover:underline dark:text-emerald-400">
+            Regístrate gratis
+          </Link>
+        </p>
+      )}
     </div>
   )
 }

--- a/src/domains/auth/credentials.ts
+++ b/src/domains/auth/credentials.ts
@@ -5,14 +5,24 @@ import { db } from '@/lib/db'
 import { isAdminRole } from '@/lib/roles'
 import { checkRateLimit } from '@/lib/ratelimit'
 import { isTwoFactorEnabled, verifyLoginCode } from '@/domains/auth/two-factor'
+import {
+  issueTrustedDeviceCookie,
+  verifyTrustedDeviceCookie,
+} from '@/domains/auth/trusted-device'
 
 const credentialsSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  // Optional TOTP code. Admins with 2FA enrolled must include it;
+  // Optional TOTP code. Admins with 2FA enrolled must include it
+  // (unless a valid trusted-device cookie is present for this user);
   // accounts without 2FA leave it blank. 6–8 digits covers both the
   // standard 6-digit TOTP and longer formats some authenticators use.
   totpCode: z.string().trim().min(6).max(10).regex(/^\d+$/).optional(),
+  // Two-step login UX: when the admin checks "trust this device" on
+  // the TOTP step, mint a signed cookie that lets the next 30 days
+  // of logins from this browser skip the TOTP prompt. Arrives as
+  // form-encoded "1" / "true" / "on"; we normalise below.
+  rememberDevice: z.union([z.literal('1'), z.literal('true'), z.literal('on')]).optional(),
 })
 
 export interface AuthenticatedUser {
@@ -73,17 +83,29 @@ export async function authorizeCredentials(credentials: unknown): Promise<Authen
   if (!valid) return null
 
   // Second factor gate. If the user has 2FA enabled (admin or future
-  // buyer opt-in), the code is required at login. Admins WITHOUT 2FA
-  // are allowed through here but the proxy forces them to /admin/
-  // security/enroll on their next admin-route request — see
-  // src/proxy.ts for the redirect.
+  // buyer opt-in), the code is required at login — unless a valid
+  // trusted-device cookie proves this browser completed TOTP within
+  // the last 30 days AND the password hasn't rotated since. Admins
+  // WITHOUT 2FA are allowed through here but the proxy forces them
+  // to /admin/security/enroll on their next admin-route request —
+  // see src/proxy.ts for the redirect.
   const has2fa = await isTwoFactorEnabled(user.id)
   void isAdminRole // kept imported for the proxy-side enforcement
   if (has2fa) {
     const code = parsed.data.totpCode
-    if (!code) return null
-    const totpOk = await verifyLoginCode(user.id, code)
-    if (!totpOk) return null
+    if (code) {
+      const totpOk = await verifyLoginCode(user.id, code)
+      if (!totpOk) return null
+      if (parsed.data.rememberDevice) {
+        // Tie the trust to the hash we just verified against, so a
+        // password change immediately invalidates every trusted
+        // device without a separate revocation table.
+        await issueTrustedDeviceCookie(user.id, user.passwordHash)
+      }
+    } else {
+      const trusted = await verifyTrustedDeviceCookie(user.id, user.passwordHash)
+      if (!trusted) return null
+    }
   }
 
   return {

--- a/src/domains/auth/trusted-device.ts
+++ b/src/domains/auth/trusted-device.ts
@@ -1,0 +1,128 @@
+/**
+ * Trusted-device cookie for admin 2FA (issue: two-step admin login).
+ *
+ * After a successful TOTP verification, if the admin opts to trust the
+ * device, we mint an HMAC-signed cookie that lets subsequent logins
+ * from the same browser skip the second factor for 30 days. The cookie
+ * is bound to the user id AND a fingerprint of the current password
+ * hash, so a password change (via reset or /cuenta change-password)
+ * invalidates every trusted device automatically without needing a
+ * separate revocation table.
+ *
+ * Wire format: `v1.<userId-b64url>.<exp>.<pwdFp>.<sig-b64url>`
+ * where sig = HMAC-SHA256(v1.userId.exp.pwdFp) under a key derived
+ * from AUTH_SECRET via HKDF (separate info string from 2fa-at-rest
+ * encryption so the two keys never collide).
+ *
+ * Kept out of the `@/domains/auth` barrel because it depends on
+ * next/headers cookies() — pulling it into a shared barrel would
+ * contaminate any edge consumer.
+ */
+
+import crypto from 'crypto'
+import { cookies } from 'next/headers'
+import { isSecureAuthDeployment } from '@/lib/auth-env'
+
+const COOKIE_BASE = 'admin-2fa-trust'
+const TTL_SECONDS = 30 * 24 * 60 * 60
+const VERSION = 'v1'
+const HKDF_INFO = 'admin-2fa-trust:v1'
+
+function getCookieName(): string {
+  return isSecureAuthDeployment(process.env) ? `__Secure-${COOKIE_BASE}` : COOKIE_BASE
+}
+
+function getSigningKey(): Buffer {
+  const secret = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET
+  const material = secret
+    ? Buffer.from(secret)
+    : Buffer.from('dev-only-fallback-do-not-use-in-prod')
+  const derived = crypto.hkdfSync(
+    'sha256',
+    material,
+    Buffer.alloc(0),
+    Buffer.from(HKDF_INFO),
+    32
+  )
+  return Buffer.from(derived)
+}
+
+function hashPasswordFingerprint(passwordHash: string): string {
+  // 12-char prefix of a SHA-256 is plenty to detect a password change
+  // (~72 bits) without leaking the bcrypt hash itself into a client-
+  // readable envelope (the HMAC still covers the full payload).
+  return crypto.createHash('sha256').update(passwordHash).digest('base64url').slice(0, 12)
+}
+
+function sign(payload: string): string {
+  return crypto.createHmac('sha256', getSigningKey()).update(payload).digest('base64url')
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'base64url')
+  const bb = Buffer.from(b, 'base64url')
+  if (ab.length !== bb.length || ab.length === 0) return false
+  return crypto.timingSafeEqual(ab, bb)
+}
+
+export async function issueTrustedDeviceCookie(
+  userId: string,
+  passwordHash: string
+): Promise<void> {
+  const exp = Math.floor(Date.now() / 1000) + TTL_SECONDS
+  const fp = hashPasswordFingerprint(passwordHash)
+  const userIdB64 = Buffer.from(userId).toString('base64url')
+  const body = `${VERSION}.${userIdB64}.${exp}.${fp}`
+  const value = `${body}.${sign(body)}`
+  const store = await cookies()
+  store.set(getCookieName(), value, {
+    httpOnly: true,
+    secure: isSecureAuthDeployment(process.env),
+    sameSite: 'strict',
+    path: '/',
+    maxAge: TTL_SECONDS,
+  })
+}
+
+/**
+ * Returns true iff the current request carries a valid trusted-device
+ * cookie for `expectedUserId` AND the user's current password hash
+ * still matches the fingerprint embedded in the cookie (changed
+ * password => invalidated device).
+ */
+export async function verifyTrustedDeviceCookie(
+  expectedUserId: string,
+  currentPasswordHash: string
+): Promise<boolean> {
+  const store = await cookies()
+  const raw = store.get(getCookieName())?.value
+  if (!raw) return false
+
+  const parts = raw.split('.')
+  if (parts.length !== 5) return false
+  const [version, userIdB64, expStr, fp, sig] = parts
+  if (version !== VERSION) return false
+
+  const body = `${version}.${userIdB64}.${expStr}.${fp}`
+  if (!safeEqual(sig!, sign(body))) return false
+
+  const exp = Number(expStr)
+  if (!Number.isFinite(exp) || Math.floor(Date.now() / 1000) >= exp) return false
+
+  let userId: string
+  try {
+    userId = Buffer.from(userIdB64!, 'base64url').toString('utf8')
+  } catch {
+    return false
+  }
+  if (userId !== expectedUserId) return false
+
+  if (fp !== hashPasswordFingerprint(currentPasswordHash)) return false
+
+  return true
+}
+
+export async function clearTrustedDeviceCookie(): Promise<void> {
+  const store = await cookies()
+  store.delete(getCookieName())
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -158,6 +158,16 @@ const en: Record<TranslationKeys, string> = {
   'login.portal.admin.badge': 'Admin panel',
   'login.portal.admin.title': 'Sign in as administrator',
   'login.portal.admin.desc': 'Oversee the marketplace, reviews and internal operations.',
+  'login.continue': 'Continue',
+  'login.back': 'Back',
+  'login.error.invalidCredentials': 'Invalid email or password',
+  'login.error.tooManyAttempts': 'Too many attempts. Try again in a few minutes.',
+  'login.error.generic': 'We could not process the request. Please try again.',
+  'login.totp.label': '2FA code',
+  'login.totp.description': 'Enter the 6-digit code shown by your authenticator app.',
+  'login.totp.rememberDevice': 'Trust this device for 30 days',
+  'login.totp.rememberDeviceHint': 'We will not ask for the code on this browser until it expires or you change your password.',
+  'login.totp.submit': 'Verify and sign in',
 
   // Auth – register
   'register.title': 'Create account',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -156,6 +156,16 @@ const es = {
   'login.portal.admin.badge': 'Panel admin',
   'login.portal.admin.title': 'Entrar como administrador',
   'login.portal.admin.desc': 'Supervisa el marketplace, revisiones y operaciones internas.',
+  'login.continue': 'Continuar',
+  'login.back': 'Volver',
+  'login.error.invalidCredentials': 'Email o contraseña incorrectos',
+  'login.error.tooManyAttempts': 'Demasiados intentos. Prueba de nuevo en unos minutos.',
+  'login.error.generic': 'No pudimos procesar la petición. Inténtalo de nuevo.',
+  'login.totp.label': 'Código 2FA',
+  'login.totp.description': 'Introduce el código de 6 dígitos que muestra tu app de autenticación.',
+  'login.totp.rememberDevice': 'Confiar en este dispositivo durante 30 días',
+  'login.totp.rememberDeviceHint': 'No te pediremos el código en este navegador hasta que caduque o cambies la contraseña.',
+  'login.totp.submit': 'Verificar y entrar',
 
   // Auth – register
   'register.title': 'Crear cuenta',

--- a/test/integration/api-route-auth-audit.test.ts
+++ b/test/integration/api-route-auth-audit.test.ts
@@ -47,6 +47,10 @@ const PUBLIC_API_ROUTES: ReadonlyArray<{ path: string; why: string }> = [
     why: 'Email-link verification. Auth is the token in the URL, not a session.',
   },
   {
+    path: 'src/app/api/auth/login-precheck/route.ts',
+    why: 'Two-step admin login step 1 (password + has2fa lookup). Must be reachable when logged out. Rate-limited per IP and per identity on the same order as login itself.',
+  },
+  {
     path: 'src/app/api/contacto/route.ts',
     why: 'Public contact form. Rate-limited per IP and per identity.',
   },


### PR DESCRIPTION
## Summary
- Admin login is now two-step: email + password first, TOTP only when the user has 2FA enrolled **and** no trusted-device cookie is valid.
- Adds `/api/auth/login-precheck` (rate-limited, allow-listed as public) so the client knows whether to reveal the TOTP field without attempting a full NextAuth sign-in first.
- New signed-HMAC `admin-2fa-trust` cookie (`__Secure-` in prod, `httpOnly`, `SameSite=Strict`, 30-day TTL) lets the same browser skip 2FA for 30 days. The cookie is bound to a fingerprint of the user's current `passwordHash`, so a password change invalidates every trusted device automatically — no revocation table needed.
- Buyer / vendor portals keep the existing single-form UX; 2FA remains admin-only.

## Behaviour matrix
| User state | Step 1 submit | Step 2 submit |
| --- | --- | --- |
| No 2FA enrolled | precheck → `needs2fa:false` → signIn succeeds → proxy redirects to `/admin/security/enroll` | — |
| 2FA + valid trust cookie | precheck → `needs2fa:false` → signIn succeeds (authorize checks the cookie) | — |
| 2FA + no trust cookie | precheck → `needs2fa:true` → reveal TOTP step | signIn with `totpCode` (+ optional `rememberDevice=1`) → authorize verifies TOTP, optionally mints the trust cookie |
| Wrong password | precheck → `ok:false` → opaque error | — |

## Security notes
- Precheck is a password oracle in the same sense the NextAuth callback already is. Mitigated with the same bucket sizes as the login flow (`login-precheck-ip` 20/15m, `login-precheck-identity` 10/15m, both fail-closed).
- Trust cookie signs `v1.<userId>.<exp>.<pwdFingerprint>` with HMAC-SHA256 under an HKDF-derived key (separate `info` from the 2FA at-rest encryption key).
- `SameSite=Strict` prevents the cookie from being sent on cross-site navigations, matching the threat model for admin-only endpoints.
- `clearTrustedDeviceCookie()` is exported from `src/domains/auth/trusted-device.ts` for future "sign out all devices" UX.

## Test plan
- [ ] Fresh admin account without 2FA: login at `/login?callbackUrl=/admin` prompts only email+password, redirects to enroll.
- [ ] Admin with 2FA, first login on a new browser: step 1 → step 2 → after TOTP succeeds, `__Secure-admin-2fa-trust` is set.
- [ ] Same admin, reload and log in again: step 1 submit signs in directly (no TOTP prompt).
- [ ] Uncheck "remember this device" → cookie not set → next login asks for TOTP again.
- [ ] Change password → existing trusted cookie rejected on next login, TOTP required.
- [ ] Buyer/vendor login unaffected (single-form flow).
- [ ] `npm run test -- test/integration/api-route-auth-audit.test.ts` passes with the new allow-list entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)