### PR TITLE
perf(observability): pipe Core Web Vitals into PostHog

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Suspense } from 'react'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { AnalyticsProvider } from '@/components/analytics/AnalyticsProvider'
 import { PostHogProvider } from '@/components/analytics/PostHogProvider'
+import { WebVitalsReporter } from '@/components/analytics/WebVitalsReporter'
 import { THEME_COLORS } from '@/lib/theme'
 import { SITE_METADATA_BASE } from '@/lib/seo'
 import { SessionProvider } from '@/components/SessionProvider'
@@ -97,6 +98,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <AnalyticsProvider />
               </Suspense>
               <PostHogProvider />
+              <WebVitalsReporter />
               <PwaRegister />
               <OfflineIndicator />
               <CartHydrationProvider />

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useReportWebVitals } from 'next/web-vitals'
+import { capturePostHog, isPostHogEnabled } from '@/lib/posthog'
+
+/**
+ * Pipes Core Web Vitals from Next's built-in reporter into PostHog so we
+ * get real p75 LCP / INP / CLS / TTFB / FCP from production users — not
+ * just lab numbers from Lighthouse synthetic runs.
+ *
+ * Why this component exists:
+ *   - Before this, the repo had no runtime perf telemetry. A regression
+ *     that landed between Lighthouse runs (or on a page that Lighthouse
+ *     doesn't hit) was invisible until a user complained.
+ *   - PostHog is already wired up (see `src/lib/posthog.ts`). Reusing it
+ *     avoids a second SDK for the same job and gives us the existing
+ *     session/identification plumbing for free.
+ *
+ * Event shape:
+ *   `$web_vitals` with `{ name, value, rating, id, delta, navigationType }`.
+ *   The `$` prefix marks these as PostHog-internal events so they group
+ *   cleanly in dashboards without polluting business event lists.
+ *
+ * Sampling is handled at the PostHog project level — don't add sampling
+ * here or p75 math downstream will be biased.
+ */
+export function WebVitalsReporter() {
+  useReportWebVitals(metric => {
+    if (!isPostHogEnabled()) return
+    capturePostHog('$web_vitals', {
+      name: metric.name,
+      value: metric.value,
+      rating: (metric as { rating?: string }).rating,
+      delta: metric.delta,
+      id: metric.id,
+      navigationType: (metric as { navigationType?: string }).navigationType,
+      path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+    })
+  })
+
+  return null
+}


### PR DESCRIPTION
## Summary

Phase C from `docs/audits/runtime-performance-audit.md`. Fills the observability gap flagged in the audit: we had no production Web Vitals telemetry — a regression that showed up only on real devices or on a page Lighthouse doesn't hit was invisible until a user complained.

New client component `WebVitalsReporter.tsx` mounted in root layout next to `PostHogProvider`. Uses Next 16's built-in `useReportWebVitals` (no new dep) and forwards each LCP/INP/CLS/TTFB/FCP to the existing PostHog wrapper as a `$web_vitals` event with name / value / rating / delta / path.

## Decisions

- **No in-app sampling.** PostHog project-level sampling is the right knob. Sampling in code would bias any p75 math downstream.
- **`$web_vitals` event name.** The `$` prefix keeps these out of business-event lists in PostHog dashboards.
- **Silent when PostHog disabled** (`isPostHogEnabled()` gate). No-op in dev without a `NEXT_PUBLIC_POSTHOG_KEY`.
- **Reuses PostHog**, doesn't add Sentry perf. Keeps the metrics next to user identity and the `pwa_*`, `purchase`, `add_to_cart` events the team already uses.

## Risk — nil

- New file, plus one import and one JSX line in root layout.
- Next's `useReportWebVitals` is passive (PerformanceObserver under the hood); can't crash the page if PostHog is broken.
- Rollback = revert the commit.

## Test plan

- [ ] Deploy → open any page in prod → verify `$web_vitals` events arrive in PostHog with 5 entries per navigation (CLS, FCP, INP, LCP, TTFB).
- [ ] Verify `rating` is one of `good|needs-improvement|poor` per Web Vitals spec.
- [ ] Verify no events in local dev without `NEXT_PUBLIC_POSTHOG_KEY`.

## Next up in Phase C

- Smoke E2E spec: mutation → UI reflects change (no hard refresh needed).
- Lighthouse CI on `/checkout` and `/productos/[slug]`.
- Promote `audit:contracts` from advisory to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)