### PR TITLE
feat(vendors): celebratory modal on the vendor's very first sale

### DIFF
--- a/src/app/(vendor)/layout.tsx
+++ b/src/app/(vendor)/layout.tsx
@@ -9,6 +9,7 @@ import { requireVendor } from '@/lib/auth-guard'
 import { getAvailablePortals } from '@/lib/portals'
 import { IMPERSONATION_COOKIE, verifyImpersonationToken } from '@/lib/impersonation'
 import { VendorWelcomeTour } from '@/components/vendor/VendorWelcomeTour'
+import { VendorFirstSaleCelebration } from '@/components/vendor/VendorFirstSaleCelebration'
 
 export default async function VendorLayout({ children }: { children: React.ReactNode }) {
   const session = await requireVendor()
@@ -34,7 +35,7 @@ export default async function VendorLayout({ children }: { children: React.React
   // the impersonating admin's email depends on the verified impersonation
   // token. Both are cheap point lookups — run them together so the layout
   // doesn't wait on each sequentially.
-  const [pendingFulfillments, impersonatingAdminEmail] = await Promise.all([
+  const [pendingFulfillments, totalFulfillments, impersonatingAdminEmail] = await Promise.all([
     vendor
       ? db.vendorFulfillment.count({
           where: {
@@ -43,6 +44,9 @@ export default async function VendorLayout({ children }: { children: React.React
           },
         })
       : Promise.resolve(0),
+    // Total count — drives the one-shot first-sale celebration modal.
+    // Cheap: hits the same (vendorId) index as the pending count above.
+    vendor ? db.vendorFulfillment.count({ where: { vendorId: vendor.id } }) : Promise.resolve(0),
     impersonation
       ? db.user
           .findUnique({ where: { id: impersonation.adminId }, select: { email: true } })
@@ -67,6 +71,9 @@ export default async function VendorLayout({ children }: { children: React.React
           <AppBadgeSync count={pendingFulfillments} />
           <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 sm:p-6">{children}</main>
           {vendor && <VendorWelcomeTour vendorId={vendor.id} vendorName={vendor.displayName} />}
+          {vendor && totalFulfillments === 1 && (
+            <VendorFirstSaleCelebration vendorId={vendor.id} vendorName={vendor.displayName} />
+          )}
         </div>
       </div>
     </SidebarProvider>

--- a/src/components/vendor/VendorFirstSaleCelebration.tsx
+++ b/src/components/vendor/VendorFirstSaleCelebration.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { XMarkIcon, ShoppingBagIcon } from '@heroicons/react/24/outline'
+import { useT } from '@/i18n'
+
+const STORAGE_PREFIX = 'vendor-first-sale-celebrated-v1:'
+
+interface Props {
+  vendorId: string
+  vendorName: string
+}
+
+export function VendorFirstSaleCelebration({ vendorId, vendorName }: Props) {
+  const t = useT()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    try {
+      if (!window.localStorage.getItem(STORAGE_PREFIX + vendorId)) setOpen(true)
+    } catch {}
+  }, [vendorId])
+
+  function dismiss() {
+    try {
+      window.localStorage.setItem(STORAGE_PREFIX + vendorId, new Date().toISOString())
+    } catch {}
+    setOpen(false)
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="vendor-first-sale-title"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4"
+      onClick={dismiss}
+    >
+      <div
+        onClick={e => e.stopPropagation()}
+        className="relative w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-2xl overflow-hidden"
+      >
+        <div className="relative bg-gradient-to-br from-amber-400 via-orange-500 to-rose-500 p-6 pb-10 text-white overflow-hidden">
+          <div aria-hidden="true" className="absolute -right-4 -top-4 text-7xl opacity-20 select-none">🎉</div>
+          <div aria-hidden="true" className="absolute -left-6 bottom-2 text-5xl opacity-20 select-none">🥳</div>
+
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t('vendor.firstSale.dismiss')}
+            className="absolute right-3 top-3 inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2 text-white/80 hover:bg-white/15 hover:text-white transition-colors"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+
+          <p className="text-xs font-semibold uppercase tracking-widest text-white/90">
+            {t('vendor.firstSale.badge')}
+          </p>
+          <h2 id="vendor-first-sale-title" className="mt-1 text-2xl sm:text-3xl font-extrabold leading-tight">
+            {t('vendor.firstSale.title').replace('{name}', vendorName)}
+          </h2>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <p className="text-sm sm:text-base leading-relaxed text-[var(--foreground-soft)]">
+            {t('vendor.firstSale.body')}
+          </p>
+
+          <ol className="space-y-2 text-sm text-[var(--foreground-soft)]">
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-800 dark:bg-amber-900/50 dark:text-amber-300">1</span>
+              <span>{t('vendor.firstSale.tip1')}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-800 dark:bg-amber-900/50 dark:text-amber-300">2</span>
+              <span>{t('vendor.firstSale.tip2')}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span aria-hidden="true" className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-800 dark:bg-amber-900/50 dark:text-amber-300">3</span>
+              <span>{t('vendor.firstSale.tip3')}</span>
+            </li>
+          </ol>
+
+          <div className="flex items-center justify-between gap-3 pt-2">
+            <button
+              type="button"
+              onClick={dismiss}
+              className="min-h-11 rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              {t('vendor.firstSale.dismiss')}
+            </button>
+            <Link
+              href="/vendor/pedidos"
+              onClick={dismiss}
+              className="inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 dark:bg-emerald-500 dark:text-gray-950 dark:hover:bg-emerald-400 transition-colors"
+            >
+              <ShoppingBagIcon className="h-4 w-4" />
+              {t('vendor.firstSale.goToOrder')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -499,6 +499,16 @@ const en: Record<TranslationKeys, string> = {
   'vendor.welcome.skip': 'Skip tour',
   'vendor.welcome.finish': 'Complete my profile',
 
+  // Vendor – first sale celebration (shown once when totalFulfillments === 1)
+  'vendor.firstSale.badge': 'Congrats!',
+  'vendor.firstSale.title': '{name}, your first sale!',
+  'vendor.firstSale.body': 'You just got going. Someone decided to trust your craft — that\'s huge. Here are the 3 steps that take the order from inbox to delivery:',
+  'vendor.firstSale.tip1': 'Confirm the order quickly — buyers love responsiveness.',
+  'vendor.firstSale.tip2': 'Prepare it with care: photo, handwritten note… whatever you do best.',
+  'vendor.firstSale.tip3': 'Mark it as ready when you hand it over. And on to the next!',
+  'vendor.firstSale.goToOrder': 'See my order',
+  'vendor.firstSale.dismiss': 'Later',
+
   // Vendor – products list extras
   'vendor.productsList.productsOne': '1 product',
   'vendor.productsList.productsOther': '{count} products',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -497,6 +497,16 @@ const es = {
   'vendor.welcome.skip': 'Saltar tour',
   'vendor.welcome.finish': 'Completar mi perfil',
 
+  // Vendor – first sale celebration (shown once when totalFulfillments === 1)
+  'vendor.firstSale.badge': '¡Enhorabuena!',
+  'vendor.firstSale.title': '¡{name}, tu primera venta!',
+  'vendor.firstSale.body': 'Acabas de estrenarte. Alguien ha decidido confiar en lo que haces — y eso es enorme. Aquí van los 3 pasos que te llevan del pedido al reparto:',
+  'vendor.firstSale.tip1': 'Confirma el pedido cuanto antes — da confianza al comprador.',
+  'vendor.firstSale.tip2': 'Prepáralo con cariño: foto, nota a mano… lo que suelas hacer bien.',
+  'vendor.firstSale.tip3': 'Márcalo como listo cuando lo entregues. ¡Y a por el siguiente!',
+  'vendor.firstSale.goToOrder': 'Ver mi pedido',
+  'vendor.firstSale.dismiss': 'Luego lo veo',
+
   // Vendor – products list extras
   'vendor.productsList.productsOne': '1 producto',
   'vendor.productsList.productsOther': '{count} productos',

--- a/test/features/vendor-first-sale-celebration.test.ts
+++ b/test/features/vendor-first-sale-celebration.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import es from '@/i18n/locales/es'
+import en from '@/i18n/locales/en'
+
+const KEYS = [
+  'vendor.firstSale.badge',
+  'vendor.firstSale.title',
+  'vendor.firstSale.body',
+  'vendor.firstSale.tip1',
+  'vendor.firstSale.tip2',
+  'vendor.firstSale.tip3',
+  'vendor.firstSale.goToOrder',
+  'vendor.firstSale.dismiss',
+] as const
+
+test('firstSale keys exist in Spanish locale', () => {
+  for (const key of KEYS) {
+    const value = (es as Record<string, string>)[key]
+    assert.ok(value, `es missing ${key}`)
+    assert.notEqual(value, key)
+  }
+})
+
+test('firstSale keys exist in English locale', () => {
+  for (const key of KEYS) {
+    const value = (en as Record<string, string>)[key]
+    assert.ok(value, `en missing ${key}`)
+    assert.notEqual(value, key)
+  }
+})
+
+test('firstSale.title contains {name} placeholder', () => {
+  assert.ok((es as Record<string, string>)['vendor.firstSale.title']?.includes('{name}'))
+  assert.ok((en as Record<string, string>)['vendor.firstSale.title']?.includes('{name}'))
+})
+
+test('firstSale keys are symmetric across locales', () => {
+  const esKeys = new Set(Object.keys(es).filter(k => k.startsWith('vendor.firstSale.')))
+  const enKeys = new Set(Object.keys(en).filter(k => k.startsWith('vendor.firstSale.')))
+  assert.deepEqual([...esKeys].sort(), [...enKeys].sort())
+  assert.equal(esKeys.size, KEYS.length)
+})


### PR DESCRIPTION
## Summary
When a vendor's total fulfillment count reaches exactly 1, show a one-shot celebration modal that congratulates them and walks them through the 3 steps from inbox to delivery. Warm amber/rose gradient + confetti accents set it apart from the welcome tour.

- Mounted in \`(vendor)/layout.tsx\`, gated on \`totalFulfillments === 1\`
- Dismissed once per vendor via \`vendor-first-sale-celebrated-v1:<id>\` localStorage
- Primary CTA navigates to \`/vendor/pedidos\` so they can act immediately
- 8 i18n keys in es/en with parity test

## Test plan
- [ ] As a vendor with exactly 1 fulfillment, log in → modal appears on any vendor page
- [ ] As a vendor with 0 or ≥2 fulfillments → modal does not appear
- [ ] Click "Ver mi pedido" → navigates to \`/vendor/pedidos\` and marks as seen
- [ ] Click "Luego lo veo" or backdrop → dismisses and marks as seen
- [ ] Reload after dismiss → modal does not reappear
- [ ] \`node ./scripts/run-node-tests.mjs test/features/vendor-first-sale-celebration.test.ts\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)