### PR TITLE
feat(vendors): first-access welcome tour on vendor dashboard

### DIFF
--- a/src/app/(vendor)/vendor/dashboard/page.tsx
+++ b/src/app/(vendor)/vendor/dashboard/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import { getAvailableProductWhere } from '@/domains/catalog/availability'
 import { getServerT } from '@/i18n/server'
 import type { TranslationKeys } from '@/i18n/locales'
+import { VendorWelcomeTour } from '@/components/vendor/VendorWelcomeTour'
 
 export const metadata: Metadata = { title: 'Dashboard' }
 
@@ -56,6 +57,7 @@ export default async function VendorDashboardPage() {
 
   return (
     <div className="space-y-6 max-w-4xl">
+      <VendorWelcomeTour vendorId={vendor.id} vendorName={vendor.displayName} />
       <div>
         <h1 className="text-2xl font-bold text-[var(--foreground)]">
           {t('vendor.dashboard.greeting').replace('{name}', vendor.displayName)}

--- a/src/components/vendor/VendorWelcomeTour.tsx
+++ b/src/components/vendor/VendorWelcomeTour.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  HomeIcon, ShoppingBagIcon, ArchiveBoxIcon, UserCircleIcon,
+  CurrencyEuroIcon, StarIcon, XMarkIcon,
+} from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+import type { TranslationKeys } from '@/i18n/locales'
+
+const STORAGE_PREFIX = 'vendor-welcome-seen-v1:'
+
+interface Step {
+  titleKey: TranslationKeys
+  bodyKey: TranslationKeys
+  Icon: React.ComponentType<{ className?: string }>
+}
+
+const STEPS: Step[] = [
+  { titleKey: 'vendor.welcome.step1.title', bodyKey: 'vendor.welcome.step1.body', Icon: HomeIcon },
+  { titleKey: 'vendor.welcome.step2.title', bodyKey: 'vendor.welcome.step2.body', Icon: ArchiveBoxIcon },
+  { titleKey: 'vendor.welcome.step3.title', bodyKey: 'vendor.welcome.step3.body', Icon: ShoppingBagIcon },
+  { titleKey: 'vendor.welcome.step4.title', bodyKey: 'vendor.welcome.step4.body', Icon: UserCircleIcon },
+  { titleKey: 'vendor.welcome.step5.title', bodyKey: 'vendor.welcome.step5.body', Icon: CurrencyEuroIcon },
+  { titleKey: 'vendor.welcome.step6.title', bodyKey: 'vendor.welcome.step6.body', Icon: StarIcon },
+]
+
+const TOTAL = STEPS.length + 1
+
+interface Props {
+  vendorId: string
+  vendorName: string
+}
+
+export function VendorWelcomeTour({ vendorId, vendorName }: Props) {
+  const t = useT()
+  const [open, setOpen] = useState(false)
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    try {
+      const key = STORAGE_PREFIX + vendorId
+      if (!window.localStorage.getItem(key)) setOpen(true)
+    } catch {}
+  }, [vendorId])
+
+  function dismiss() {
+    try {
+      window.localStorage.setItem(STORAGE_PREFIX + vendorId, new Date().toISOString())
+    } catch {}
+    setOpen(false)
+  }
+
+  if (!open) return null
+
+  const isFirst = index === 0
+  const isLast = index === TOTAL - 1
+  const step = isFirst ? null : STEPS[index - 1]
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="vendor-welcome-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={dismiss}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="relative w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-2xl"
+      >
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label={t('vendor.welcome.skip')}
+          className="absolute right-3 top-3 inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+
+        {isFirst ? (
+          <div className="space-y-2 pr-8">
+            <p className="text-xs font-semibold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+              {t('vendor.welcome.badge')}
+            </p>
+            <h2 id="vendor-welcome-title" className="text-2xl font-bold text-[var(--foreground)]">
+              {t('vendor.welcome.intro.title').replace('{name}', vendorName)}
+            </h2>
+            <p className="text-sm text-[var(--muted)]">{t('vendor.welcome.intro.body')}</p>
+          </div>
+        ) : (
+          step && (
+            <div className="space-y-3 pr-8">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+                <step.Icon className="h-6 w-6" />
+              </div>
+              <p className="text-xs font-medium text-[var(--muted)]">
+                {index} / {TOTAL - 1}
+              </p>
+              <h2 id="vendor-welcome-title" className="text-xl font-bold text-[var(--foreground)]">
+                {t(step.titleKey)}
+              </h2>
+              <p className="text-sm text-[var(--muted)]">{t(step.bodyKey)}</p>
+            </div>
+          )
+        )}
+
+        <div className="mt-6 flex items-center gap-1.5" aria-hidden="true">
+          {Array.from({ length: TOTAL }).map((_, i) => (
+            <span
+              key={i}
+              className={`h-2 rounded-full transition-all ${
+                i === index
+                  ? 'w-8 bg-emerald-500'
+                  : i < index
+                    ? 'w-2 bg-emerald-500/60'
+                    : 'w-2 bg-gray-300 dark:bg-gray-600'
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={dismiss}
+            className="min-h-11 rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted)] hover:text-[var(--foreground)]"
+          >
+            {t('vendor.welcome.skip')}
+          </button>
+
+          <div className="flex items-center gap-2">
+            {!isFirst && (
+              <button
+                type="button"
+                onClick={() => setIndex(i => i - 1)}
+                className="min-h-11 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)]"
+              >
+                {t('vendor.welcome.back')}
+              </button>
+            )}
+            {isLast ? (
+              <Link
+                href="/vendor/perfil"
+                onClick={dismiss}
+                className="inline-flex min-h-11 items-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400"
+              >
+                {t('vendor.welcome.finish')}
+              </Link>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIndex(i => i + 1)}
+                className="min-h-11 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400"
+              >
+                {t('vendor.welcome.next')}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -464,6 +464,27 @@ const en: Record<TranslationKeys, string> = {
   'vendor.dashboard.actionManage': 'Manage catalog',
   'vendor.dashboard.actionViewStore': 'View store',
 
+  // Vendor – welcome tour (first access after becoming vendor)
+  'vendor.welcome.badge': 'Welcome aboard',
+  'vendor.welcome.intro.title': 'Hi, {name}! 👋',
+  'vendor.welcome.intro.body': 'Congrats on joining as a producer. Here is a quick tour of your panel so you know where everything is.',
+  'vendor.welcome.step1.title': 'Your panel',
+  'vendor.welcome.step1.body': 'This is your activity summary: pending setup, urgent orders and quick stats.',
+  'vendor.welcome.step2.title': 'Products',
+  'vendor.welcome.step2.body': 'Create, edit and manage your catalog. Add photos, prices and stock to start selling.',
+  'vendor.welcome.step3.title': 'Orders',
+  'vendor.welcome.step3.body': 'Your customers\' purchases arrive here. Confirm them, prepare them and mark when they are ready to ship.',
+  'vendor.welcome.step4.title': 'Your profile',
+  'vendor.welcome.step4.body': 'Complete your description, location and details so buyers can get to know you.',
+  'vendor.welcome.step5.title': 'Payouts',
+  'vendor.welcome.step5.body': 'Set up your bank details and check your settlements to get paid.',
+  'vendor.welcome.step6.title': 'Reviews',
+  'vendor.welcome.step6.body': 'See what your customers think. Start by completing your profile to build trust!',
+  'vendor.welcome.next': 'Next',
+  'vendor.welcome.back': 'Back',
+  'vendor.welcome.skip': 'Skip',
+  'vendor.welcome.finish': 'Complete profile',
+
   // Vendor – products list extras
   'vendor.productsList.productsOne': '1 product',
   'vendor.productsList.productsOther': '{count} products',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -462,6 +462,27 @@ const es = {
   'vendor.dashboard.actionManage': 'Gestionar catálogo',
   'vendor.dashboard.actionViewStore': 'Ver tienda',
 
+  // Vendor – welcome tour (first access after becoming vendor)
+  'vendor.welcome.badge': 'Bienvenido a bordo',
+  'vendor.welcome.intro.title': '¡Hola, {name}! 👋',
+  'vendor.welcome.intro.body': 'Enhorabuena por unirte como productor. Te damos un recorrido rápido por tu panel para que sepas dónde está todo.',
+  'vendor.welcome.step1.title': 'Tu panel',
+  'vendor.welcome.step1.body': 'Desde aquí verás un resumen de tu actividad: configuración pendiente, pedidos urgentes y estadísticas rápidas.',
+  'vendor.welcome.step2.title': 'Productos',
+  'vendor.welcome.step2.body': 'Crea, edita y gestiona tu catálogo. Añade fotos, precios y stock para empezar a vender.',
+  'vendor.welcome.step3.title': 'Pedidos',
+  'vendor.welcome.step3.body': 'Aquí llegan las compras de tus clientes. Confírmalas, prepáralas y marca cuándo están listas para envío.',
+  'vendor.welcome.step4.title': 'Tu perfil',
+  'vendor.welcome.step4.body': 'Completa la descripción, la ubicación y tus datos para que los compradores te conozcan.',
+  'vendor.welcome.step5.title': 'Cobros',
+  'vendor.welcome.step5.body': 'Configura tus datos bancarios y consulta tus liquidaciones para recibir pagos.',
+  'vendor.welcome.step6.title': 'Valoraciones',
+  'vendor.welcome.step6.body': 'Consulta las opiniones de tus clientes. ¡Empieza completando tu perfil para dar confianza!',
+  'vendor.welcome.next': 'Siguiente',
+  'vendor.welcome.back': 'Atrás',
+  'vendor.welcome.skip': 'Saltar',
+  'vendor.welcome.finish': 'Completar perfil',
+
   // Vendor – products list extras
   'vendor.productsList.productsOne': '1 producto',
   'vendor.productsList.productsOther': '{count} productos',

--- a/test/features/vendor-welcome-tour.test.ts
+++ b/test/features/vendor-welcome-tour.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import es from '@/i18n/locales/es'
+import en from '@/i18n/locales/en'
+
+const WELCOME_KEYS = [
+  'vendor.welcome.badge',
+  'vendor.welcome.intro.title',
+  'vendor.welcome.intro.body',
+  'vendor.welcome.step1.title',
+  'vendor.welcome.step1.body',
+  'vendor.welcome.step2.title',
+  'vendor.welcome.step2.body',
+  'vendor.welcome.step3.title',
+  'vendor.welcome.step3.body',
+  'vendor.welcome.step4.title',
+  'vendor.welcome.step4.body',
+  'vendor.welcome.step5.title',
+  'vendor.welcome.step5.body',
+  'vendor.welcome.step6.title',
+  'vendor.welcome.step6.body',
+  'vendor.welcome.next',
+  'vendor.welcome.back',
+  'vendor.welcome.skip',
+  'vendor.welcome.finish',
+] as const
+
+test('welcome tour keys exist in Spanish locale and are non-empty', () => {
+  for (const key of WELCOME_KEYS) {
+    const value = (es as Record<string, string>)[key]
+    assert.ok(value, `es missing key ${key}`)
+    assert.notEqual(value, key, `es[${key}] must not equal the key itself`)
+  }
+})
+
+test('welcome tour keys exist in English locale and are non-empty', () => {
+  for (const key of WELCOME_KEYS) {
+    const value = (en as Record<string, string>)[key]
+    assert.ok(value, `en missing key ${key}`)
+    assert.notEqual(value, key, `en[${key}] must not equal the key itself`)
+  }
+})
+
+test('intro.title contains {name} placeholder for both locales', () => {
+  assert.ok((es as Record<string, string>)['vendor.welcome.intro.title']?.includes('{name}'))
+  assert.ok((en as Record<string, string>)['vendor.welcome.intro.title']?.includes('{name}'))
+})
+
+test('welcome keys are present in both locales symmetrically', () => {
+  const esKeys = new Set(Object.keys(es).filter(k => k.startsWith('vendor.welcome.')))
+  const enKeys = new Set(Object.keys(en).filter(k => k.startsWith('vendor.welcome.')))
+  assert.deepEqual([...esKeys].sort(), [...enKeys].sort())
+  assert.equal(esKeys.size, WELCOME_KEYS.length)
+})


### PR DESCRIPTION
## Summary
- 7-step welcome modal on `/vendor/dashboard` shown once per vendor (localStorage-backed)
- Walks new producers through: intro → panel → products → orders → profile → payouts → reviews
- Skip at any point; last step deep-links to `/vendor/perfil`
- 19 new i18n keys in both `es` and `en`
- Locale-parity test in [test/features/vendor-welcome-tour.test.ts](test/features/vendor-welcome-tour.test.ts) so a future branch switch that drops keys fails CI

## Test plan
- [ ] Log in as vendor → `/vendor/dashboard` → modal appears
- [ ] Click through all 7 steps, verify counter `1/6`…`6/6` and progress dots
- [ ] Click "Saltar" or backdrop → closes and does not reappear on reload
- [ ] Click final "Completar perfil" → navigates to `/vendor/perfil`
- [ ] Switch EN locale → text renders in English
- [ ] Mobile viewport — modal fits
- [ ] `node ./scripts/run-node-tests.mjs test/features/vendor-welcome-tour.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)