### PR TITLE
perf(header): isolate usePathname() so navigation stops re-rendering the header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import {
   ShoppingCartIcon,
@@ -19,7 +18,7 @@ import type { UserRole } from '@/generated/prisma/enums'
 import { SignOutButton } from '@/components/auth/SignOutButton'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { LanguageToggle } from '@/components/LanguageToggle'
-import InstallButton from '@/components/pwa/InstallButton'
+import { InstallCtaGate, LoginLink } from '@/components/layout/HeaderPathnameParts'
 import { useLocale, useT } from '@/i18n'
 import { useSession } from 'next-auth/react'
 
@@ -102,7 +101,12 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
     window.addEventListener('scroll', handleScroll, { passive: true })
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
-  const pathname = usePathname()
+  // Note: `usePathname()` used to live here. Reading it at the top level
+  // made the whole Header re-render on every `<Link>` navigation even
+  // though only two sub-branches actually depend on the path (install CTA
+  // gate and the /login link highlight). Those have been extracted to
+  // `HeaderPathnameParts.tsx` so the rest of the header can stay stable
+  // across navigations.
   const { locale } = useLocale()
   const t = useT()
   const liveCartCount = useCartStore(state => state.items.reduce((sum, item) => sum + item.quantity, 0))
@@ -115,12 +119,6 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
   const portalHref = getPrimaryPortalHref(currentUser?.role)
   const portalLabel = getPortalLabel(currentUser?.role, locale)
   const isBuyerPortal = portalHref === '/cuenta'
-  // Hide the install CTA in work surfaces (admin, vendor, checkout) so we
-  // never interrupt a buy flow or an operator's task with an install prompt.
-  const canShowInstallCta =
-    !pathname.startsWith('/admin') &&
-    !pathname.startsWith('/vendor') &&
-    !pathname.startsWith('/checkout')
   const cartAriaLabel = cartHasItems
     ? `${t('cart')}, ${cartCountLabel}`
     : t('cart')
@@ -212,7 +210,7 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
 
           {/* Right actions */}
           <div className="ml-auto flex items-center gap-1">
-            {canShowInstallCta && <InstallButton />}
+            <InstallCtaGate />
             <LanguageToggle />
             <ThemeToggle />
 
@@ -277,15 +275,7 @@ export function Header({ user, cartCount = 0 }: HeaderProps) {
               </>
             ) : (
               <>
-                <Link
-                  href="/login"
-                  className={cn(
-                    'hidden rounded-xl px-3 py-2 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] lg:block',
-                    pathname === '/login' && 'bg-[var(--surface-raised)]'
-                  )}
-                >
-                  {t('signIn')}
-                </Link>
+                <LoginLink label={t('signIn')} />
                 <Link
                   href="/register"
                   className="hidden rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] lg:block"

--- a/src/components/layout/HeaderPathnameParts.tsx
+++ b/src/components/layout/HeaderPathnameParts.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+/**
+ * Tiny pathname-reactive slices extracted out of `Header.tsx` so the big
+ * header body doesn't have to subscribe to `usePathname()`.
+ *
+ * Before, any navigation re-rendered all ~440 lines of Header plus its
+ * 6 heroicons and several context hooks, just to adjust two details: the
+ * install-CTA gate and the active-style on the /login link. Pushing the
+ * pathname read down to these two tiny components lets React skip the
+ * Header body on `<Link>`-level navigations entirely.
+ *
+ * Keep these components small. Anything that grows here re-introduces
+ * the original problem.
+ */
+
+import { usePathname } from 'next/navigation'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+import InstallButton from '@/components/pwa/InstallButton'
+
+/**
+ * Renders <InstallButton /> only on surfaces where prompting a PWA
+ * install is appropriate — i.e. anywhere that is NOT an admin / vendor
+ * / checkout flow. Kept as its own component so the gate recomputes
+ * without re-rendering the entire header on every navigation.
+ */
+export function InstallCtaGate() {
+  const pathname = usePathname()
+  const allowed =
+    !pathname.startsWith('/admin') &&
+    !pathname.startsWith('/vendor') &&
+    !pathname.startsWith('/checkout')
+  if (!allowed) return null
+  return <InstallButton />
+}
+
+/**
+ * The "Sign in" link in the desktop header. Its only pathname-dependent
+ * behaviour is a subtle background highlight when the user is already
+ * on /login. Isolated so toggling that style does not re-render the
+ * rest of the header.
+ */
+export function LoginLink({ label }: { label: string }) {
+  const pathname = usePathname()
+  return (
+    <Link
+      href="/login"
+      className={cn(
+        'hidden rounded-xl px-3 py-2 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)] lg:block',
+        pathname === '/login' && 'bg-[var(--surface-raised)]'
+      )}
+    >
+      {label}
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary

Phase B → P0-6 from `docs/audits/runtime-performance-audit.md`.

`Header.tsx` is 440 LOC and `'use client'`. It reads `usePathname()` at the top, so every `<Link>` navigation re-renders the entire header, all six Heroicons, the cart subscription, the dropdown state — just to recompute two small pathname-dependent details:

1. Whether to show the PWA install CTA (hidden on /admin, /vendor, /checkout).
2. A background highlight on the /login link when on /login.

This PR extracts those two reads into a new `HeaderPathnameParts.tsx` that exports `<InstallCtaGate />` and `<LoginLink />`. The Header body stops subscribing to pathname, so navigations now only re-render those two tiny components.

## Risk — low

Behaviour unchanged:
- Same denylist prefixes on the install CTA.
- Same exact-match regex on `/login` for the active style.
- Same render order (InstallCtaGate sits exactly where `{canShowInstallCta && <InstallButton />}` used to).

No shared state between Header and the extracted parts. Worst case rollback = revert this single commit.

## Test plan

- [x] `npm run typecheck` clean for these 2 files.
- [ ] Manual smoke after merge:
  - Navigate across public pages — install CTA still hidden on admin/vendor/checkout.
  - Hit /login — the link background highlight still appears.
  - Cart updates still reflect in the header badge (independent of pathname).

🤖 Generated with [Claude Code](https://claude.com/claude-code)