### PR TITLE
docs(git-workflow): concrete multi-agent isolation conventions

### DIFF
--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -76,6 +76,33 @@ Multiple Claude Code agents (or a human + agent) can be active in the same repo 
 
 This rule comes directly from the 2026-04-12 incident, where an agent overwrote a concurrent agent's WIP because it assumed the worktree was idle.
 
+### Concrete conventions
+
+**1 agent = 1 worktree.** Non-negotiable. The base checkout at `/home/whisper/marketplace` is for solo work; parallel agents must branch out.
+
+- **Path layout:**
+
+  ```text
+  /home/whisper/marketplace          → base (not shared in parallel)
+  /home/whisper/worktrees/<agent-1>  → isolated
+  /home/whisper/worktrees/<agent-2>  → isolated
+  ```
+
+- **Spawn:**
+
+  ```bash
+  git fetch origin
+  git worktree add /home/whisper/worktrees/<name> origin/main -b feat/<feature>
+  ```
+
+- **Port per agent:** each agent runs its own dev server on its own port (`3001`, `3002`, `3003`, …). Never share a `next dev` process.
+- **`node_modules`:** reuse across worktrees only if the build stays green. Prisma `generate` has bitten us here — when in doubt, install fresh.
+- **Rebase policy:** do **not** rebase every time `main` moves. Rebase once, when work is ready to merge (or immediately before merge). Constant rebasing burns CI and creates phantom "behind" churn.
+- **Stop on anomalies.** Files mutating without cause, branch switching under you, or index errors → halt, move work to a fresh worktree, do not try to salvage in-place.
+- Never `reset`, `checkout`, `clean`, or modify branches outside your own worktree.
+
+Priority: **isolation > convenience.** An extra worktree is cheap; corrupted work is not.
+
 ---
 
 ## Hygiene


### PR DESCRIPTION
## Summary
- Add an *Concrete conventions* subsection under *Concurrent-agent safety* in [docs/git-workflow.md](docs/git-workflow.md) covering: worktree path layout (`/home/whisper/worktrees/<name>`), port-per-agent, rebase-only-at-end, and stop-on-anomaly.
- The existing doc stated the principle ("1 worktree per task"); this PR adds the operational specifics so parallel agents converge on the same setup without rediscovery.

## Motivation
Recent concurrent-agent sessions have kept landing in the same base checkout, causing index stomps, unexpected branch switches, and rebase-churn against a moving `main`. Encoding the conventions in the workflow doc makes them enforceable.

## Test plan
- [x] Docs-only change, no code paths touched
- [ ] Review rendered markdown in the PR preview