### PR TITLE
feat(admin): first-access welcome tour for new admins

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,5 +1,6 @@
 import { AdminSidebar } from '@/components/admin/AdminSidebar'
 import { AdminHeader } from '@/components/admin/AdminHeader'
+import { AdminWelcomeTour } from '@/components/admin/AdminWelcomeTour'
 import { SidebarProvider } from '@/components/layout/SidebarProvider'
 import { requireAdmin } from '@/lib/auth-guard'
 import { getAvailablePortals } from '@/lib/portals'
@@ -15,6 +16,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         <div className="flex flex-1 flex-col overflow-hidden">
           <AdminHeader user={session.user} portals={portals} />
           <main className="flex-1 overflow-y-auto p-6">{children}</main>
+          <AdminWelcomeTour adminId={session.user.id} adminName={session.user.name ?? session.user.email ?? 'admin'} />
         </div>
       </div>
     </SidebarProvider>

--- a/src/components/admin/AdminWelcomeTour.tsx
+++ b/src/components/admin/AdminWelcomeTour.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  HomeIcon, ShoppingBagIcon, ArchiveBoxIcon, UserGroupIcon,
+  CurrencyEuroIcon, XMarkIcon, SparklesIcon, IdentificationIcon,
+} from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+import type { TranslationKeys } from '@/i18n/locales'
+
+const STORAGE_PREFIX = 'admin-welcome-seen-v1:'
+const QUERY_PARAM = 'admin_tour'
+
+interface Step {
+  path: string
+  titleKey: TranslationKeys
+  bodyKey: TranslationKeys
+  Icon: React.ComponentType<{ className?: string }>
+  emoji: string
+}
+
+const STEPS: Step[] = [
+  { path: '/admin/dashboard',    titleKey: 'admin.welcome.intro.title',    bodyKey: 'admin.welcome.intro.body',    Icon: SparklesIcon,       emoji: '🛠️' },
+  { path: '/admin/dashboard',    titleKey: 'admin.welcome.step1.title',    bodyKey: 'admin.welcome.step1.body',    Icon: HomeIcon,           emoji: '📊' },
+  { path: '/admin/productores',  titleKey: 'admin.welcome.step2.title',    bodyKey: 'admin.welcome.step2.body',    Icon: UserGroupIcon,      emoji: '👥' },
+  { path: '/admin/productos',    titleKey: 'admin.welcome.step3.title',    bodyKey: 'admin.welcome.step3.body',    Icon: ArchiveBoxIcon,     emoji: '✅' },
+  { path: '/admin/pedidos',      titleKey: 'admin.welcome.step4.title',    bodyKey: 'admin.welcome.step4.body',    Icon: ShoppingBagIcon,    emoji: '📦' },
+  { path: '/admin/comisiones',   titleKey: 'admin.welcome.step5.title',    bodyKey: 'admin.welcome.step5.body',    Icon: CurrencyEuroIcon,   emoji: '💶' },
+  { path: '/admin/productores',  titleKey: 'admin.welcome.step6.title',    bodyKey: 'admin.welcome.step6.body',    Icon: IdentificationIcon, emoji: '🕵️' },
+]
+
+interface Props {
+  adminId: string
+  adminName: string
+}
+
+export function AdminWelcomeTour({ adminId, adminName }: Props) {
+  const t = useT()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const [mounted, setMounted] = useState(false)
+
+  const tourParam = searchParams.get(QUERY_PARAM)
+  const index = tourParam === null ? -1 : Math.max(0, Math.min(STEPS.length - 1, Number(tourParam) | 0))
+  const open = index >= 0
+
+  useEffect(() => {
+    setMounted(true)
+    if (pathname !== '/admin/dashboard') return
+    if (tourParam !== null) return
+    try {
+      if (window.localStorage.getItem(STORAGE_PREFIX + adminId)) return
+    } catch { return }
+    const params = new URLSearchParams(searchParams.toString())
+    params.set(QUERY_PARAM, '0')
+    router.replace(`/admin/dashboard?${params.toString()}`, { scroll: false })
+  }, [pathname, tourParam, adminId, router, searchParams])
+
+  const markSeen = useCallback(() => {
+    try {
+      window.localStorage.setItem(STORAGE_PREFIX + adminId, new Date().toISOString())
+    } catch {}
+  }, [adminId])
+
+  const clearTourParam = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete(QUERY_PARAM)
+    const q = params.toString()
+    router.replace(q ? `${pathname}?${q}` : pathname, { scroll: false })
+  }, [pathname, router, searchParams])
+
+  const goToStep = useCallback((nextIndex: number) => {
+    const next = STEPS[nextIndex]
+    if (!next) return
+    const params = new URLSearchParams(searchParams.toString())
+    params.set(QUERY_PARAM, String(nextIndex))
+    router.push(`${next.path}?${params.toString()}`, { scroll: false })
+  }, [router, searchParams])
+
+  const dismiss = useCallback(() => {
+    markSeen()
+    clearTourParam()
+  }, [markSeen, clearTourParam])
+
+  const finish = useCallback(() => {
+    markSeen()
+    clearTourParam()
+  }, [markSeen, clearTourParam])
+
+  if (!mounted || !open) return null
+  const step = STEPS[index]
+  if (!step) return null
+
+  const isFirst = index === 0
+  const isLast = index === STEPS.length - 1
+  const total = STEPS.length - 1
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="admin-welcome-title"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center sm:inset-auto sm:bottom-6 sm:right-6 sm:justify-end p-4 sm:p-0"
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="pointer-events-auto relative w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden"
+      >
+        <div className="relative bg-gradient-to-br from-indigo-500 via-indigo-600 to-violet-600 p-6 pb-8 text-white">
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t('admin.welcome.skip')}
+            className="absolute right-3 top-3 inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2 text-white/80 hover:bg-white/15 hover:text-white transition-colors"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+
+          <div className="flex items-center gap-3">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-white/20 text-3xl backdrop-blur-sm ring-1 ring-white/30">
+              <span aria-hidden="true">{step.emoji}</span>
+            </div>
+            <div className="min-w-0">
+              {!isFirst && (
+                <p className="text-xs font-medium uppercase tracking-wider text-white/80">
+                  {t('admin.welcome.stepCounter').replace('{current}', String(index)).replace('{total}', String(total))}
+                </p>
+              )}
+              <h2 id="admin-welcome-title" className="text-xl sm:text-2xl font-bold leading-tight">
+                {isFirst ? t(step.titleKey).replace('{name}', adminName) : t(step.titleKey)}
+              </h2>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6 space-y-5">
+          <p className="text-sm sm:text-base leading-relaxed text-[var(--foreground-soft)]">
+            {t(step.bodyKey)}
+          </p>
+
+          <div className="flex items-center gap-1.5" aria-hidden="true">
+            {STEPS.map((_, i) => (
+              <span
+                key={i}
+                className={`h-2 rounded-full transition-all ${
+                  i === index
+                    ? 'w-8 bg-indigo-500'
+                    : i < index
+                      ? 'w-2 bg-indigo-500/60'
+                      : 'w-2 bg-[var(--border)]'
+                }`}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between gap-3 pt-1">
+            <button
+              type="button"
+              onClick={dismiss}
+              className="min-h-11 rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              {t('admin.welcome.skip')}
+            </button>
+
+            <div className="flex items-center gap-2">
+              {!isFirst && (
+                <button
+                  type="button"
+                  onClick={() => goToStep(index - 1)}
+                  className="min-h-11 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm font-medium text-[var(--foreground-soft)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] transition-colors"
+                >
+                  {t('admin.welcome.back')}
+                </button>
+              )}
+              {isLast ? (
+                <button
+                  type="button"
+                  onClick={finish}
+                  className="inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400 transition-colors"
+                >
+                  {t('admin.welcome.finish')}
+                  <span aria-hidden="true">✓</span>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => goToStep(index + 1)}
+                  className="inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400 transition-colors"
+                >
+                  {isFirst ? t('admin.welcome.start') : t('admin.welcome.next')}
+                  <span aria-hidden="true">→</span>
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1299,6 +1299,28 @@ const en: Record<TranslationKeys, string> = {
   'admin.vendors': 'Producers',
   'admin.config': 'Configuration',
 
+  // Admin – welcome tour (first access for new admins)
+  'admin.welcome.stepCounter': 'Step {current} of {total}',
+  'admin.welcome.intro.title': 'Hi, {name}!',
+  'admin.welcome.intro.body': 'This is the admin panel. In under a minute we\'ll show you the essentials: producers, products, orders and how to impersonate a producer to support them. Ready?',
+  'admin.welcome.step1.title': 'Control panel',
+  'admin.welcome.step1.body': 'The marketplace pulse: recent orders, new producers, products pending review and incident alerts. Everything important at a glance.',
+  'admin.welcome.step2.title': 'Producers',
+  'admin.welcome.step2.body': 'Manage approvals, activate or suspend accounts and access their stores. Core to moderating the community.',
+  'admin.welcome.step3.title': 'Products',
+  'admin.welcome.step3.body': 'Review and approve new products, mark drafts or remove ones that don\'t comply. Your moderation queue lives here.',
+  'admin.welcome.step4.title': 'Orders',
+  'admin.welcome.step4.body': 'Global view of every marketplace order. Use it to resolve incidents, track status and check history.',
+  'admin.welcome.step5.title': 'Commissions & payouts',
+  'admin.welcome.step5.body': 'Tweak per-producer commissions, review settlements and control payouts. The marketplace till.',
+  'admin.welcome.step6.title': 'Impersonate producer',
+  'admin.welcome.step6.body': 'From any producer\'s page you can enter their panel in impersonation mode to help them live. An orange banner keeps you aware while using it.',
+  'admin.welcome.start': 'Get started',
+  'admin.welcome.next': 'Next',
+  'admin.welcome.back': 'Back',
+  'admin.welcome.skip': 'Skip',
+  'admin.welcome.finish': 'Got it',
+
   // Admin · Producers
   'adminProducers.eyebrow': 'Catalog',
   // Admin – promotions overview (phase 5)

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1298,6 +1298,28 @@ const es = {
   'admin.vendors': 'Productores',
   'admin.config': 'Configuración',
 
+  // Admin – welcome tour (first access for new admins)
+  'admin.welcome.stepCounter': 'Paso {current} de {total}',
+  'admin.welcome.intro.title': '¡Hola, {name}!',
+  'admin.welcome.intro.body': 'Este es el panel de administración. En menos de un minuto te enseñamos lo esencial: productores, productos, pedidos y cómo actuar como ellos para dar soporte. ¿Empezamos?',
+  'admin.welcome.step1.title': 'Panel de control',
+  'admin.welcome.step1.body': 'Aquí ves el pulso del marketplace: pedidos recientes, productores nuevos, productos pendientes de revisar y alertas de incidencias. Lo importante, de un vistazo.',
+  'admin.welcome.step2.title': 'Productores',
+  'admin.welcome.step2.body': 'Gestiona aprobaciones, activa o suspende cuentas y accede a sus escaparates. Clave en la moderación de la comunidad.',
+  'admin.welcome.step3.title': 'Productos',
+  'admin.welcome.step3.body': 'Revisa y aprueba productos nuevos, marca borradores o retira los que no cumplan. Tu cola de moderación vive aquí.',
+  'admin.welcome.step4.title': 'Pedidos',
+  'admin.welcome.step4.body': 'Vista global de todos los pedidos del marketplace. Úsala para resolver incidencias, seguir el estado y consultar historial.',
+  'admin.welcome.step5.title': 'Comisiones y pagos',
+  'admin.welcome.step5.body': 'Ajusta las comisiones por productor, revisa liquidaciones y controla los pagos a los productores. La caja del marketplace.',
+  'admin.welcome.step6.title': 'Impersonar productor',
+  'admin.welcome.step6.body': 'Desde la ficha de cada productor puedes entrar a su panel en modo impersonación para ayudarles en directo. Un banner naranja te lo recuerda mientras lo usas.',
+  'admin.welcome.start': 'Empezar',
+  'admin.welcome.next': 'Siguiente',
+  'admin.welcome.back': 'Atrás',
+  'admin.welcome.skip': 'Saltar',
+  'admin.welcome.finish': 'Entendido',
+
   // Admin · Productores
   'adminProducers.eyebrow': 'Catálogo',
   // Admin – promotions overview (phase 5)

--- a/test/features/admin-welcome-tour.test.ts
+++ b/test/features/admin-welcome-tour.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import es from '@/i18n/locales/es'
+import en from '@/i18n/locales/en'
+
+const WELCOME_KEYS = [
+  'admin.welcome.stepCounter',
+  'admin.welcome.intro.title',
+  'admin.welcome.intro.body',
+  'admin.welcome.step1.title',
+  'admin.welcome.step1.body',
+  'admin.welcome.step2.title',
+  'admin.welcome.step2.body',
+  'admin.welcome.step3.title',
+  'admin.welcome.step3.body',
+  'admin.welcome.step4.title',
+  'admin.welcome.step4.body',
+  'admin.welcome.step5.title',
+  'admin.welcome.step5.body',
+  'admin.welcome.step6.title',
+  'admin.welcome.step6.body',
+  'admin.welcome.start',
+  'admin.welcome.next',
+  'admin.welcome.back',
+  'admin.welcome.skip',
+  'admin.welcome.finish',
+] as const
+
+test('admin welcome keys exist in Spanish locale', () => {
+  for (const key of WELCOME_KEYS) {
+    const value = (es as Record<string, string>)[key]
+    assert.ok(value, `es missing ${key}`)
+    assert.notEqual(value, key)
+  }
+})
+
+test('admin welcome keys exist in English locale', () => {
+  for (const key of WELCOME_KEYS) {
+    const value = (en as Record<string, string>)[key]
+    assert.ok(value, `en missing ${key}`)
+    assert.notEqual(value, key)
+  }
+})
+
+test('admin intro.title contains {name} placeholder', () => {
+  assert.ok((es as Record<string, string>)['admin.welcome.intro.title']?.includes('{name}'))
+  assert.ok((en as Record<string, string>)['admin.welcome.intro.title']?.includes('{name}'))
+})
+
+test('admin stepCounter contains {current} and {total}', () => {
+  for (const locale of [es, en]) {
+    const v = (locale as Record<string, string>)['admin.welcome.stepCounter']
+    assert.ok(v?.includes('{current}'))
+    assert.ok(v?.includes('{total}'))
+  }
+})
+
+test('admin welcome keys are symmetric across locales', () => {
+  const esKeys = new Set(Object.keys(es).filter(k => k.startsWith('admin.welcome.')))
+  const enKeys = new Set(Object.keys(en).filter(k => k.startsWith('admin.welcome.')))
+  assert.deepEqual([...esKeys].sort(), [...enKeys].sort())
+  assert.equal(esKeys.size, WELCOME_KEYS.length)
+})


### PR DESCRIPTION
## Summary
Mirror the vendor welcome tour for the admin panel. Walks new admins through the essentials in 7 slides: intro → dashboard → producers → products → orders → commissions → impersonation.

- Indigo/violet gradient to distinguish visually from the vendor emerald tour
- Bottom-right cornered, no backdrop (same pattern as vendor)
- URL-driven via \`?admin_tour=N\`, survives route changes
- Persisted once per admin via \`admin-welcome-seen-v1:<userId>\` localStorage key
- 20 i18n keys in \`es\` + \`en\` with parity test

## Test plan
- [ ] Log in as admin with cleared localStorage
- [ ] \`/admin/dashboard\` → intro modal appears bottom-right
- [ ] Navigate all 7 slides, verify URL changes and counter updates
- [ ] Final step CTA "Entendido" closes cleanly, does not reappear
- [ ] \`node ./scripts/run-node-tests.mjs test/features/admin-welcome-tour.test.ts\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)