### PR TITLE
feat(ingestion): Phase 1 PR-C — sync + media-download handlers

### DIFF
--- a/docs/ingestion/telegram.md
+++ b/docs/ingestion/telegram.md
@@ -88,7 +88,48 @@ placeholder.
 - [`services/telegram-sidecar/`](../../services/telegram-sidecar/) —
   Python + Telethon sidecar (FastAPI). Phase 1 PR-B ships the contract
   surface; auth + read endpoints return `501` until PR-C.
+- [`src/domains/ingestion/telegram/jobs/`](../../src/domains/ingestion/telegram/jobs/)
+  — pure job handlers (`telegramSyncHandler`, `telegramMediaDownloadHandler`)
+  with dependency-injected `db` / provider / store / clock. Tests drive
+  the pure form; production wraps them in
+  [`src/workers/jobs/`](../../src/workers/jobs/).
 - `prisma/schema.prisma` — the `TelegramIngestion*` models + `IngestionJob`.
+
+### Job handlers (PR-C)
+
+| Job | Singleton key | Retry | Concurrency (default) |
+|---|---|---|---|
+| `telegram.sync` | per chat | exponential ×5 | 1 |
+| `telegram.mediaDownload` | `media:<fileUniqueId>` | exponential ×5 | 1 |
+
+**Sync handler invariants** (pinned in tests):
+
+- Kill switch is the first operation — zero I/O when engaged.
+- Disabled chat / inactive connection → skip without opening a run.
+- Message upserts + cursor advance run in **one transaction**;
+  mid-batch failure → rollback → next attempt re-reads → `@@unique`
+  dedupes. No gaps, no duplicates.
+- `TelegramChatGoneError` → disables the chat (terminal state).
+- Other provider errors rethrow so pg-boss applies retry policy.
+- Media downloads are enqueued **after** the commit, deduped by
+  `fileUniqueId` within the batch. Enqueue failure leaves the media
+  row `PENDING` for the Phase 6 sweeper.
+
+**Media handler invariants** (pinned in tests):
+
+- Kill switch first. Then dedupe on `blobKey`.
+- Hard size cap enforced both as pre-check and mid-stream.
+- `SOURCE_GONE` terminal; `AUTH_REQUIRED` rethrows for alert; retryable
+  errors leave row `PENDING` and rethrow.
+
+**Runtime tunables** (env, conservative defaults):
+
+| Env var | Default | Max | Purpose |
+|---|---|---|---|
+| `INGESTION_TELEGRAM_BATCH_SIZE` | 100 | 500 | Messages per sync batch |
+| `INGESTION_TELEGRAM_SYNC_CONCURRENCY` | 1 | 4 | Parallel sync workers |
+| `INGESTION_TELEGRAM_MEDIA_CONCURRENCY` | 1 | 4 | Parallel media workers |
+| `INGESTION_TELEGRAM_MEDIA_MAX_BYTES` | 20 MB | 256 MB | Hard cap per file |
 
 ### Provider contract
 
@@ -170,9 +211,14 @@ without deploying anything:
    `src/lib/flags.ts` is fail-open and the flag meaning inverts for
    `kill-*` (`true` = killed). Pinned by
    `test/features/ingestion-flags.test.ts`.
-5. **No handler registered** — `src/workers/index.ts` boots pg-boss but
-   calls no `registerHandler`. If the worker were deployed today, it would
-   idle. Handlers land in PR-C.
+5. **Handler kill-switch invariant** — `src/workers/index.ts` registers
+   two handlers (`telegram.sync`, `telegram.mediaDownload`). The very
+   first operation in each handler is a `kill-ingestion-telegram`
+   probe; if engaged, the handler returns `KILLED` before any provider
+   I/O, DB create, or enqueue. The default provider is `mock`, so even
+   an accidental deploy with the kill switch disabled returns no data.
+   Pinned by `test/features/ingestion-sync-handler.test.ts` and
+   `test/features/ingestion-media-handler.test.ts`.
 
 ### Rollout plan
 

--- a/docs/ingestion/telegram.md
+++ b/docs/ingestion/telegram.md
@@ -77,12 +77,44 @@ placeholder.
 ## Components
 
 - [`src/domains/ingestion/`](../../src/domains/ingestion/) — domain barrel,
-  types, flag helpers, admin authz guard.
+  types, flag helpers, admin authz guard, Telegram provider layer.
+- [`src/domains/ingestion/telegram/providers/`](../../src/domains/ingestion/telegram/providers/)
+  — provider contract (`TelegramIngestionProvider`), `createMockProvider`,
+  `createTelethonHttpProvider`, typed error classes, env-selected factory
+  `getTelegramProvider`.
 - [`src/lib/queue.ts`](../../src/lib/queue.ts) — pg-boss wrapper
   (`getQueue`, `enqueue`, `registerHandler`, `stopQueue`).
 - [`src/workers/index.ts`](../../src/workers/index.ts) — worker entrypoint.
-- `services/telegram-sidecar/` — Python/Telethon sidecar. **(PR-B)**
+- [`services/telegram-sidecar/`](../../services/telegram-sidecar/) —
+  Python + Telethon sidecar (FastAPI). Phase 1 PR-B ships the contract
+  surface; auth + read endpoints return `501` until PR-C.
 - `prisma/schema.prisma` — the `TelegramIngestion*` models + `IngestionJob`.
+
+### Provider contract
+
+The worker never talks to Telegram directly. It obtains a
+`TelegramIngestionProvider` via `getTelegramProvider()` and uses the
+contract:
+
+```ts
+fetchChats(input): Promise<{ chats: RawTelegramChat[] }>
+fetchMessages(input): Promise<{ messages: RawTelegramMessage[]; nextFromMessageId: string | null }>
+fetchMedia(input): Promise<{ stream: AsyncIterable<Uint8Array>; mimeType; sizeBytes }>
+```
+
+Selection is env-driven via `INGESTION_TELEGRAM_PROVIDER`:
+
+| Value | Implementation | Default? |
+|---|---|---|
+| `mock` (or unset) | in-memory fixtures | yes |
+| `telethon` | HTTP bridge to the sidecar (requires `TELEGRAM_SIDECAR_URL` + `TELEGRAM_SIDECAR_TOKEN`) | no |
+
+Errors bubble as a closed taxonomy so the worker can dispatch without
+string matching: `TelegramTransportError` (retryable),
+`TelegramFloodWaitError` (reschedule with `retryAfterSeconds`),
+`TelegramAuthRequiredError` (disable connection, alert),
+`TelegramChatGoneError` (disable chat), `TelegramBadResponseError`
+(fail loud — indicates SDK/sidecar drift).
 
 ## Feature flags
 

--- a/services/telegram-sidecar/.dockerignore
+++ b/services/telegram-sidecar/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+__pycache__
+*.pyc
+.env
+.env.*
+!.env.example

--- a/services/telegram-sidecar/.env.example
+++ b/services/telegram-sidecar/.env.example
@@ -1,0 +1,19 @@
+# Sidecar HTTP bind.
+# MUST be a private address (loopback, pod IP, private VPC) — never 0.0.0.0
+# on a publicly reachable host.
+SIDECAR_BIND_HOST=127.0.0.1
+SIDECAR_BIND_PORT=8088
+
+# Shared secret required on every request via `X-Sidecar-Token`. Generate
+# with `openssl rand -base64 48`. Must match TELEGRAM_SIDECAR_TOKEN on the
+# Node side (see .env.example at repo root).
+SIDECAR_SHARED_SECRET=
+
+# Where Telethon stores its per-connection session file. Mount an
+# encrypted volume here in production — the file can be used to
+# impersonate the session if exfiltrated.
+SIDECAR_SESSION_DIR=/var/lib/telegram-sidecar/sessions
+
+# Telethon API credentials. Obtain from https://my.telegram.org/apps
+TELEGRAM_API_ID=
+TELEGRAM_API_HASH=

--- a/services/telegram-sidecar/Dockerfile
+++ b/services/telegram-sidecar/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+# System deps kept minimal; Telethon is pure-python but cryptg (optional
+# speed-up) needs a compiler. We skip cryptg in Phase 1 to keep the image
+# lean; the sidecar is not on the hot path.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+# Non-root user so the session volume can be owned and locked down.
+RUN useradd --uid 10001 --create-home sidecar \
+    && mkdir -p /var/lib/telegram-sidecar/sessions \
+    && chown -R sidecar:sidecar /var/lib/telegram-sidecar
+USER sidecar
+
+ENV SIDECAR_BIND_HOST=0.0.0.0
+ENV SIDECAR_BIND_PORT=8088
+EXPOSE 8088
+
+CMD ["sh", "-c", "uvicorn app.main:app --host ${SIDECAR_BIND_HOST} --port ${SIDECAR_BIND_PORT}"]

--- a/services/telegram-sidecar/README.md
+++ b/services/telegram-sidecar/README.md
@@ -1,0 +1,90 @@
+# Telegram ingestion sidecar
+
+FastAPI service wrapping [Telethon](https://docs.telethon.dev/). The worker
+process ([`src/workers/`](../../src/workers/)) talks to this sidecar over
+HTTP to read public Telegram groups; Telethon's MTProto session lives here
+and only here.
+
+## ⚠️ Deployment invariant — private network only
+
+The sidecar holds a real user session. It MUST NOT be reachable from the
+public internet, the browser, or the main marketplace web app. The only
+permitted caller is the worker container on the same private network.
+
+Enforcement checklist for any environment that runs this service:
+
+1. Bind address defaults to `127.0.0.1`. In Kubernetes / ECS, bind to the
+   pod/container IP and expose only within the private network.
+2. No public Ingress / Load Balancer rule must route to this service.
+3. Requests without a valid `X-Sidecar-Token` header return `401` before
+   any Telethon call.
+4. The shared secret is long (≥32 bytes), rotated on any suspected leak,
+   and NEVER logged.
+
+## Endpoints
+
+All endpoints require `X-Sidecar-Token: <shared-secret>`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/health` | Liveness probe. No auth. Returns `{ "ok": true }`. |
+| `POST` | `/auth/start` | Start the Telethon login flow for a connection. |
+| `POST` | `/auth/verify` | Complete the Telethon login with the SMS code. |
+| `POST` | `/chats` | List chats reachable by a connection. |
+| `POST` | `/messages` | Fetch messages for one chat, cursor-based. |
+| `GET`  | `/media/{file_unique_id}` | Stream media bytes. |
+
+Error responses use JSON with `error` (human string) and, when applicable,
+`retry_after_seconds`, `connection_id`, or `tg_chat_id` fields. The Node
+bridge in [`src/domains/ingestion/telegram/providers/telethon-http.ts`](../../src/domains/ingestion/telegram/providers/telethon-http.ts)
+maps status codes to typed errors:
+
+- `401` / `403` → `TelegramAuthRequiredError`
+- `404` → `TelegramChatGoneError`
+- `429` → `TelegramFloodWaitError` (reads `retry_after_seconds`)
+- `5xx` → `TelegramTransportError` (retryable)
+
+## Environment
+
+```env
+SIDECAR_BIND_HOST=127.0.0.1
+SIDECAR_BIND_PORT=8088
+SIDECAR_SHARED_SECRET=<long-random-token>
+SIDECAR_SESSION_DIR=/var/lib/telegram-sidecar/sessions
+# Telethon API credentials (https://my.telegram.org/apps)
+TELEGRAM_API_ID=
+TELEGRAM_API_HASH=
+```
+
+See `.env.example` for the canonical list.
+
+## Running locally
+
+```bash
+cd services/telegram-sidecar
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env   # fill in the values
+uvicorn app.main:app --host 127.0.0.1 --port 8088
+```
+
+## Docker
+
+```bash
+docker build -t marketplace-telegram-sidecar .
+docker run --rm -p 127.0.0.1:8088:8088 \
+  --env-file .env \
+  -v sidecar-sessions:/var/lib/telegram-sidecar/sessions \
+  marketplace-telegram-sidecar
+```
+
+The container image does not expose the port to all interfaces; the
+`-p 127.0.0.1:8088:8088` form binds to the loopback of the host.
+
+## Phase 1 status
+
+The sidecar is NOT deployed in any environment yet. Only the Node bridge
+and the provider registry are wired in Phase 1 PR-B. The actual Telethon
+calls ship in PR-C together with the first sync handler. Auth endpoints
+return `501 Not Implemented` until then — intentional, so the surface
+is documented but non-functional.

--- a/services/telegram-sidecar/app/main.py
+++ b/services/telegram-sidecar/app/main.py
@@ -1,0 +1,140 @@
+"""Telegram ingestion sidecar — FastAPI entrypoint.
+
+Phase 1 PR-B ships the contract surface only. Every endpoint except
+`/health` is protected by a shared-secret header; Telethon integration
+itself is deliberately stubbed out (`501 Not Implemented`) and lands
+in PR-C together with the first sync handler. That split keeps this
+PR's blast radius zero: even if someone accidentally deployed this
+image today, it could not talk to Telegram.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from fastapi import FastAPI, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+
+SHARED_SECRET_ENV = "SIDECAR_SHARED_SECRET"
+
+
+def _require_token(x_sidecar_token: Optional[str]) -> None:
+    expected = os.environ.get(SHARED_SECRET_ENV, "").strip()
+    if not expected:
+        # Fail closed — refusing to serve protected endpoints without a
+        # configured secret is deliberately louder than the alternative.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="sidecar misconfigured: SIDECAR_SHARED_SECRET not set",
+        )
+    if not x_sidecar_token or x_sidecar_token != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or missing X-Sidecar-Token",
+        )
+
+
+app = FastAPI(
+    title="Telegram ingestion sidecar",
+    version="1.0.0-phase1",
+    # Disable docs by default — this service must not be browsable.
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
+)
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    """Unauthenticated liveness probe."""
+    return {"ok": True}
+
+
+# ─── Auth flow (stubs until PR-C) ────────────────────────────────────────────
+
+class AuthStartRequest(BaseModel):
+    connection_id: str
+    phone_number: str
+
+
+class AuthVerifyRequest(BaseModel):
+    connection_id: str
+    code: str
+
+
+@app.post("/auth/start")
+def auth_start(
+    _body: AuthStartRequest,
+    x_sidecar_token: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    _require_token(x_sidecar_token)
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={"error": "auth.start not implemented in Phase 1 PR-B"},
+    )
+
+
+@app.post("/auth/verify")
+def auth_verify(
+    _body: AuthVerifyRequest,
+    x_sidecar_token: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    _require_token(x_sidecar_token)
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={"error": "auth.verify not implemented in Phase 1 PR-B"},
+    )
+
+
+# ─── Read endpoints (stubs until PR-C) ───────────────────────────────────────
+
+class ChatsRequest(BaseModel):
+    connection_id: str
+    limit: Optional[int] = None
+
+
+class MessagesRequest(BaseModel):
+    connection_id: str
+    tg_chat_id: str
+    from_message_id: Optional[str] = None
+    limit: int = 100
+
+
+@app.post("/chats")
+def chats(
+    _body: ChatsRequest,
+    x_sidecar_token: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    _require_token(x_sidecar_token)
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={"error": "chats not implemented in Phase 1 PR-B"},
+    )
+
+
+@app.post("/messages")
+def messages(
+    _body: MessagesRequest,
+    x_sidecar_token: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    _require_token(x_sidecar_token)
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={"error": "messages not implemented in Phase 1 PR-B"},
+    )
+
+
+@app.get("/media/{file_unique_id}")
+def media(
+    file_unique_id: str,
+    x_sidecar_token: Optional[str] = Header(default=None),
+) -> JSONResponse:
+    _require_token(x_sidecar_token)
+    _ = file_unique_id
+    return JSONResponse(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        content={"error": "media not implemented in Phase 1 PR-B"},
+    )

--- a/services/telegram-sidecar/requirements.txt
+++ b/services/telegram-sidecar/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+pydantic==2.10.4
+telethon==1.38.1
+python-dotenv==1.0.1

--- a/src/domains/ingestion/index.ts
+++ b/src/domains/ingestion/index.ts
@@ -30,6 +30,37 @@ export {
   IngestionFeatureUnavailableError,
 } from './authz'
 
+// Runtime tunables (batch size, concurrency, media cap).
+export {
+  DEFAULT_SYNC_BATCH_SIZE,
+  MAX_SYNC_BATCH_SIZE,
+  DEFAULT_SYNC_CONCURRENCY,
+  DEFAULT_MEDIA_CONCURRENCY,
+  DEFAULT_MEDIA_MAX_BYTES,
+  DEFAULT_JOB_RETRY_LIMIT,
+  resolveIngestionRuntimeConfig,
+  type IngestionRuntimeConfig,
+} from './telegram/config'
+
+// Job handlers — pure functions exported so tests can drive them
+// with fakes, and the worker wires them with real dependencies.
+export {
+  telegramSyncHandler,
+  telegramMediaDownloadHandler,
+  MediaOversizeError,
+  type TelegramSyncDeps,
+  type TelegramSyncOutcome,
+  type TelegramMediaDownloadDeps,
+  type TelegramMediaDownloadOutcome,
+  type TelegramSyncJobData,
+  type TelegramMediaDownloadJobData,
+  type IngestionSyncDb,
+  type MediaStoreFn,
+  type MediaStoreResult,
+  type ChatWithConnection,
+  type MessageMediaWithMessage,
+} from './telegram/jobs'
+
 // Provider layer — types + factory + typed error taxonomy. The worker
 // imports `getTelegramProvider` to obtain the configured client;
 // business code only needs the types for DTO shapes and the error

--- a/src/domains/ingestion/index.ts
+++ b/src/domains/ingestion/index.ts
@@ -29,3 +29,35 @@ export {
   requireIngestionAdmin,
   IngestionFeatureUnavailableError,
 } from './authz'
+
+// Provider layer — types + factory + typed error taxonomy. The worker
+// imports `getTelegramProvider` to obtain the configured client;
+// business code only needs the types for DTO shapes and the error
+// classes for `instanceof` dispatch.
+export {
+  type TelegramIngestionProvider,
+  type TelegramIngestionProviderCode,
+  type RawTelegramChat,
+  type RawTelegramMessage,
+  type RawTelegramMessageMedia,
+  type FetchChatsInput,
+  type FetchChatsResult,
+  type FetchMessagesInput,
+  type FetchMessagesResult,
+  type FetchMediaInput,
+  type FetchMediaResult,
+  type MockFixture,
+  type TelethonHttpProviderConfig,
+  createMockProvider,
+  createTelethonHttpProvider,
+  getTelegramProvider,
+  resolveProviderCode,
+  TELEGRAM_PROVIDER_ENV,
+  TelegramProviderConfigError,
+  TelegramProviderError,
+  TelegramTransportError,
+  TelegramBadResponseError,
+  TelegramAuthRequiredError,
+  TelegramFloodWaitError,
+  TelegramChatGoneError,
+} from './telegram/providers'

--- a/src/domains/ingestion/telegram/config.ts
+++ b/src/domains/ingestion/telegram/config.ts
@@ -1,0 +1,64 @@
+/**
+ * Runtime tunables for the Telegram ingestion jobs.
+ *
+ * Every knob is env-driven with a conservative default. Concurrency
+ * is deliberately tiny in Phase 1 (1 worker per job kind, small batch,
+ * 20 MB media cap) so an ingestion runaway cannot starve the web
+ * database or blow up memory.
+ *
+ * Raising any of these values requires a Phase 6 review — see
+ * docs/ingestion/telegram.md § Decisions log.
+ */
+
+export const DEFAULT_SYNC_BATCH_SIZE = 100
+export const MAX_SYNC_BATCH_SIZE = 500
+export const DEFAULT_SYNC_CONCURRENCY = 1
+export const DEFAULT_MEDIA_CONCURRENCY = 1
+export const DEFAULT_MEDIA_MAX_BYTES = 20 * 1024 * 1024 // 20 MB
+export const DEFAULT_JOB_RETRY_LIMIT = 5
+
+export interface IngestionRuntimeConfig {
+  syncBatchSize: number
+  syncConcurrency: number
+  mediaConcurrency: number
+  mediaMaxBytes: number
+}
+
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  max: number | null = null,
+): number {
+  if (!raw) return fallback
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return fallback
+  if (max !== null && n > max) return max
+  return n
+}
+
+export function resolveIngestionRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): IngestionRuntimeConfig {
+  return {
+    syncBatchSize: parsePositiveInt(
+      env.INGESTION_TELEGRAM_BATCH_SIZE,
+      DEFAULT_SYNC_BATCH_SIZE,
+      MAX_SYNC_BATCH_SIZE,
+    ),
+    syncConcurrency: parsePositiveInt(
+      env.INGESTION_TELEGRAM_SYNC_CONCURRENCY,
+      DEFAULT_SYNC_CONCURRENCY,
+      4,
+    ),
+    mediaConcurrency: parsePositiveInt(
+      env.INGESTION_TELEGRAM_MEDIA_CONCURRENCY,
+      DEFAULT_MEDIA_CONCURRENCY,
+      4,
+    ),
+    mediaMaxBytes: parsePositiveInt(
+      env.INGESTION_TELEGRAM_MEDIA_MAX_BYTES,
+      DEFAULT_MEDIA_MAX_BYTES,
+      256 * 1024 * 1024,
+    ),
+  }
+}

--- a/src/domains/ingestion/telegram/jobs/index.ts
+++ b/src/domains/ingestion/telegram/jobs/index.ts
@@ -1,0 +1,24 @@
+export { telegramSyncHandler } from './sync'
+export type {
+  TelegramSyncDeps,
+  TelegramSyncOutcome,
+} from './sync'
+
+export {
+  telegramMediaDownloadHandler,
+  MediaOversizeError,
+} from './media-download'
+export type {
+  TelegramMediaDownloadDeps,
+  TelegramMediaDownloadOutcome,
+  MediaStoreFn,
+  MediaStoreResult,
+} from './media-download'
+
+export type {
+  TelegramSyncJobData,
+  TelegramMediaDownloadJobData,
+  IngestionSyncDb,
+  ChatWithConnection,
+  MessageMediaWithMessage,
+} from './types'

--- a/src/domains/ingestion/telegram/jobs/media-download.ts
+++ b/src/domains/ingestion/telegram/jobs/media-download.ts
@@ -1,0 +1,277 @@
+import { logger } from '@/lib/logger'
+import { generateCorrelationId } from '@/lib/correlation'
+import { isIngestionKilled } from '@/domains/ingestion/flags'
+import { INGESTION_JOB_KINDS } from '@/domains/ingestion/types'
+import {
+  TelegramAuthRequiredError,
+  TelegramChatGoneError,
+  TelegramProviderError,
+  type TelegramIngestionProvider,
+} from '@/domains/ingestion/telegram/providers'
+import type {
+  IngestionSyncDb,
+  TelegramMediaDownloadJobData,
+} from './types'
+
+/**
+ * `telegram.mediaDownload` handler — download one media item.
+ *
+ * Safety invariants (tested):
+ *
+ *   1. **Kill switch first.** Same early-exit as the sync handler.
+ *   2. **Dedupe.** If the media already has a `blobKey`, the handler
+ *      returns OK without touching the provider — Telegram often
+ *      forwards the same file across chats and we pay the transfer
+ *      cost exactly once per `fileUniqueId`.
+ *   3. **Streaming + hard cap.** The provider yields an async
+ *      iterable of bytes; we count chunks as they arrive and abort
+ *      if the running total exceeds `mediaMaxBytes`. A cap breach
+ *      marks the row `SKIPPED_OVERSIZE` and does NOT retry.
+ *   4. **Typed error routing.**
+ *        - `TelegramChatGoneError` → `SOURCE_GONE` (terminal).
+ *        - `TelegramAuthRequiredError` → `FAILED` + rethrow so the
+ *          worker surfaces the alert. Not retryable.
+ *        - Other non-retryable provider errors → `FAILED` (terminal).
+ *        - Retryable errors (Transport, FloodWait) → rethrow so
+ *          pg-boss applies its backoff policy.
+ *   5. **Never writes business tables.**
+ */
+
+const LOG_SCOPE = 'ingestion.telegram.media'
+
+export interface MediaStoreResult {
+  blobKey: string
+  sizeBytes: number
+  mimeType: string | null
+}
+
+/** Pluggable blob writer so tests don't touch disk. */
+export type MediaStoreFn = (input: {
+  fileUniqueId: string
+  stream: AsyncIterable<Uint8Array>
+  mimeType: string | null
+  sizeHintBytes: number | null
+  maxBytes: number
+}) => Promise<MediaStoreResult>
+
+export interface TelegramMediaDownloadDeps {
+  db: IngestionSyncDb
+  provider: TelegramIngestionProvider
+  store: MediaStoreFn
+  now: () => Date
+  mediaMaxBytes: number
+  isKilled?: (ctx: {
+    correlationId: string
+    messageMediaId: string
+  }) => Promise<boolean>
+}
+
+export interface TelegramMediaDownloadOutcome {
+  status: 'KILLED' | 'ALREADY_DONE' | 'OK' | 'SKIPPED_OVERSIZE' | 'SOURCE_GONE' | 'FAILED'
+  messageMediaId: string
+  correlationId: string
+  sizeBytes: number | null
+}
+
+export class MediaOversizeError extends Error {
+  constructor(readonly limitBytes: number, readonly observedBytes: number) {
+    super(`media exceeds ${limitBytes}B cap (observed ≥ ${observedBytes}B)`)
+    this.name = 'MediaOversizeError'
+  }
+}
+
+export async function telegramMediaDownloadHandler(
+  data: TelegramMediaDownloadJobData,
+  deps: TelegramMediaDownloadDeps,
+): Promise<TelegramMediaDownloadOutcome> {
+  const correlationId = data.correlationId ?? generateCorrelationId()
+  const isKilledFn = deps.isKilled ?? defaultKillProbe
+
+  if (await isKilledFn({ correlationId, messageMediaId: data.messageMediaId })) {
+    return result('KILLED', data.messageMediaId, correlationId, null)
+  }
+
+  const media = await deps.db.telegramIngestionMessageMedia.findUnique({
+    where: { id: data.messageMediaId },
+    include: {
+      message: { include: { chat: { include: { connection: true } } } },
+    },
+  })
+  if (!media) {
+    logger.warn(`${LOG_SCOPE}.not_found`, {
+      messageMediaId: data.messageMediaId,
+      correlationId,
+    })
+    return result('FAILED', data.messageMediaId, correlationId, null)
+  }
+
+  // Dedupe: if we already have a blob key, we're done. Telegram
+  // forwards are common — one fileUniqueId → one blob → many
+  // messages.
+  if (media.blobKey) {
+    logger.info(`${LOG_SCOPE}.already_downloaded`, {
+      messageMediaId: media.id,
+      fileUniqueId: media.fileUniqueId,
+      correlationId,
+    })
+    return result('ALREADY_DONE', media.id, correlationId, media.sizeBytes ?? null)
+  }
+
+  // Cheap pre-check: if the provider hinted a size and it's already
+  // over the cap, don't even open the socket.
+  if (media.sizeBytes !== null && media.sizeBytes > deps.mediaMaxBytes) {
+    await deps.db.telegramIngestionMessageMedia.update({
+      where: { id: media.id },
+      data: {
+        status: 'SKIPPED_OVERSIZE',
+        lastErrorMsg: `pre-check: ${media.sizeBytes}B > ${deps.mediaMaxBytes}B`,
+      },
+    })
+    logger.info(`${LOG_SCOPE}.skipped_oversize_precheck`, {
+      messageMediaId: media.id,
+      sizeBytes: media.sizeBytes,
+      cap: deps.mediaMaxBytes,
+      correlationId,
+    })
+    return result('SKIPPED_OVERSIZE', media.id, correlationId, media.sizeBytes)
+  }
+
+  const connectionId = media.message.chat.connectionId
+  logger.info(`${LOG_SCOPE}.started`, {
+    messageMediaId: media.id,
+    fileUniqueId: media.fileUniqueId,
+    correlationId,
+  })
+
+  try {
+    const fetched = await deps.provider.fetchMedia({
+      connectionId,
+      fileUniqueId: media.fileUniqueId,
+    })
+    const stored = await deps.store({
+      fileUniqueId: media.fileUniqueId,
+      stream: fetched.stream,
+      mimeType: fetched.mimeType,
+      sizeHintBytes: fetched.sizeBytes,
+      maxBytes: deps.mediaMaxBytes,
+    })
+
+    await deps.db.telegramIngestionMessageMedia.update({
+      where: { id: media.id },
+      data: {
+        status: 'DOWNLOADED',
+        blobKey: stored.blobKey,
+        sizeBytes: stored.sizeBytes,
+        mimeType: stored.mimeType ?? media.mimeType ?? undefined,
+        downloadedAt: deps.now(),
+      },
+    })
+    logger.info(`${LOG_SCOPE}.ok`, {
+      messageMediaId: media.id,
+      fileUniqueId: media.fileUniqueId,
+      sizeBytes: stored.sizeBytes,
+      correlationId,
+    })
+    return result('OK', media.id, correlationId, stored.sizeBytes)
+  } catch (err) {
+    if (err instanceof MediaOversizeError) {
+      await deps.db.telegramIngestionMessageMedia.update({
+        where: { id: media.id },
+        data: {
+          status: 'SKIPPED_OVERSIZE',
+          lastErrorMsg: err.message.slice(0, 500),
+        },
+      })
+      logger.warn(`${LOG_SCOPE}.skipped_oversize`, {
+        messageMediaId: media.id,
+        correlationId,
+        error: err.message,
+      })
+      return result('SKIPPED_OVERSIZE', media.id, correlationId, err.observedBytes)
+    }
+
+    if (err instanceof TelegramChatGoneError) {
+      await deps.db.telegramIngestionMessageMedia.update({
+        where: { id: media.id },
+        data: {
+          status: 'SOURCE_GONE',
+          lastErrorMsg: err.message.slice(0, 500),
+        },
+      })
+      logger.warn(`${LOG_SCOPE}.source_gone`, {
+        messageMediaId: media.id,
+        correlationId,
+      })
+      return result('SOURCE_GONE', media.id, correlationId, null)
+    }
+
+    if (err instanceof TelegramAuthRequiredError) {
+      await deps.db.telegramIngestionMessageMedia.update({
+        where: { id: media.id },
+        data: {
+          status: 'FAILED',
+          lastErrorMsg: err.message.slice(0, 500),
+        },
+      })
+      logger.error(`${LOG_SCOPE}.auth_required`, {
+        messageMediaId: media.id,
+        correlationId,
+        error: err,
+      })
+      throw err
+    }
+
+    if (err instanceof TelegramProviderError && !err.retryable) {
+      await deps.db.telegramIngestionMessageMedia.update({
+        where: { id: media.id },
+        data: {
+          status: 'FAILED',
+          lastErrorMsg: err.message.slice(0, 500),
+        },
+      })
+      logger.error(`${LOG_SCOPE}.failed_terminal`, {
+        messageMediaId: media.id,
+        correlationId,
+        error: err,
+      })
+      return result('FAILED', media.id, correlationId, null)
+    }
+
+    // Retryable — record last-error diagnostics but leave status as
+    // PENDING so the next attempt can pick up cleanly.
+    await deps.db.telegramIngestionMessageMedia.update({
+      where: { id: media.id },
+      data: {
+        lastErrorMsg: (err instanceof Error ? err.message : String(err)).slice(
+          0,
+          500,
+        ),
+      },
+    })
+    logger.warn(`${LOG_SCOPE}.retryable_error`, {
+      messageMediaId: media.id,
+      correlationId,
+      error: err,
+    })
+    throw err
+  }
+}
+
+function result(
+  status: TelegramMediaDownloadOutcome['status'],
+  messageMediaId: string,
+  correlationId: string,
+  sizeBytes: number | null,
+): TelegramMediaDownloadOutcome {
+  return { status, messageMediaId, correlationId, sizeBytes }
+}
+
+async function defaultKillProbe(ctx: {
+  correlationId: string
+  messageMediaId: string
+}): Promise<boolean> {
+  return isIngestionKilled(undefined, {
+    correlationId: ctx.correlationId,
+    jobKind: INGESTION_JOB_KINDS.telegramMediaDownload,
+  })
+}

--- a/src/domains/ingestion/telegram/jobs/sync.ts
+++ b/src/domains/ingestion/telegram/jobs/sync.ts
@@ -1,0 +1,338 @@
+import { logger } from '@/lib/logger'
+import { generateCorrelationId } from '@/lib/correlation'
+import { isIngestionKilled } from '@/domains/ingestion/flags'
+import { INGESTION_JOB_KINDS } from '@/domains/ingestion/types'
+import {
+  TelegramChatGoneError,
+  TelegramProviderError,
+  type FetchMessagesResult,
+  type RawTelegramMessageMedia,
+  type TelegramIngestionProvider,
+} from '@/domains/ingestion/telegram/providers'
+import type {
+  ChatWithConnection,
+  IngestionSyncDb,
+  TelegramSyncJobData,
+} from './types'
+
+/**
+ * `telegram.sync` handler — incremental fetch of one chat.
+ *
+ * Safety invariants (tested):
+ *
+ *   1. **Kill switch first.** The very first operation is the kill
+ *      check; if killed, the handler returns before any I/O.
+ *   2. **Strictly incremental.** `fromMessageId` is the previously
+ *      persisted cursor, so we never re-pull history. If the cursor
+ *      is `null` the provider is free to return the newest window;
+ *      expanding that window into a backfill is explicitly out of
+ *      scope and has to be a manual admin tool in a later phase.
+ *   3. **Atomic batch.** Message upserts, media-row upserts, cursor
+ *      advance, and sync-run bookkeeping run in one transaction.
+ *      Mid-batch crash → rollback → next run re-reads → `@@unique`
+ *      dedupes. No gaps, no duplicates.
+ *   4. **No side effects outside raw tables.** Never writes to
+ *      Product / Vendor / ProductImage. Media download is a
+ *      separate job that the worker enqueues best-effort after the
+ *      transaction commits.
+ */
+
+const LOG_SCOPE = 'ingestion.telegram.sync'
+
+export interface TelegramSyncDeps {
+  db: IngestionSyncDb
+  provider: TelegramIngestionProvider
+  enqueueMediaDownload: (input: {
+    messageMediaId: string
+    fileUniqueId: string
+    correlationId: string
+  }) => Promise<void>
+  now: () => Date
+  batchSize: number
+  /** Injected kill-switch probe so tests don't depend on PostHog.
+   *  Defaults to the real helper. */
+  isKilled?: (ctx: { correlationId: string; chatId: string }) => Promise<boolean>
+}
+
+export interface TelegramSyncOutcome {
+  status: 'KILLED' | 'CHAT_DISABLED' | 'OK' | 'FAILED'
+  syncRunId: string | null
+  messagesFetched: number
+  mediaQueued: number
+  correlationId: string
+}
+
+export async function telegramSyncHandler(
+  data: TelegramSyncJobData,
+  deps: TelegramSyncDeps,
+): Promise<TelegramSyncOutcome> {
+  const correlationId = data.correlationId ?? generateCorrelationId()
+  const isKilledFn = deps.isKilled ?? defaultKillProbe
+
+  // 1. Kill switch — BEFORE any I/O.
+  if (await isKilledFn({ correlationId, chatId: data.chatId })) {
+    return {
+      status: 'KILLED',
+      syncRunId: null,
+      messagesFetched: 0,
+      mediaQueued: 0,
+      correlationId,
+    }
+  }
+
+  // 2. Load chat. Missing or disabled chats short-circuit without a
+  //    sync-run row; logging makes the skip obvious for operators.
+  const chat = await deps.db.telegramIngestionChat.findUnique({
+    where: { id: data.chatId },
+    include: { connection: true },
+  })
+  if (!chat) {
+    logger.warn(`${LOG_SCOPE}.chat_not_found`, {
+      chatId: data.chatId,
+      correlationId,
+    })
+    return outcome('CHAT_DISABLED', null, 0, 0, correlationId)
+  }
+  if (!chat.isEnabled) {
+    logger.info(`${LOG_SCOPE}.skipped_disabled`, {
+      chatId: chat.id,
+      correlationId,
+    })
+    return outcome('CHAT_DISABLED', null, 0, 0, correlationId)
+  }
+  if (chat.connection.status !== 'ACTIVE') {
+    logger.info(`${LOG_SCOPE}.skipped_inactive_connection`, {
+      chatId: chat.id,
+      connectionStatus: chat.connection.status,
+      correlationId,
+    })
+    return outcome('CHAT_DISABLED', null, 0, 0, correlationId)
+  }
+
+  // 3. Open a sync-run row. Failures from here on must mark this row
+  //    FAILED so operators see the error tail in the admin panel.
+  const run = await deps.db.telegramIngestionSyncRun.create({
+    data: {
+      chatId: chat.id,
+      correlationId,
+      fromMessageId: chat.lastMessageId ?? null,
+    },
+  })
+  logger.info(`${LOG_SCOPE}.started`, {
+    syncRunId: run.id,
+    chatId: chat.id,
+    fromMessageId: chat.lastMessageId?.toString() ?? null,
+    batchSize: deps.batchSize,
+    correlationId,
+  })
+
+  // 4. Fetch + persist in one transaction.
+  try {
+    const fetched = await deps.provider.fetchMessages({
+      connectionId: chat.connection.id,
+      tgChatId: chat.tgChatId.toString(),
+      fromMessageId: chat.lastMessageId?.toString() ?? null,
+      limit: deps.batchSize,
+    })
+
+    const { mediaQueued } = await persistBatch({
+      chat,
+      fetched,
+      deps,
+      correlationId,
+    })
+
+    await deps.db.telegramIngestionSyncRun.update({
+      where: { id: run.id },
+      data: {
+        status: 'OK',
+        finishedAt: deps.now(),
+        messagesFetched: fetched.messages.length,
+        mediaFetched: mediaQueued,
+        toMessageId:
+          fetched.nextFromMessageId !== null
+            ? BigInt(fetched.nextFromMessageId)
+            : null,
+      },
+    })
+
+    logger.info(`${LOG_SCOPE}.ok`, {
+      syncRunId: run.id,
+      chatId: chat.id,
+      messagesFetched: fetched.messages.length,
+      mediaQueued,
+      nextFromMessageId: fetched.nextFromMessageId,
+      correlationId,
+    })
+
+    return outcome('OK', run.id, fetched.messages.length, mediaQueued, correlationId)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await deps.db.telegramIngestionSyncRun.update({
+      where: { id: run.id },
+      data: {
+        status: 'FAILED',
+        finishedAt: deps.now(),
+        errorMessage: errorMessage.slice(0, 2_000),
+      },
+    })
+
+    // Chat-gone is a permanent terminal state — disable the chat so
+    // future scheduled syncs don't thrash against a removed target.
+    if (err instanceof TelegramChatGoneError) {
+      await deps.db.telegramIngestionChat.update({
+        where: { id: chat.id },
+        data: {
+          isEnabled: false,
+          disabledReason: err.message.slice(0, 500),
+        },
+      })
+      logger.warn(`${LOG_SCOPE}.chat_gone_disabled`, {
+        syncRunId: run.id,
+        chatId: chat.id,
+        correlationId,
+      })
+      return outcome('FAILED', run.id, 0, 0, correlationId)
+    }
+
+    logger.error(`${LOG_SCOPE}.failed`, {
+      syncRunId: run.id,
+      chatId: chat.id,
+      correlationId,
+      error: err,
+      retryable:
+        err instanceof TelegramProviderError ? err.retryable : true,
+    })
+    // Rethrow so pg-boss records the failure and retries per policy.
+    throw err
+  }
+}
+
+async function persistBatch(input: {
+  chat: ChatWithConnection
+  fetched: FetchMessagesResult
+  deps: TelegramSyncDeps
+  correlationId: string
+}): Promise<{ mediaQueued: number }> {
+  const { chat, fetched, deps, correlationId } = input
+  const mediaToEnqueue: Array<{ messageMediaId: string; fileUniqueId: string }> = []
+  // Dedupe within the batch: if two messages reference the same
+  // fileUniqueId, upsert returns the same PENDING row both times,
+  // but we only want one download job.
+  const alreadyQueued = new Set<string>()
+
+  await deps.db.$transaction(async (tx) => {
+    for (const msg of fetched.messages) {
+      const createdMessage = await tx.telegramIngestionMessage.upsert({
+        where: {
+          chatId_tgMessageId: {
+            chatId: chat.id,
+            tgMessageId: BigInt(msg.tgMessageId),
+          },
+        },
+        create: {
+          chatId: chat.id,
+          tgMessageId: BigInt(msg.tgMessageId),
+          tgAuthorId: msg.tgAuthorId !== null ? BigInt(msg.tgAuthorId) : null,
+          text: msg.text,
+          postedAt: new Date(msg.postedAt),
+          rawJson: msg.raw,
+        },
+        update: {}, // existing rows preserved (including tombstones)
+      })
+
+      for (const media of msg.media) {
+        const mediaRow = await tx.telegramIngestionMessageMedia.upsert({
+          where: { fileUniqueId: media.fileUniqueId },
+          create: mediaCreateInput(createdMessage.id, media),
+          update: {},
+        })
+        // Enqueue a download only if the row is still PENDING AND
+        // we haven't already queued it earlier in this batch.
+        // Already-downloaded media is left alone (dedupe invariant).
+        if (
+          mediaRow.status === 'PENDING' &&
+          mediaRow.blobKey === null &&
+          !alreadyQueued.has(media.fileUniqueId)
+        ) {
+          alreadyQueued.add(media.fileUniqueId)
+          mediaToEnqueue.push({
+            messageMediaId: mediaRow.id,
+            fileUniqueId: media.fileUniqueId,
+          })
+        }
+      }
+    }
+
+    // 5. Advance cursor. Only when the batch committed; a throw
+    //    above rolls back together with all the upserts.
+    if (fetched.nextFromMessageId !== null) {
+      await tx.telegramIngestionChat.update({
+        where: { id: chat.id },
+        data: { lastMessageId: BigInt(fetched.nextFromMessageId) },
+      })
+    }
+  })
+
+  // 6. Best-effort media enqueue AFTER commit so we never tie up a
+  //    DB transaction on queue I/O.
+  let queued = 0
+  for (const m of mediaToEnqueue) {
+    try {
+      await deps.enqueueMediaDownload({ ...m, correlationId })
+      queued++
+    } catch (err) {
+      // Leaving the media row as PENDING is the correct state; a
+      // later sweeper (Phase 6) picks it up. Logged loudly so
+      // operators notice queue issues.
+      logger.warn(`${LOG_SCOPE}.media_enqueue_failed`, {
+        messageMediaId: m.messageMediaId,
+        fileUniqueId: m.fileUniqueId,
+        error: err,
+        correlationId,
+      })
+    }
+  }
+
+  return { mediaQueued: queued }
+}
+
+function mediaCreateInput(
+  messageId: string,
+  media: RawTelegramMessageMedia,
+): {
+  messageId: string
+  fileUniqueId: string
+  kind: 'PHOTO' | 'VIDEO' | 'DOCUMENT' | 'OTHER'
+  mimeType: string | null
+  sizeBytes: number | null
+} {
+  return {
+    messageId,
+    fileUniqueId: media.fileUniqueId,
+    kind: media.kind,
+    mimeType: media.mimeType,
+    sizeBytes: media.sizeBytes,
+  }
+}
+
+function outcome(
+  status: TelegramSyncOutcome['status'],
+  syncRunId: string | null,
+  messagesFetched: number,
+  mediaQueued: number,
+  correlationId: string,
+): TelegramSyncOutcome {
+  return { status, syncRunId, messagesFetched, mediaQueued, correlationId }
+}
+
+async function defaultKillProbe(ctx: {
+  correlationId: string
+  chatId: string
+}): Promise<boolean> {
+  return isIngestionKilled(undefined, {
+    correlationId: ctx.correlationId,
+    chatId: ctx.chatId,
+    jobKind: INGESTION_JOB_KINDS.telegramSync,
+  })
+}

--- a/src/domains/ingestion/telegram/jobs/types.ts
+++ b/src/domains/ingestion/telegram/jobs/types.ts
@@ -1,0 +1,170 @@
+/**
+ * Job payload shapes + handler-dependency interfaces.
+ *
+ * Handlers are written as pure functions that accept a `deps` object
+ * so tests inject a fake db / provider / clock without touching real
+ * infrastructure. Production wrappers in `src/workers/jobs/*.ts` wire
+ * the same handlers to the real `db`, provider registry, and queue.
+ */
+
+export interface TelegramSyncJobData {
+  chatId: string
+  /** Optional correlation id forwarded from the enqueuing request so
+   *  one admin "trigger sync" trace threads through the worker. */
+  correlationId?: string
+}
+
+export interface TelegramMediaDownloadJobData {
+  messageMediaId: string
+  correlationId?: string
+}
+
+// ─── Row shapes the handlers read ────────────────────────────────────────────
+//
+// Defined locally so tests don't have to reach into the generated
+// Prisma types. The real Prisma rows are a superset; assignment
+// works because every field declared here also exists on the
+// generated model row.
+
+export interface TelegramIngestionChatRow {
+  id: string
+  connectionId: string
+  tgChatId: bigint
+  title: string
+  kind: 'GROUP' | 'SUPERGROUP' | 'CHANNEL'
+  lastMessageId: bigint | null
+  isEnabled: boolean
+  disabledReason: string | null
+}
+
+export interface ChatWithConnection extends TelegramIngestionChatRow {
+  connection: { id: string; status: string }
+}
+
+export interface TelegramIngestionMessageRow {
+  id: string
+  chatId: string
+  tgMessageId: bigint
+}
+
+export interface TelegramIngestionMessageMediaRow {
+  id: string
+  messageId: string
+  fileUniqueId: string
+  kind: 'PHOTO' | 'VIDEO' | 'DOCUMENT' | 'OTHER'
+  status:
+    | 'PENDING'
+    | 'DOWNLOADED'
+    | 'SKIPPED_OVERSIZE'
+    | 'SOURCE_GONE'
+    | 'FAILED'
+  blobKey: string | null
+  sizeBytes: number | null
+  mimeType: string | null
+}
+
+export interface MessageMediaWithMessage extends TelegramIngestionMessageMediaRow {
+  message: {
+    chatId: string
+    chat: {
+      connectionId: string
+      tgChatId: bigint
+      connection: { id: string; status: string }
+    }
+  }
+}
+
+export interface TelegramIngestionSyncRunRow {
+  id: string
+  chatId: string
+}
+
+// ─── Narrow DB interface ─────────────────────────────────────────────────────
+//
+// Only the surface the handlers call. The real `db` from `@/lib/db`
+// is a superset; a test fake only implements what the test drives.
+
+export interface IngestionSyncDb {
+  telegramIngestionChat: {
+    findUnique(args: {
+      where: { id: string }
+      include?: { connection: true }
+    }): Promise<ChatWithConnection | null>
+    update(args: {
+      where: { id: string }
+      data: { lastMessageId?: bigint; disabledReason?: string; isEnabled?: boolean }
+    }): Promise<TelegramIngestionChatRow>
+  }
+  telegramIngestionSyncRun: {
+    create(args: {
+      data: {
+        chatId: string
+        correlationId: string
+        fromMessageId?: bigint | null
+      }
+    }): Promise<TelegramIngestionSyncRunRow>
+    update(args: {
+      where: { id: string }
+      data: Partial<{
+        status: 'RUNNING' | 'OK' | 'FAILED' | 'CANCELLED'
+        finishedAt: Date
+        toMessageId: bigint | null
+        messagesFetched: number
+        mediaFetched: number
+        errorMessage: string
+      }>
+    }): Promise<TelegramIngestionSyncRunRow>
+  }
+  telegramIngestionMessage: {
+    upsert(args: {
+      where: { chatId_tgMessageId: { chatId: string; tgMessageId: bigint } }
+      create: {
+        chatId: string
+        tgMessageId: bigint
+        tgAuthorId: bigint | null
+        text: string | null
+        postedAt: Date
+        rawJson: unknown
+      }
+      update: Record<string, never>
+    }): Promise<TelegramIngestionMessageRow>
+  }
+  telegramIngestionMessageMedia: {
+    upsert(args: {
+      where: { fileUniqueId: string }
+      create: {
+        messageId: string
+        fileUniqueId: string
+        kind: 'PHOTO' | 'VIDEO' | 'DOCUMENT' | 'OTHER'
+        mimeType: string | null
+        sizeBytes: number | null
+      }
+      update: Record<string, never>
+    }): Promise<TelegramIngestionMessageMediaRow>
+    findUnique(args: {
+      where: { id: string }
+      include?: {
+        message: {
+          include: { chat: { include: { connection: true } } }
+        }
+      }
+    }): Promise<MessageMediaWithMessage | null>
+    update(args: {
+      where: { id: string }
+      data: Partial<{
+        status:
+          | 'PENDING'
+          | 'DOWNLOADED'
+          | 'SKIPPED_OVERSIZE'
+          | 'SOURCE_GONE'
+          | 'FAILED'
+        blobKey: string
+        sizeBytes: number
+        mimeType: string
+        downloadedAt: Date
+        lastErrorMsg: string
+      }>
+    }): Promise<TelegramIngestionMessageMediaRow>
+  }
+  $transaction<T>(fn: (tx: IngestionSyncDb) => Promise<T>): Promise<T>
+}

--- a/src/domains/ingestion/telegram/providers/errors.ts
+++ b/src/domains/ingestion/telegram/providers/errors.ts
@@ -1,0 +1,100 @@
+/**
+ * Typed error taxonomy for Telegram ingestion providers.
+ *
+ * The worker dispatches on these classes: flood-wait is retryable
+ * after a bounded delay, auth-required needs operator action,
+ * transport errors retry with backoff, chat-gone disables the chat.
+ * Every provider — mock, HTTP, future direct — throws one of these
+ * so handler code never has to branch on raw strings.
+ */
+
+export abstract class TelegramProviderError extends Error {
+  abstract readonly code: string
+  /**
+   * Worker-level retry hint. `false` means the job should fail the
+   * current attempt without retrying; `true` means pg-boss should
+   * retry per the configured backoff policy.
+   */
+  abstract readonly retryable: boolean
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = this.constructor.name
+  }
+}
+
+/**
+ * Transport-level failure reaching the sidecar: timeout, connection
+ * refused, 5xx with no structured body. Always retryable.
+ */
+export class TelegramTransportError extends TelegramProviderError {
+  readonly code = 'TRANSPORT'
+  readonly retryable = true
+  constructor(
+    message: string,
+    readonly httpStatus: number | null = null,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options)
+  }
+}
+
+/**
+ * Sidecar answered, but the shape did not match the contract.
+ * Indicates an SDK / sidecar version drift. Not retryable — the
+ * caller should surface it loudly.
+ */
+export class TelegramBadResponseError extends TelegramProviderError {
+  readonly code = 'BAD_RESPONSE'
+  readonly retryable = false
+}
+
+/**
+ * Telethon session expired / 2FA rotation / bot kicked from the
+ * account. Needs an operator to re-auth via the admin UI (PR-D).
+ * Not retryable by the worker.
+ */
+export class TelegramAuthRequiredError extends TelegramProviderError {
+  readonly code = 'AUTH_REQUIRED'
+  readonly retryable = false
+  constructor(
+    message: string,
+    readonly connectionId: string | null = null,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options)
+  }
+}
+
+/**
+ * Telegram rate-limit response (`FLOOD_WAIT_X`). `retryAfterSeconds`
+ * is the amount Telegram told us to wait. The worker uses this to
+ * reschedule the job instead of retrying immediately.
+ */
+export class TelegramFloodWaitError extends TelegramProviderError {
+  readonly code = 'FLOOD_WAIT'
+  readonly retryable = true
+  constructor(
+    message: string,
+    readonly retryAfterSeconds: number,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options)
+  }
+}
+
+/**
+ * Chat was deleted, archived, or the ingestion account was removed.
+ * Not retryable — the worker disables the chat and logs a loud event.
+ */
+export class TelegramChatGoneError extends TelegramProviderError {
+  readonly code = 'CHAT_GONE'
+  readonly retryable = false
+  constructor(
+    message: string,
+    readonly tgChatId: string | null = null,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options)
+  }
+}

--- a/src/domains/ingestion/telegram/providers/index.ts
+++ b/src/domains/ingestion/telegram/providers/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Public surface of the Telegram ingestion provider layer. The
+ * top-level ingestion barrel re-exports from here so consumers
+ * never deep-import into individual files.
+ */
+
+export type {
+  TelegramIngestionProvider,
+  TelegramIngestionProviderCode,
+  RawTelegramChat,
+  RawTelegramMessage,
+  RawTelegramMessageMedia,
+  FetchChatsInput,
+  FetchChatsResult,
+  FetchMessagesInput,
+  FetchMessagesResult,
+  FetchMediaInput,
+  FetchMediaResult,
+} from './types'
+
+export {
+  TelegramProviderError,
+  TelegramTransportError,
+  TelegramBadResponseError,
+  TelegramAuthRequiredError,
+  TelegramFloodWaitError,
+  TelegramChatGoneError,
+} from './errors'
+
+export { createMockProvider, type MockFixture } from './mock'
+export { createTelethonHttpProvider, type TelethonHttpProviderConfig } from './telethon-http'
+export {
+  getTelegramProvider,
+  resolveProviderCode,
+  TELEGRAM_PROVIDER_ENV,
+  TelegramProviderConfigError,
+} from './registry'

--- a/src/domains/ingestion/telegram/providers/mock.ts
+++ b/src/domains/ingestion/telegram/providers/mock.ts
@@ -1,0 +1,97 @@
+import type {
+  FetchChatsInput,
+  FetchChatsResult,
+  FetchMediaInput,
+  FetchMediaResult,
+  FetchMessagesInput,
+  FetchMessagesResult,
+  RawTelegramChat,
+  RawTelegramMessage,
+  TelegramIngestionProvider,
+} from './types'
+import { TelegramChatGoneError } from './errors'
+
+/**
+ * Deterministic in-memory provider. Default in dev and tests.
+ *
+ * The fixture is a simple Map of chats → messages. Tests can pass
+ * their own fixture to `createMockProvider` to drive scenarios.
+ * Cursor semantics mirror the contract: `fromMessageId=null` returns
+ * the newest batch; otherwise returns messages with `tgMessageId > fromMessageId`.
+ * Messages are sorted ascending so the batch's last id is the next cursor.
+ */
+
+export interface MockFixture {
+  chats: RawTelegramChat[]
+  /** Keyed by tgChatId. */
+  messages: Record<string, RawTelegramMessage[]>
+  /** Media bytes keyed by fileUniqueId. */
+  media?: Record<string, Uint8Array>
+}
+
+const EMPTY_FIXTURE: MockFixture = { chats: [], messages: {} }
+
+export function createMockProvider(
+  fixture: MockFixture = EMPTY_FIXTURE,
+): TelegramIngestionProvider {
+  return {
+    code: 'mock',
+
+    async fetchChats({ limit }: FetchChatsInput): Promise<FetchChatsResult> {
+      const chats = limit ? fixture.chats.slice(0, limit) : fixture.chats
+      return { chats }
+    },
+
+    async fetchMessages({
+      tgChatId,
+      fromMessageId,
+      limit,
+    }: FetchMessagesInput): Promise<FetchMessagesResult> {
+      const all = fixture.messages[tgChatId]
+      if (!all) {
+        throw new TelegramChatGoneError(
+          `mock: unknown chat ${tgChatId}`,
+          tgChatId,
+        )
+      }
+      // Sort ascending by numeric id so cursor advance is deterministic.
+      const sorted = [...all].sort((a, b) => numericCompare(a.tgMessageId, b.tgMessageId))
+      const filtered =
+        fromMessageId === null
+          ? sorted
+          : sorted.filter((m) => numericCompare(m.tgMessageId, fromMessageId) > 0)
+      const batch = filtered.slice(0, limit)
+      const last = batch[batch.length - 1]
+      return {
+        messages: batch,
+        nextFromMessageId: last ? last.tgMessageId : null,
+      }
+    },
+
+    async fetchMedia({ fileUniqueId }: FetchMediaInput): Promise<FetchMediaResult> {
+      const bytes = fixture.media?.[fileUniqueId]
+      if (!bytes) {
+        throw new TelegramChatGoneError(
+          `mock: unknown media ${fileUniqueId}`,
+        )
+      }
+      // Wrap in a single-chunk async iterable so tests exercise the
+      // streaming contract even with tiny payloads.
+      return {
+        stream: (async function* () {
+          yield bytes
+        })(),
+        mimeType: 'application/octet-stream',
+        sizeBytes: bytes.byteLength,
+      }
+    },
+  }
+}
+
+function numericCompare(a: string, b: string): number {
+  // Compare as BigInt because string compare misorders unequal-length
+  // decimal strings (e.g. "9" vs "10").
+  const ba = BigInt(a)
+  const bb = BigInt(b)
+  return ba < bb ? -1 : ba > bb ? 1 : 0
+}

--- a/src/domains/ingestion/telegram/providers/registry.ts
+++ b/src/domains/ingestion/telegram/providers/registry.ts
@@ -1,0 +1,68 @@
+import type { TelegramIngestionProvider, TelegramIngestionProviderCode } from './types'
+import { createMockProvider } from './mock'
+import { createTelethonHttpProvider } from './telethon-http'
+
+/**
+ * Lazy factory for the Telegram ingestion provider.
+ *
+ * Selected by `INGESTION_TELEGRAM_PROVIDER`:
+ *   - `mock` (default) — in-memory fixtures; no I/O.
+ *   - `telethon` — HTTP bridge to the Python sidecar.
+ *
+ * Module-level state is intentionally absent: calling `getProvider`
+ * without env vars does not open sockets, does not read files, and
+ * does not cache. The worker invokes this once per job; overhead is
+ * trivial compared to the network cost of the job itself.
+ */
+
+export const TELEGRAM_PROVIDER_ENV = 'INGESTION_TELEGRAM_PROVIDER'
+
+export class TelegramProviderConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TelegramProviderConfigError'
+  }
+}
+
+export function resolveProviderCode(
+  env: Record<string, string | undefined> = process.env,
+): TelegramIngestionProviderCode {
+  const raw = env[TELEGRAM_PROVIDER_ENV]?.trim().toLowerCase()
+  if (!raw || raw === 'mock') return 'mock'
+  if (raw === 'telethon') return 'telethon'
+  throw new TelegramProviderConfigError(
+    `Invalid ${TELEGRAM_PROVIDER_ENV}=${raw} (expected "mock" or "telethon")`,
+  )
+}
+
+export function getTelegramProvider(
+  env: Record<string, string | undefined> = process.env,
+): TelegramIngestionProvider {
+  const code = resolveProviderCode(env)
+  if (code === 'mock') {
+    // An empty fixture in production is deliberate: if someone ever
+    // runs the worker without opting into `telethon`, the mock returns
+    // no data rather than silently syncing fabricated messages.
+    return createMockProvider()
+  }
+
+  const baseUrl = env.TELEGRAM_SIDECAR_URL?.trim()
+  const sharedSecret = env.TELEGRAM_SIDECAR_TOKEN?.trim()
+  if (!baseUrl || !sharedSecret) {
+    throw new TelegramProviderConfigError(
+      `${TELEGRAM_PROVIDER_ENV}=telethon requires TELEGRAM_SIDECAR_URL and TELEGRAM_SIDECAR_TOKEN`,
+    )
+  }
+  const timeoutMs = parseIntOr(env.TELEGRAM_SIDECAR_TIMEOUT_MS, 15_000)
+  return createTelethonHttpProvider({
+    baseUrl,
+    sharedSecret,
+    timeoutMs,
+  })
+}
+
+function parseIntOr(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}

--- a/src/domains/ingestion/telegram/providers/telethon-http.ts
+++ b/src/domains/ingestion/telegram/providers/telethon-http.ts
@@ -1,0 +1,348 @@
+import { logger } from '@/lib/logger'
+import {
+  TelegramAuthRequiredError,
+  TelegramBadResponseError,
+  TelegramChatGoneError,
+  TelegramFloodWaitError,
+  TelegramProviderError,
+  TelegramTransportError,
+} from './errors'
+import type {
+  FetchChatsInput,
+  FetchChatsResult,
+  FetchMediaInput,
+  FetchMediaResult,
+  FetchMessagesInput,
+  FetchMessagesResult,
+  TelegramIngestionProvider,
+} from './types'
+
+/**
+ * HTTP bridge to the Python Telethon sidecar.
+ *
+ * Deployment invariant: this client must only be reachable by the
+ * worker process, and the sidecar itself must only bind to a
+ * private network / loopback. See services/telegram-sidecar/README.md
+ * and docs/ingestion/telegram.md § "How to verify zero runtime
+ * impact" for the contract operators commit to.
+ *
+ * Behaviour:
+ *
+ *   - `AbortController` per request with a configurable timeout.
+ *   - Exponential retry (x3) on TelegramTransportError only.
+ *     Flood-wait, auth-required, chat-gone, and bad-response never
+ *     retry here — they bubble to the worker, which handles them
+ *     with different strategies (reschedule, disable, alert).
+ *   - Shared-secret auth via `X-Sidecar-Token`.
+ *   - Structured logs on every request (`ingestion.telegram.http.*`)
+ *     with a correlation id so oncall can trace one sync run end to
+ *     end even when the sidecar is a separate process.
+ */
+
+const LOG_SCOPE = 'ingestion.telegram.http'
+const USER_AGENT = 'marketplace-ingestion/1.0'
+
+export interface TelethonHttpProviderConfig {
+  baseUrl: string
+  sharedSecret: string
+  timeoutMs: number
+  maxAttempts?: number
+  /** Custom fetch, primarily for tests. */
+  fetchImpl?: typeof fetch
+}
+
+export function createTelethonHttpProvider(
+  config: TelethonHttpProviderConfig,
+): TelegramIngestionProvider {
+  const maxAttempts = config.maxAttempts ?? 3
+  const fetchImpl = config.fetchImpl ?? fetch
+
+  async function request<T>(
+    path: string,
+    init: RequestInit,
+    correlationId: string,
+  ): Promise<T> {
+    const url = `${config.baseUrl.replace(/\/$/, '')}${path}`
+    let lastErr: unknown = null
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), config.timeoutMs)
+      try {
+        logger.info(`${LOG_SCOPE}.request`, {
+          path,
+          attempt,
+          correlationId,
+        })
+        const res = await fetchImpl(url, {
+          ...init,
+          signal: controller.signal,
+          headers: {
+            'X-Sidecar-Token': config.sharedSecret,
+            'User-Agent': USER_AGENT,
+            Accept: 'application/json',
+            ...(init.headers ?? {}),
+          },
+        })
+        clearTimeout(timer)
+
+        if (res.status >= 500) {
+          throw new TelegramTransportError(
+            `sidecar ${path} responded ${res.status}`,
+            res.status,
+          )
+        }
+
+        if (!res.ok) {
+          await throwStructuredError(res, path)
+        }
+
+        const body = (await res.json()) as T
+        logger.info(`${LOG_SCOPE}.response`, {
+          path,
+          status: res.status,
+          attempt,
+          correlationId,
+        })
+        return body
+      } catch (err) {
+        clearTimeout(timer)
+        lastErr = err
+
+        // Non-retryable: stop immediately.
+        if (err instanceof TelegramProviderError && !err.retryable) {
+          throw err
+        }
+
+        // Treat AbortError as a transport error so retry policy applies.
+        if (isAbortError(err)) {
+          lastErr = new TelegramTransportError(
+            `sidecar ${path} timed out after ${config.timeoutMs}ms`,
+            null,
+            { cause: err },
+          )
+        }
+
+        // Network-level fetch failures.
+        if (!(lastErr instanceof TelegramProviderError)) {
+          lastErr = new TelegramTransportError(
+            `sidecar ${path} transport error`,
+            null,
+            { cause: err },
+          )
+        }
+
+        if (attempt < maxAttempts) {
+          const backoffMs = 200 * 2 ** (attempt - 1)
+          logger.warn(`${LOG_SCOPE}.retry`, {
+            path,
+            attempt,
+            backoffMs,
+            error: lastErr,
+            correlationId,
+          })
+          await sleep(backoffMs)
+          continue
+        }
+      }
+    }
+
+    logger.error(`${LOG_SCOPE}.failed`, {
+      path,
+      correlationId,
+      error: lastErr,
+    })
+    // lastErr is always a TelegramProviderError at this point per the
+    // normalization above, but TS can't prove it.
+    throw lastErr as TelegramProviderError
+  }
+
+  function correlation(input: { correlationId?: string }): string {
+    return input.correlationId ?? cryptoRandomId()
+  }
+
+  return {
+    code: 'telethon',
+
+    async fetchChats(input: FetchChatsInput): Promise<FetchChatsResult> {
+      const cid = correlation(input as { correlationId?: string })
+      const body = await request<{ chats: FetchChatsResult['chats'] }>(
+        '/chats',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            connection_id: input.connectionId,
+            limit: input.limit ?? null,
+          }),
+        },
+        cid,
+      )
+      if (!body || !Array.isArray(body.chats)) {
+        throw new TelegramBadResponseError('sidecar /chats returned malformed body')
+      }
+      return { chats: body.chats }
+    },
+
+    async fetchMessages(input: FetchMessagesInput): Promise<FetchMessagesResult> {
+      const cid = correlation(input as { correlationId?: string })
+      const body = await request<FetchMessagesResult>(
+        '/messages',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            connection_id: input.connectionId,
+            tg_chat_id: input.tgChatId,
+            from_message_id: input.fromMessageId,
+            limit: input.limit,
+          }),
+        },
+        cid,
+      )
+      if (!body || !Array.isArray(body.messages)) {
+        throw new TelegramBadResponseError('sidecar /messages returned malformed body')
+      }
+      return {
+        messages: body.messages,
+        nextFromMessageId: body.nextFromMessageId ?? null,
+      }
+    },
+
+    async fetchMedia(input: FetchMediaInput): Promise<FetchMediaResult> {
+      const cid = correlation(input as { correlationId?: string })
+      const url = `${config.baseUrl.replace(/\/$/, '')}/media/${encodeURIComponent(input.fileUniqueId)}`
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), config.timeoutMs)
+      let res: Response
+      try {
+        res = await fetchImpl(url, {
+          method: 'GET',
+          signal: controller.signal,
+          headers: {
+            'X-Sidecar-Token': config.sharedSecret,
+            'User-Agent': USER_AGENT,
+          },
+        })
+      } catch (err) {
+        clearTimeout(timer)
+        if (isAbortError(err)) {
+          throw new TelegramTransportError(
+            `sidecar /media timed out after ${config.timeoutMs}ms`,
+            null,
+            { cause: err },
+          )
+        }
+        throw new TelegramTransportError(
+          `sidecar /media transport error`,
+          null,
+          { cause: err },
+        )
+      }
+      // NOTE: the timer is intentionally left running; aborting the
+      // controller aborts the body stream too, which is desirable if
+      // the sidecar stops sending chunks partway through. The caller
+      // is expected to consume the stream promptly.
+
+      if (res.status === 404) {
+        throw new TelegramChatGoneError('sidecar: media gone (404)')
+      }
+      if (res.status === 401 || res.status === 403) {
+        throw new TelegramAuthRequiredError('sidecar: unauthorized')
+      }
+      if (!res.ok) {
+        throw new TelegramTransportError(
+          `sidecar /media responded ${res.status}`,
+          res.status,
+        )
+      }
+      if (!res.body) {
+        throw new TelegramBadResponseError('sidecar /media returned no body')
+      }
+      logger.info(`${LOG_SCOPE}.response`, {
+        path: '/media',
+        status: res.status,
+        correlationId: cid,
+      })
+      return {
+        stream: iterateResponseBody(res),
+        mimeType: res.headers.get('content-type'),
+        sizeBytes: parseContentLength(res.headers.get('content-length')),
+      }
+    },
+  }
+}
+
+async function throwStructuredError(res: Response, path: string): Promise<never> {
+  let body: unknown = null
+  try {
+    body = await res.json()
+  } catch {
+    // ignore; fall through to generic error below
+  }
+  const payload = (body ?? {}) as {
+    error?: string
+    retry_after_seconds?: number
+    connection_id?: string
+    tg_chat_id?: string
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    throw new TelegramAuthRequiredError(
+      payload.error ?? `sidecar ${path} unauthorized`,
+      payload.connection_id ?? null,
+    )
+  }
+  if (res.status === 429 && typeof payload.retry_after_seconds === 'number') {
+    throw new TelegramFloodWaitError(
+      payload.error ?? `sidecar ${path} rate-limited`,
+      payload.retry_after_seconds,
+    )
+  }
+  if (res.status === 404) {
+    throw new TelegramChatGoneError(
+      payload.error ?? `sidecar ${path} target gone`,
+      payload.tg_chat_id ?? null,
+    )
+  }
+  throw new TelegramBadResponseError(
+    payload.error ?? `sidecar ${path} responded ${res.status}`,
+  )
+}
+
+async function* iterateResponseBody(res: Response): AsyncIterable<Uint8Array> {
+  // `Response.body` is a WHATWG ReadableStream; reader pull loop.
+  const reader = res.body!.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return
+      if (value) yield value
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'AbortError' || /aborted/i.test(err.message))
+  )
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null
+  const n = Number.parseInt(value, 10)
+  return Number.isFinite(n) ? n : null
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function cryptoRandomId(): string {
+  // Only needed for correlation fallbacks; not security-sensitive.
+  // Math.random is plenty for a log-grouping id.
+  return `cid_${Math.random().toString(36).slice(2, 10)}`
+}

--- a/src/domains/ingestion/telegram/providers/types.ts
+++ b/src/domains/ingestion/telegram/providers/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Contract between the ingestion worker and a Telegram data source.
+ *
+ * The contract is intentionally minimal: it transports raw messages
+ * and media, nothing business-domain. Classification, extraction,
+ * and draft creation live elsewhere and never know whether the
+ * bytes came from Telethon, a mock, or a future direct client.
+ *
+ * Two implementations ship in Phase 1:
+ *
+ *   - `mock` — deterministic in-memory fixtures; default in
+ *     development and tests.
+ *   - `telethon` — HTTP bridge to the Python Telethon sidecar;
+ *     never selected unless `INGESTION_TELEGRAM_PROVIDER=telethon`.
+ *
+ * The factory in `./registry.ts` wires env to implementation with
+ * no module-level side effects.
+ */
+
+export type TelegramIngestionProviderCode = 'mock' | 'telethon'
+
+// ─── Raw DTOs (provider → worker) ────────────────────────────────────────────
+
+export interface RawTelegramChat {
+  /** Telegram's numeric chat id. Serialized as string because JS Number
+   *  cannot safely hold 64-bit ints; callers convert to BigInt at the
+   *  Prisma boundary. */
+  tgChatId: string
+  title: string
+  kind: 'GROUP' | 'SUPERGROUP' | 'CHANNEL'
+}
+
+export interface RawTelegramMessageMedia {
+  fileUniqueId: string
+  kind: 'PHOTO' | 'VIDEO' | 'DOCUMENT' | 'OTHER'
+  mimeType: string | null
+  /** Best-effort size hint; null when Telegram doesn't provide one. */
+  sizeBytes: number | null
+}
+
+export interface RawTelegramMessage {
+  /** Serialized 64-bit int (see RawTelegramChat.tgChatId). */
+  tgMessageId: string
+  /** Serialized 64-bit int; null for anonymous admin posts in channels. */
+  tgAuthorId: string | null
+  text: string | null
+  postedAt: string // ISO-8601
+  media: RawTelegramMessageMedia[]
+  /** Raw provider payload preserved verbatim as source of truth. */
+  raw: unknown
+}
+
+// ─── Input / output shapes ───────────────────────────────────────────────────
+
+export interface FetchChatsInput {
+  connectionId: string
+  limit?: number
+}
+export interface FetchChatsResult {
+  chats: RawTelegramChat[]
+}
+
+export interface FetchMessagesInput {
+  connectionId: string
+  tgChatId: string
+  /** Incremental cursor. Pass `null` to fetch the newest batch. */
+  fromMessageId: string | null
+  /** Upper bound on messages returned. Providers may return fewer. */
+  limit: number
+}
+export interface FetchMessagesResult {
+  messages: RawTelegramMessage[]
+  /** Highest tgMessageId seen in this batch, or `null` if empty.
+   *  The worker advances the per-chat cursor to this value only
+   *  after the batch lands in DB. */
+  nextFromMessageId: string | null
+}
+
+export interface FetchMediaInput {
+  connectionId: string
+  fileUniqueId: string
+}
+export interface FetchMediaResult {
+  /** Stream the body as chunks so large media never buffer fully
+   *  in memory. Implementations SHOULD yield raw bytes; order is
+   *  preserved. */
+  stream: AsyncIterable<Uint8Array>
+  mimeType: string | null
+  sizeBytes: number | null
+}
+
+// ─── Provider interface ──────────────────────────────────────────────────────
+
+export interface TelegramIngestionProvider {
+  readonly code: TelegramIngestionProviderCode
+  fetchChats(input: FetchChatsInput): Promise<FetchChatsResult>
+  fetchMessages(input: FetchMessagesInput): Promise<FetchMessagesResult>
+  fetchMedia(input: FetchMediaInput): Promise<FetchMediaResult>
+}

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -6,15 +6,28 @@
  * container / dyno. Heavy ingestion work lives here so the Next.js
  * request/response cycle stays untouched.
  *
- * Phase 1 scope: boot pg-boss, register no job handlers yet, stay
- * alive to prove the deployment story. Handlers land in PR-C
- * (telegram.sync, telegram.mediaDownload). The kill switch is
- * checked inside each handler, not at the worker level, so a flipped
- * flag stops work immediately without needing a redeploy.
+ * PR-C registers two handlers:
+ *
+ *   - `telegram.sync`           — incremental pull for one chat
+ *   - `telegram.mediaDownload`  — one media file per job
+ *
+ * Both handlers start with a `kill-ingestion-telegram` probe so a
+ * flipped flag stops new work within a single poll cycle, with no
+ * redeploy needed. Concurrency is configurable but defaults to 1 per
+ * job kind, which is deliberately conservative — raising it requires
+ * a Phase 6 review.
  */
 
-import { getQueue, stopQueue } from '@/lib/queue'
+import { getQueue, registerHandler, stopQueue } from '@/lib/queue'
 import { logger } from '@/lib/logger'
+import {
+  INGESTION_JOB_KINDS,
+  resolveIngestionRuntimeConfig,
+  type TelegramMediaDownloadJobData,
+  type TelegramSyncJobData,
+} from '@/domains/ingestion'
+import { runTelegramSyncJob } from './jobs/telegram-sync'
+import { runTelegramMediaDownloadJob } from './jobs/telegram-media-download'
 
 async function main() {
   logger.info('worker.starting', {
@@ -22,13 +35,29 @@ async function main() {
     pid: process.pid,
   })
 
+  const config = resolveIngestionRuntimeConfig()
   await getQueue()
 
-  // PR-C will register handlers here, e.g.:
-  //   await registerHandler('telegram.sync', telegramSyncHandler)
-  //   await registerHandler('telegram.mediaDownload', telegramMediaDownloadHandler)
+  await registerHandler<TelegramSyncJobData>(
+    INGESTION_JOB_KINDS.telegramSync,
+    async (job) => {
+      await runTelegramSyncJob(job)
+    },
+  )
+  await registerHandler<TelegramMediaDownloadJobData>(
+    INGESTION_JOB_KINDS.telegramMediaDownload,
+    async (job) => {
+      await runTelegramMediaDownloadJob(job)
+    },
+  )
 
-  logger.info('worker.ready')
+  logger.info('worker.ready', {
+    handlers: [
+      INGESTION_JOB_KINDS.telegramSync,
+      INGESTION_JOB_KINDS.telegramMediaDownload,
+    ],
+    config,
+  })
 
   const shutdown = async (signal: string) => {
     logger.info('worker.shutdown_signal', { signal })

--- a/src/workers/jobs/telegram-media-download.ts
+++ b/src/workers/jobs/telegram-media-download.ts
@@ -1,0 +1,25 @@
+import type PgBoss from 'pg-boss'
+import { db } from '@/lib/db'
+import {
+  getTelegramProvider,
+  resolveIngestionRuntimeConfig,
+  telegramMediaDownloadHandler,
+  type IngestionSyncDb,
+  type TelegramMediaDownloadJobData,
+} from '@/domains/ingestion'
+import { defaultMediaStore } from './telegram-media-store'
+
+export async function runTelegramMediaDownloadJob(
+  job: PgBoss.Job<TelegramMediaDownloadJobData>,
+): Promise<void> {
+  const config = resolveIngestionRuntimeConfig()
+  const provider = getTelegramProvider()
+
+  await telegramMediaDownloadHandler(job.data, {
+    db: db as unknown as IngestionSyncDb,
+    provider,
+    store: defaultMediaStore,
+    now: () => new Date(),
+    mediaMaxBytes: config.mediaMaxBytes,
+  })
+}

--- a/src/workers/jobs/telegram-media-store.ts
+++ b/src/workers/jobs/telegram-media-store.ts
@@ -1,0 +1,53 @@
+import { Buffer } from 'node:buffer'
+import { getBlobUploader } from '@/lib/blob-storage'
+import { MediaOversizeError, type MediaStoreFn } from '@/domains/ingestion'
+
+/**
+ * Default media-store implementation used by the production worker.
+ *
+ * Reads the provider's async-iterable chunk by chunk, enforcing the
+ * size cap on the running total (the provider's `sizeHintBytes` is
+ * a pre-check in the handler, but we re-assert here because Telegram
+ * sometimes under-reports media size). On overflow we abort the
+ * iterator so bytes stop flowing through the pipe.
+ *
+ * Once the buffer is complete we hand it to the existing
+ * `BlobUploader` abstraction; that lives in `src/lib/blob-storage.ts`
+ * and chooses `local` or `vercel-blob` based on env. Callers never
+ * see either — they just get back a `blobKey`.
+ */
+
+export const defaultMediaStore: MediaStoreFn = async ({
+  fileUniqueId,
+  stream,
+  mimeType,
+  sizeHintBytes: _sizeHintBytes,
+  maxBytes,
+}) => {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for await (const chunk of stream) {
+    total += chunk.byteLength
+    if (total > maxBytes) {
+      throw new MediaOversizeError(maxBytes, total)
+    }
+    chunks.push(chunk)
+  }
+
+  const bytes = Buffer.concat(chunks, total)
+  const uploader = getBlobUploader()
+  const effectiveContentType = mimeType ?? 'application/octet-stream'
+  const originalName = `telegram-${fileUniqueId}.bin`
+  const result = await uploader.upload({
+    bytes,
+    contentType: effectiveContentType,
+    originalName,
+    prefix: 'ingestion/telegram',
+  })
+
+  return {
+    blobKey: result.storageKey,
+    sizeBytes: total,
+    mimeType: effectiveContentType,
+  }
+}

--- a/src/workers/jobs/telegram-sync.ts
+++ b/src/workers/jobs/telegram-sync.ts
@@ -1,0 +1,38 @@
+import type PgBoss from 'pg-boss'
+import { db } from '@/lib/db'
+import { enqueue } from '@/lib/queue'
+import {
+  getTelegramProvider,
+  INGESTION_JOB_KINDS,
+  resolveIngestionRuntimeConfig,
+  telegramSyncHandler,
+  type IngestionSyncDb,
+  type TelegramSyncJobData,
+} from '@/domains/ingestion'
+
+/**
+ * Worker adapter: wires the pure `telegramSyncHandler` to the real
+ * `db`, the env-selected provider, and the pg-boss queue. Kept tiny
+ * on purpose so the integration surface is easy to audit.
+ */
+
+export async function runTelegramSyncJob(
+  job: PgBoss.Job<TelegramSyncJobData>,
+): Promise<void> {
+  const config = resolveIngestionRuntimeConfig()
+  const provider = getTelegramProvider()
+
+  await telegramSyncHandler(job.data, {
+    db: db as unknown as IngestionSyncDb,
+    provider,
+    enqueueMediaDownload: async ({ messageMediaId, fileUniqueId, correlationId }) => {
+      await enqueue(
+        INGESTION_JOB_KINDS.telegramMediaDownload,
+        { messageMediaId, correlationId },
+        { singletonKey: `media:${fileUniqueId}` },
+      )
+    },
+    now: () => new Date(),
+    batchSize: config.syncBatchSize,
+  })
+}

--- a/test/features/ingestion-media-handler.test.ts
+++ b/test/features/ingestion-media-handler.test.ts
@@ -1,0 +1,306 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  MediaOversizeError,
+  telegramMediaDownloadHandler,
+  TelegramAuthRequiredError,
+  TelegramChatGoneError,
+  TelegramTransportError,
+  type IngestionSyncDb,
+  type MediaStoreFn,
+  type MessageMediaWithMessage,
+  type TelegramIngestionProvider,
+  type TelegramMediaDownloadDeps,
+} from '@/domains/ingestion'
+
+function mediaFixture(
+  overrides: Partial<MessageMediaWithMessage> = {},
+): MessageMediaWithMessage {
+  return {
+    id: 'm1',
+    messageId: 'msg1',
+    fileUniqueId: 'file-A',
+    kind: 'PHOTO',
+    status: 'PENDING',
+    blobKey: null,
+    sizeBytes: null,
+    mimeType: null,
+    message: {
+      chatId: 'chat_1',
+      chat: {
+        connectionId: 'conn_1',
+        tgChatId: BigInt(-100),
+        connection: { id: 'conn_1', status: 'ACTIVE' },
+      },
+    },
+    ...overrides,
+  }
+}
+
+function createFakeDb(seed: MessageMediaWithMessage) {
+  let row: MessageMediaWithMessage | null = { ...seed }
+  const db: IngestionSyncDb = {
+    telegramIngestionChat: {
+      async findUnique() {
+        throw new Error('not used')
+      },
+      async update() {
+        throw new Error('not used')
+      },
+    },
+    telegramIngestionSyncRun: {
+      async create() {
+        throw new Error('not used')
+      },
+      async update() {
+        throw new Error('not used')
+      },
+    },
+    telegramIngestionMessage: {
+      async upsert() {
+        throw new Error('not used')
+      },
+    },
+    telegramIngestionMessageMedia: {
+      async upsert() {
+        throw new Error('not used')
+      },
+      async findUnique({ where }) {
+        if (row && row.id === where.id) return row
+        return null
+      },
+      async update({ where, data }) {
+        if (!row || row.id !== where.id)
+          throw new Error('media not found in fake db')
+        row = { ...row, ...data } as MessageMediaWithMessage
+        return {
+          id: row.id,
+          messageId: row.messageId,
+          fileUniqueId: row.fileUniqueId,
+          kind: row.kind,
+          status: row.status,
+          blobKey: row.blobKey,
+          sizeBytes: row.sizeBytes,
+          mimeType: row.mimeType,
+        }
+      },
+    },
+    async $transaction(fn) {
+      return fn(db)
+    },
+  }
+  return { db, current: () => row, setRow: (r: MessageMediaWithMessage | null) => (row = r) }
+}
+
+function provider(
+  overrides: Partial<TelegramIngestionProvider> = {},
+): TelegramIngestionProvider {
+  return {
+    code: 'mock',
+    async fetchChats() {
+      throw new Error('not used')
+    },
+    async fetchMessages() {
+      throw new Error('not used')
+    },
+    async fetchMedia() {
+      return {
+        stream: (async function* () {
+          yield new Uint8Array([1, 2, 3])
+        })(),
+        mimeType: 'image/jpeg',
+        sizeBytes: 3,
+      }
+    },
+    ...overrides,
+  }
+}
+
+function deps(
+  db: IngestionSyncDb,
+  p: TelegramIngestionProvider = provider(),
+  extra: Partial<TelegramMediaDownloadDeps> = {},
+): TelegramMediaDownloadDeps {
+  const store: MediaStoreFn = async ({ stream, maxBytes }) => {
+    let total = 0
+    for await (const chunk of stream) {
+      total += chunk.byteLength
+      if (total > maxBytes) throw new MediaOversizeError(maxBytes, total)
+    }
+    return { blobKey: `ingestion/telegram/blob-${total}`, sizeBytes: total, mimeType: 'image/jpeg' }
+  }
+  return {
+    db,
+    provider: p,
+    store,
+    now: () => new Date('2026-04-20T12:00:00Z'),
+    mediaMaxBytes: 1024,
+    isKilled: async () => false,
+    ...extra,
+  }
+}
+
+// ─── Kill switch ─────────────────────────────────────────────────────────────
+
+test('media handler returns KILLED before any I/O when kill switch is engaged', async () => {
+  const fake = createFakeDb(mediaFixture())
+  let providerCalled = false
+  const p = provider({
+    async fetchMedia() {
+      providerCalled = true
+      throw new Error('should not be called')
+    },
+  })
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db, p, { isKilled: async () => true }),
+  )
+  assert.equal(result.status, 'KILLED')
+  assert.equal(providerCalled, false)
+  // No mutation.
+  assert.equal(fake.current()!.blobKey, null)
+  assert.equal(fake.current()!.status, 'PENDING')
+})
+
+// ─── Dedupe ──────────────────────────────────────────────────────────────────
+
+test('media handler is a no-op when blobKey is already set (dedupe invariant)', async () => {
+  const fake = createFakeDb(
+    mediaFixture({ blobKey: 'already/stored', status: 'DOWNLOADED', sizeBytes: 42 }),
+  )
+  let providerCalled = false
+  const p = provider({
+    async fetchMedia() {
+      providerCalled = true
+      throw new Error('should not be called')
+    },
+  })
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db, p),
+  )
+  assert.equal(result.status, 'ALREADY_DONE')
+  assert.equal(providerCalled, false)
+  assert.equal(fake.current()!.blobKey, 'already/stored')
+})
+
+// ─── Size cap ────────────────────────────────────────────────────────────────
+
+test('media handler skips oversize before I/O when pre-check size exceeds cap', async () => {
+  const fake = createFakeDb(mediaFixture({ sizeBytes: 100_000_000 }))
+  let providerCalled = false
+  const p = provider({
+    async fetchMedia() {
+      providerCalled = true
+      throw new Error('should not be called')
+    },
+  })
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db, p, { mediaMaxBytes: 1024 }),
+  )
+  assert.equal(result.status, 'SKIPPED_OVERSIZE')
+  assert.equal(providerCalled, false)
+  assert.equal(fake.current()!.status, 'SKIPPED_OVERSIZE')
+})
+
+test('media handler marks SKIPPED_OVERSIZE if body exceeds cap mid-stream', async () => {
+  const fake = createFakeDb(mediaFixture()) // no pre-check size
+  const p = provider({
+    async fetchMedia() {
+      return {
+        stream: (async function* () {
+          // yield chunks that exceed the 10-byte cap only after
+          // streaming starts — the pre-check can't save us here.
+          yield new Uint8Array(6)
+          yield new Uint8Array(6)
+        })(),
+        mimeType: 'video/mp4',
+        sizeBytes: null,
+      }
+    },
+  })
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db, p, { mediaMaxBytes: 10 }),
+  )
+  assert.equal(result.status, 'SKIPPED_OVERSIZE')
+  assert.equal(fake.current()!.status, 'SKIPPED_OVERSIZE')
+  // NO blob key was written.
+  assert.equal(fake.current()!.blobKey, null)
+})
+
+// ─── Happy path ──────────────────────────────────────────────────────────────
+
+test('media handler stores bytes and records DOWNLOADED', async () => {
+  const fake = createFakeDb(mediaFixture())
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db),
+  )
+  assert.equal(result.status, 'OK')
+  assert.equal(result.sizeBytes, 3)
+  assert.equal(fake.current()!.status, 'DOWNLOADED')
+  assert.match(fake.current()!.blobKey ?? '', /^ingestion\/telegram\/blob-/)
+  assert.equal(fake.current()!.sizeBytes, 3)
+})
+
+// ─── Typed-error routing ─────────────────────────────────────────────────────
+
+test('media handler marks SOURCE_GONE on TelegramChatGoneError (terminal)', async () => {
+  const fake = createFakeDb(mediaFixture())
+  const p = provider({
+    async fetchMedia() {
+      throw new TelegramChatGoneError('file gone')
+    },
+  })
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db, p),
+  )
+  assert.equal(result.status, 'SOURCE_GONE')
+  assert.equal(fake.current()!.status, 'SOURCE_GONE')
+})
+
+test('media handler marks FAILED and rethrows TelegramAuthRequiredError (operator alert)', async () => {
+  const fake = createFakeDb(mediaFixture())
+  const p = provider({
+    async fetchMedia() {
+      throw new TelegramAuthRequiredError('session expired', 'conn_1')
+    },
+  })
+  await assert.rejects(
+    telegramMediaDownloadHandler({ messageMediaId: 'm1' }, deps(fake.db, p)),
+    TelegramAuthRequiredError,
+  )
+  assert.equal(fake.current()!.status, 'FAILED')
+})
+
+test('media handler rethrows TelegramTransportError for pg-boss retry (row stays PENDING)', async () => {
+  const fake = createFakeDb(mediaFixture())
+  const p = provider({
+    async fetchMedia() {
+      throw new TelegramTransportError('sidecar boom', 503)
+    },
+  })
+  await assert.rejects(
+    telegramMediaDownloadHandler({ messageMediaId: 'm1' }, deps(fake.db, p)),
+    TelegramTransportError,
+  )
+  // Row is still PENDING so a retry does the real work.
+  assert.equal(fake.current()!.status, 'PENDING')
+  assert.equal(fake.current()!.blobKey, null)
+  assert.match(fake.current()!.mimeType ?? 'null', /jpeg|null/)
+})
+
+// ─── Missing row ─────────────────────────────────────────────────────────────
+
+test('media handler returns FAILED when the media row no longer exists', async () => {
+  const fake = createFakeDb(mediaFixture())
+  fake.setRow(null)
+  const result = await telegramMediaDownloadHandler(
+    { messageMediaId: 'm1' },
+    deps(fake.db),
+  )
+  assert.equal(result.status, 'FAILED')
+})

--- a/test/features/ingestion-provider-http.test.ts
+++ b/test/features/ingestion-provider-http.test.ts
@@ -1,0 +1,256 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createTelethonHttpProvider,
+  TelegramAuthRequiredError,
+  TelegramBadResponseError,
+  TelegramChatGoneError,
+  TelegramFloodWaitError,
+  TelegramTransportError,
+} from '@/domains/ingestion'
+
+interface FakeFetchCall {
+  url: string
+  init: RequestInit | undefined
+}
+
+function fakeFetch(
+  responder: (call: FakeFetchCall) => Response | Promise<Response>,
+): { fetch: typeof fetch; calls: FakeFetchCall[] } {
+  const calls: FakeFetchCall[] = []
+  const fn: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as Request).url
+    calls.push({ url, init })
+    return responder({ url, init })
+  }
+  return { fetch: fn, calls }
+}
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  })
+}
+
+const BASE = 'http://sidecar.test'
+const SECRET = 'test-secret'
+
+test('http.fetchMessages sends shared-secret header and parses body', async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    jsonResponse(200, { messages: [], nextFromMessageId: null }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    fetchImpl: fetch,
+  })
+  const result = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: null,
+    limit: 10,
+  })
+  assert.deepEqual(result, { messages: [], nextFromMessageId: null })
+  assert.equal(calls.length, 1)
+  const headers = calls[0]!.init!.headers as Record<string, string>
+  assert.equal(headers['X-Sidecar-Token'], SECRET)
+  assert.equal(headers['Content-Type'], 'application/json')
+})
+
+test('http.fetchMessages retries on 5xx then succeeds', async () => {
+  let n = 0
+  const { fetch, calls } = fakeFetch(() => {
+    n++
+    if (n < 3) return new Response('boom', { status: 502 })
+    return jsonResponse(200, { messages: [], nextFromMessageId: null })
+  })
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    maxAttempts: 3,
+    fetchImpl: fetch,
+  })
+  const result = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: null,
+    limit: 10,
+  })
+  assert.deepEqual(result.messages, [])
+  assert.equal(calls.length, 3)
+})
+
+test('http.fetchMessages surfaces TelegramTransportError after exhausting retries', async () => {
+  const { fetch, calls } = fakeFetch(
+    () => new Response('boom', { status: 503 }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    maxAttempts: 2,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-100',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    (err: unknown) => err instanceof TelegramTransportError && err.retryable === true,
+  )
+  assert.equal(calls.length, 2)
+})
+
+test('http.fetchMessages maps 401 → TelegramAuthRequiredError (no retry)', async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    jsonResponse(401, { error: 'session expired', connection_id: 'c1' }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    maxAttempts: 3,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-100',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    (err: unknown) =>
+      err instanceof TelegramAuthRequiredError && err.connectionId === 'c1',
+  )
+  // Crucial: auth errors must not retry.
+  assert.equal(calls.length, 1)
+})
+
+test('http.fetchMessages maps 429 → TelegramFloodWaitError with retry-after', async () => {
+  const { fetch } = fakeFetch(() =>
+    jsonResponse(429, { error: 'FLOOD_WAIT_60', retry_after_seconds: 60 }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    maxAttempts: 3,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-100',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    (err: unknown) =>
+      err instanceof TelegramFloodWaitError && err.retryAfterSeconds === 60,
+  )
+})
+
+test('http.fetchMessages maps 404 → TelegramChatGoneError', async () => {
+  const { fetch } = fakeFetch(() =>
+    jsonResponse(404, { error: 'chat removed', tg_chat_id: '-100' }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-100',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    TelegramChatGoneError,
+  )
+})
+
+test('http.fetchMessages maps malformed body → TelegramBadResponseError (no retry)', async () => {
+  const { fetch, calls } = fakeFetch(() => jsonResponse(200, { nope: 'wrong' }))
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    maxAttempts: 3,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-100',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    TelegramBadResponseError,
+  )
+  assert.equal(calls.length, 1)
+})
+
+test('http.fetchMedia streams chunks from the response body', async () => {
+  const { fetch } = fakeFetch(
+    () =>
+      new Response(new Uint8Array([1, 2, 3, 4]), {
+        status: 200,
+        headers: { 'content-type': 'image/jpeg', 'content-length': '4' },
+      }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    fetchImpl: fetch,
+  })
+  const { stream, sizeBytes, mimeType } = await provider.fetchMedia({
+    connectionId: 'c1',
+    fileUniqueId: 'abc',
+  })
+  assert.equal(sizeBytes, 4)
+  assert.equal(mimeType, 'image/jpeg')
+  const bytes: number[] = []
+  for await (const chunk of stream) bytes.push(...chunk)
+  assert.deepEqual(bytes, [1, 2, 3, 4])
+})
+
+test('http.fetchMedia maps 404 → TelegramChatGoneError', async () => {
+  const { fetch } = fakeFetch(() => new Response('gone', { status: 404 }))
+  const provider = createTelethonHttpProvider({
+    baseUrl: BASE,
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    fetchImpl: fetch,
+  })
+  await assert.rejects(
+    provider.fetchMedia({ connectionId: 'c1', fileUniqueId: 'abc' }),
+    TelegramChatGoneError,
+  )
+})
+
+test('http request URL honours baseUrl without trailing slash', async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    jsonResponse(200, { messages: [], nextFromMessageId: null }),
+  )
+  const provider = createTelethonHttpProvider({
+    baseUrl: 'http://sidecar.test/', // trailing slash
+    sharedSecret: SECRET,
+    timeoutMs: 500,
+    fetchImpl: fetch,
+  })
+  await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: null,
+    limit: 10,
+  })
+  // No double slash between base and path.
+  assert.equal(calls[0]!.url, 'http://sidecar.test/messages')
+})

--- a/test/features/ingestion-provider-import-side-effects.test.ts
+++ b/test/features/ingestion-provider-import-side-effects.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+/**
+ * PR-B safety gate: importing the ingestion provider layer must not
+ * open network connections, read files, spawn children, or initialise
+ * pg-boss. If this test ever starts to flake because some module-level
+ * side effect leaks (a `new PgBoss()`, a top-level `fetch`, a
+ * `fs.readFileSync`) we want to catch it here, not in production.
+ */
+
+test('importing @/domains/ingestion is side-effect free', async () => {
+  const originalFetch = globalThis.fetch
+  let fetchCalled = false
+  globalThis.fetch = (async () => {
+    fetchCalled = true
+    throw new Error('fetch must not be called at import time')
+  }) as typeof fetch
+
+  const before = {
+    netSockets: countActiveHandles('TCP'),
+    timers: countActiveHandles('Timeout'),
+  }
+
+  try {
+    const mod = await import('@/domains/ingestion')
+    // Touch the exports so tree-shaking analysis cannot elide the
+    // module entirely — we genuinely want to exercise the import.
+    assert.equal(typeof mod.getTelegramProvider, 'function')
+    assert.equal(typeof mod.createMockProvider, 'function')
+    assert.equal(typeof mod.isIngestionKilled, 'function')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.equal(fetchCalled, false, 'no HTTP calls at import time')
+
+  const after = {
+    netSockets: countActiveHandles('TCP'),
+    timers: countActiveHandles('Timeout'),
+  }
+  assert.equal(
+    after.netSockets,
+    before.netSockets,
+    'no extra TCP sockets opened at import time',
+  )
+  assert.equal(
+    after.timers,
+    before.timers,
+    'no extra timers scheduled at import time',
+  )
+})
+
+function countActiveHandles(kind: string): number {
+  // `process._getActiveHandles` is undocumented but stable enough to
+  // use as a smoke test here; if it ever disappears this test can
+  // fall back to `performance.eventLoopUtilization()`.
+  const getHandles = (process as unknown as {
+    _getActiveHandles?: () => Array<{ constructor: { name: string } }>
+  })._getActiveHandles
+  if (typeof getHandles !== 'function') return 0
+  return getHandles().filter((h) => h.constructor.name.includes(kind)).length
+}

--- a/test/features/ingestion-provider-mock.test.ts
+++ b/test/features/ingestion-provider-mock.test.ts
@@ -1,0 +1,157 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createMockProvider,
+  TelegramChatGoneError,
+  type MockFixture,
+  type RawTelegramMessage,
+} from '@/domains/ingestion'
+
+function msg(id: string, postedAt = '2026-04-20T10:00:00Z'): RawTelegramMessage {
+  return {
+    tgMessageId: id,
+    tgAuthorId: '42',
+    text: `m${id}`,
+    postedAt,
+    media: [],
+    raw: { id },
+  }
+}
+
+test('mock.fetchChats returns configured chats', async () => {
+  const provider = createMockProvider({
+    chats: [{ tgChatId: '-100123', title: 'Test', kind: 'SUPERGROUP' }],
+    messages: {},
+  })
+  const { chats } = await provider.fetchChats({ connectionId: 'c1' })
+  assert.equal(chats.length, 1)
+  assert.equal(chats[0]!.title, 'Test')
+})
+
+test('mock.fetchChats honours limit', async () => {
+  const provider = createMockProvider({
+    chats: [
+      { tgChatId: '-1', title: 'a', kind: 'GROUP' },
+      { tgChatId: '-2', title: 'b', kind: 'GROUP' },
+      { tgChatId: '-3', title: 'c', kind: 'GROUP' },
+    ],
+    messages: {},
+  })
+  const { chats } = await provider.fetchChats({ connectionId: 'c1', limit: 2 })
+  assert.equal(chats.length, 2)
+})
+
+test('mock.fetchMessages returns newest batch when cursor is null', async () => {
+  const fx: MockFixture = {
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3')] },
+  }
+  const provider = createMockProvider(fx)
+  const { messages, nextFromMessageId } = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: null,
+    limit: 10,
+  })
+  assert.equal(messages.length, 3)
+  assert.equal(nextFromMessageId, '3')
+})
+
+test('mock.fetchMessages advances cursor strictly (fromMessageId excluded)', async () => {
+  const fx: MockFixture = {
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3')] },
+  }
+  const provider = createMockProvider(fx)
+  const { messages, nextFromMessageId } = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: '2',
+    limit: 10,
+  })
+  assert.deepEqual(
+    messages.map((m) => m.tgMessageId),
+    ['3'],
+  )
+  assert.equal(nextFromMessageId, '3')
+})
+
+test('mock.fetchMessages caps at limit and returns the correct cursor', async () => {
+  const fx: MockFixture = {
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3'), msg('4')] },
+  }
+  const provider = createMockProvider(fx)
+  const { messages, nextFromMessageId } = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: '1',
+    limit: 2,
+  })
+  assert.deepEqual(
+    messages.map((m) => m.tgMessageId),
+    ['2', '3'],
+  )
+  assert.equal(nextFromMessageId, '3')
+})
+
+test('mock.fetchMessages uses numeric (BigInt) comparison, not lexical', async () => {
+  // "9" > "10" lexically but 9 < 10 numerically — the mock MUST order by
+  // numeric value so the sync cursor stays correct past the 10-message mark.
+  const fx: MockFixture = {
+    chats: [],
+    messages: { '-100': [msg('9'), msg('10'), msg('11')] },
+  }
+  const provider = createMockProvider(fx)
+  const { messages } = await provider.fetchMessages({
+    connectionId: 'c1',
+    tgChatId: '-100',
+    fromMessageId: null,
+    limit: 10,
+  })
+  assert.deepEqual(
+    messages.map((m) => m.tgMessageId),
+    ['9', '10', '11'],
+  )
+})
+
+test('mock.fetchMessages throws TelegramChatGoneError for unknown chat', async () => {
+  const provider = createMockProvider()
+  await assert.rejects(
+    provider.fetchMessages({
+      connectionId: 'c1',
+      tgChatId: '-999',
+      fromMessageId: null,
+      limit: 10,
+    }),
+    TelegramChatGoneError,
+  )
+})
+
+test('mock.fetchMedia streams bytes for configured fileUniqueId', async () => {
+  const bytes = new Uint8Array([1, 2, 3, 4])
+  const provider = createMockProvider({
+    chats: [],
+    messages: {},
+    media: { abc: bytes },
+  })
+  const { stream, sizeBytes, mimeType } = await provider.fetchMedia({
+    connectionId: 'c1',
+    fileUniqueId: 'abc',
+  })
+  assert.equal(sizeBytes, 4)
+  assert.equal(mimeType, 'application/octet-stream')
+  const collected: number[] = []
+  for await (const chunk of stream) {
+    collected.push(...chunk)
+  }
+  assert.deepEqual(collected, [1, 2, 3, 4])
+})
+
+test('mock.fetchMedia throws for unknown fileUniqueId', async () => {
+  const provider = createMockProvider()
+  await assert.rejects(
+    provider.fetchMedia({ connectionId: 'c1', fileUniqueId: 'none' }),
+    TelegramChatGoneError,
+  )
+})

--- a/test/features/ingestion-provider-registry.test.ts
+++ b/test/features/ingestion-provider-registry.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getTelegramProvider,
+  resolveProviderCode,
+  TelegramProviderConfigError,
+  TELEGRAM_PROVIDER_ENV,
+} from '@/domains/ingestion'
+
+test('resolveProviderCode defaults to mock when env is unset', () => {
+  assert.equal(resolveProviderCode({}), 'mock')
+})
+
+test('resolveProviderCode accepts "mock" / "telethon" case-insensitively', () => {
+  assert.equal(resolveProviderCode({ [TELEGRAM_PROVIDER_ENV]: 'mock' }), 'mock')
+  assert.equal(resolveProviderCode({ [TELEGRAM_PROVIDER_ENV]: 'Telethon' }), 'telethon')
+  assert.equal(resolveProviderCode({ [TELEGRAM_PROVIDER_ENV]: 'TELETHON' }), 'telethon')
+})
+
+test('resolveProviderCode throws on unknown values (fail loud)', () => {
+  assert.throws(
+    () => resolveProviderCode({ [TELEGRAM_PROVIDER_ENV]: 'real' }),
+    TelegramProviderConfigError,
+  )
+})
+
+test('getTelegramProvider returns a mock provider by default', () => {
+  const provider = getTelegramProvider({})
+  assert.equal(provider.code, 'mock')
+})
+
+test('getTelegramProvider requires URL + token when telethon is selected', () => {
+  assert.throws(
+    () => getTelegramProvider({ [TELEGRAM_PROVIDER_ENV]: 'telethon' }),
+    TelegramProviderConfigError,
+  )
+  assert.throws(
+    () =>
+      getTelegramProvider({
+        [TELEGRAM_PROVIDER_ENV]: 'telethon',
+        TELEGRAM_SIDECAR_URL: 'http://localhost:8088',
+      }),
+    TelegramProviderConfigError,
+  )
+})
+
+test('getTelegramProvider wires Telethon HTTP when both URL + token are set', () => {
+  const provider = getTelegramProvider({
+    [TELEGRAM_PROVIDER_ENV]: 'telethon',
+    TELEGRAM_SIDECAR_URL: 'http://localhost:8088',
+    TELEGRAM_SIDECAR_TOKEN: 'secret',
+  })
+  assert.equal(provider.code, 'telethon')
+})

--- a/test/features/ingestion-sync-handler.test.ts
+++ b/test/features/ingestion-sync-handler.test.ts
@@ -1,0 +1,480 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createMockProvider,
+  telegramSyncHandler,
+  type ChatWithConnection,
+  type IngestionSyncDb,
+  type MessageMediaWithMessage,
+  type RawTelegramMessage,
+  TelegramTransportError,
+  type TelegramSyncDeps,
+} from '@/domains/ingestion'
+
+/**
+ * Tests for the telegram.sync handler. We inject fake `db` and
+ * `provider` dependencies so assertions describe the observable
+ * behaviour (rows written, cursor advance, enqueued downloads)
+ * without hitting Postgres or PostHog.
+ */
+
+// ─── Fake DB ─────────────────────────────────────────────────────────────────
+
+interface FakeMessageRow {
+  id: string
+  chatId: string
+  tgMessageId: bigint
+  tgAuthorId: bigint | null
+  text: string | null
+  postedAt: Date
+  rawJson: unknown
+}
+interface FakeMediaRow {
+  id: string
+  messageId: string
+  fileUniqueId: string
+  kind: 'PHOTO' | 'VIDEO' | 'DOCUMENT' | 'OTHER'
+  status: 'PENDING' | 'DOWNLOADED' | 'SKIPPED_OVERSIZE' | 'SOURCE_GONE' | 'FAILED'
+  blobKey: string | null
+  sizeBytes: number | null
+  mimeType: string | null
+}
+interface FakeRunRow {
+  id: string
+  chatId: string
+  status: 'RUNNING' | 'OK' | 'FAILED' | 'CANCELLED'
+  finishedAt: Date | null
+  toMessageId: bigint | null
+  messagesFetched: number
+  mediaFetched: number
+  errorMessage: string | null
+  correlationId: string
+  fromMessageId: bigint | null
+}
+
+function createFakeDb(seed: { chat: ChatWithConnection }): {
+  db: IngestionSyncDb
+  chat: ChatWithConnection
+  messages: FakeMessageRow[]
+  media: FakeMediaRow[]
+  runs: FakeRunRow[]
+  txCount: () => number
+} {
+  const chat = { ...seed.chat }
+  const messages: FakeMessageRow[] = []
+  const media: FakeMediaRow[] = []
+  const runs: FakeRunRow[] = []
+  let txCalls = 0
+  let nextId = 1
+  const id = () => `id_${nextId++}`
+
+  const api: IngestionSyncDb = {
+    telegramIngestionChat: {
+      async findUnique({ where }) {
+        if (where.id !== chat.id) return null
+        return chat
+      },
+      async update({ where, data }) {
+        assert.equal(where.id, chat.id)
+        if (data.lastMessageId !== undefined) chat.lastMessageId = data.lastMessageId
+        if (data.isEnabled !== undefined) chat.isEnabled = data.isEnabled
+        if (data.disabledReason !== undefined)
+          chat.disabledReason = data.disabledReason
+        return chat
+      },
+    },
+    telegramIngestionSyncRun: {
+      async create({ data }) {
+        const row: FakeRunRow = {
+          id: id(),
+          chatId: data.chatId,
+          status: 'RUNNING',
+          finishedAt: null,
+          toMessageId: null,
+          messagesFetched: 0,
+          mediaFetched: 0,
+          errorMessage: null,
+          correlationId: data.correlationId,
+          fromMessageId: data.fromMessageId ?? null,
+        }
+        runs.push(row)
+        return { id: row.id, chatId: row.chatId }
+      },
+      async update({ where, data }) {
+        const row = runs.find((r) => r.id === where.id)
+        if (!row) throw new Error(`run ${where.id} not found`)
+        Object.assign(row, data)
+        return { id: row.id, chatId: row.chatId }
+      },
+    },
+    telegramIngestionMessage: {
+      async upsert({ where, create }) {
+        const existing = messages.find(
+          (m) =>
+            m.chatId === where.chatId_tgMessageId.chatId &&
+            m.tgMessageId === where.chatId_tgMessageId.tgMessageId,
+        )
+        if (existing) return { id: existing.id, chatId: existing.chatId, tgMessageId: existing.tgMessageId }
+        const row: FakeMessageRow = {
+          id: id(),
+          chatId: create.chatId,
+          tgMessageId: create.tgMessageId,
+          tgAuthorId: create.tgAuthorId,
+          text: create.text,
+          postedAt: create.postedAt,
+          rawJson: create.rawJson,
+        }
+        messages.push(row)
+        return { id: row.id, chatId: row.chatId, tgMessageId: row.tgMessageId }
+      },
+    },
+    telegramIngestionMessageMedia: {
+      async upsert({ where, create }) {
+        const existing = media.find((m) => m.fileUniqueId === where.fileUniqueId)
+        if (existing) return { ...existing }
+        const row: FakeMediaRow = {
+          id: id(),
+          messageId: create.messageId,
+          fileUniqueId: create.fileUniqueId,
+          kind: create.kind,
+          status: 'PENDING',
+          blobKey: null,
+          sizeBytes: create.sizeBytes,
+          mimeType: create.mimeType,
+        }
+        media.push(row)
+        return { ...row }
+      },
+      async findUnique() {
+        throw new Error('not used in sync handler')
+      },
+      async update() {
+        throw new Error('not used in sync handler')
+      },
+    },
+    async $transaction(fn) {
+      txCalls++
+      // Real transactions roll back on throw; mirror that by
+      // snapshotting the arrays and restoring on failure.
+      const snap = {
+        messages: [...messages],
+        media: [...media],
+        chat: { ...chat },
+      }
+      try {
+        return await fn(api)
+      } catch (err) {
+        messages.length = 0
+        messages.push(...snap.messages)
+        media.length = 0
+        media.push(...snap.media)
+        Object.assign(chat, snap.chat)
+        throw err
+      }
+    },
+  }
+
+  return { db: api, chat, messages, media, runs, txCount: () => txCalls }
+}
+
+function chatFixture(overrides: Partial<ChatWithConnection> = {}): ChatWithConnection {
+  return {
+    id: 'chat_1',
+    connectionId: 'conn_1',
+    tgChatId: BigInt(-100),
+    title: 'Test',
+    kind: 'SUPERGROUP',
+    lastMessageId: null,
+    isEnabled: true,
+    disabledReason: null,
+    connection: { id: 'conn_1', status: 'ACTIVE' },
+    ...overrides,
+  }
+}
+
+function msg(
+  tgMessageId: string,
+  opts: { mediaId?: string } = {},
+): RawTelegramMessage {
+  return {
+    tgMessageId,
+    tgAuthorId: '42',
+    text: `msg ${tgMessageId}`,
+    postedAt: '2026-04-20T10:00:00Z',
+    media: opts.mediaId
+      ? [{ fileUniqueId: opts.mediaId, kind: 'PHOTO', mimeType: null, sizeBytes: null }]
+      : [],
+    raw: { id: tgMessageId },
+  }
+}
+
+function deps(
+  db: IngestionSyncDb,
+  provider = createMockProvider(),
+  extra: Partial<TelegramSyncDeps> = {},
+): TelegramSyncDeps {
+  return {
+    db,
+    provider,
+    enqueueMediaDownload: async () => {},
+    now: () => new Date('2026-04-20T12:00:00Z'),
+    batchSize: 100,
+    isKilled: async () => false,
+    ...extra,
+  }
+}
+
+// ─── Kill switch ─────────────────────────────────────────────────────────────
+
+test('sync handler returns KILLED before any I/O when kill switch is engaged', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    // If the handler ever calls the provider under a kill switch,
+    // returning here would silently succeed — so throw instead and
+    // assert no throw reaches us.
+    messages: { '-100': [msg('1')] },
+  })
+  let providerCalled = false
+  const wrapped = {
+    ...provider,
+    fetchMessages: async (...args: Parameters<typeof provider.fetchMessages>) => {
+      providerCalled = true
+      return provider.fetchMessages(...args)
+    },
+  }
+  const result = await telegramSyncHandler(
+    { chatId: 'chat_1' },
+    deps(fake.db, wrapped, { isKilled: async () => true }),
+  )
+  assert.equal(result.status, 'KILLED')
+  assert.equal(result.syncRunId, null)
+  assert.equal(providerCalled, false, 'provider must not be called under kill switch')
+  assert.equal(fake.runs.length, 0, 'no sync-run row must be created')
+  assert.equal(fake.messages.length, 0)
+})
+
+// ─── Chat gating ─────────────────────────────────────────────────────────────
+
+test('sync handler skips a disabled chat without opening a run', async () => {
+  const fake = createFakeDb({ chat: chatFixture({ isEnabled: false }) })
+  const result = await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db))
+  assert.equal(result.status, 'CHAT_DISABLED')
+  assert.equal(fake.runs.length, 0)
+})
+
+test('sync handler skips when the connection is not ACTIVE', async () => {
+  const fake = createFakeDb({
+    chat: chatFixture({ connection: { id: 'conn_1', status: 'REVOKED' } }),
+  })
+  const result = await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db))
+  assert.equal(result.status, 'CHAT_DISABLED')
+})
+
+test('sync handler returns CHAT_DISABLED when chatId does not exist', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const result = await telegramSyncHandler(
+    { chatId: 'does_not_exist' },
+    deps(fake.db),
+  )
+  assert.equal(result.status, 'CHAT_DISABLED')
+})
+
+// ─── Cursor + idempotency ────────────────────────────────────────────────────
+
+test('sync handler persists messages and advances cursor atomically', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3')] },
+  })
+  const result = await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider))
+  assert.equal(result.status, 'OK')
+  assert.equal(result.messagesFetched, 3)
+  assert.deepEqual(
+    fake.messages.map((m) => m.tgMessageId.toString()),
+    ['1', '2', '3'],
+  )
+  assert.equal(fake.chat.lastMessageId?.toString(), '3')
+  assert.equal(fake.runs.length, 1)
+  assert.equal(fake.runs[0]!.status, 'OK')
+  assert.equal(fake.runs[0]!.toMessageId?.toString(), '3')
+  assert.equal(fake.txCount(), 1, 'exactly one transaction')
+})
+
+test('sync handler is idempotent: re-running with same cursor creates no duplicates', async () => {
+  const fake = createFakeDb({ chat: chatFixture({ lastMessageId: BigInt(2) }) })
+  const provider = createMockProvider({
+    chats: [],
+    // Provider honours the cursor and returns only messages > 2.
+    messages: { '-100': [msg('1'), msg('2'), msg('3'), msg('4')] },
+  })
+  await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider))
+  await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider))
+  const ids = fake.messages.map((m) => m.tgMessageId.toString()).sort()
+  assert.deepEqual(ids, ['3', '4'])
+  assert.equal(fake.chat.lastMessageId?.toString(), '4')
+})
+
+test('sync handler never backfills past the stored cursor', async () => {
+  const fake = createFakeDb({ chat: chatFixture({ lastMessageId: BigInt(5) }) })
+  const provider = createMockProvider({
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3'), msg('6'), msg('7')] },
+  })
+  const result = await telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider))
+  assert.equal(result.messagesFetched, 2)
+  assert.deepEqual(
+    fake.messages.map((m) => m.tgMessageId.toString()).sort(),
+    ['6', '7'],
+  )
+})
+
+// ─── Transaction rollback on error ───────────────────────────────────────────
+
+test('sync handler rolls back partial batch if transaction throws', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    messages: { '-100': [msg('1'), msg('2'), msg('3')] },
+  })
+  // Override the message upsert to throw on the 2nd insert so the
+  // transaction must roll back.
+  const original = fake.db.telegramIngestionMessage.upsert
+  let calls = 0
+  fake.db.telegramIngestionMessage.upsert = async (args) => {
+    calls++
+    if (calls === 2) throw new Error('synthetic mid-batch failure')
+    return original(args)
+  }
+  await assert.rejects(
+    telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider)),
+    /synthetic mid-batch failure/,
+  )
+  // Rollback invariant: no partial message rows survive.
+  assert.equal(fake.messages.length, 0)
+  // Cursor is unchanged.
+  assert.equal(fake.chat.lastMessageId, null)
+  // Run exists and is FAILED.
+  assert.equal(fake.runs.length, 1)
+  assert.equal(fake.runs[0]!.status, 'FAILED')
+  assert.match(fake.runs[0]!.errorMessage ?? '', /synthetic mid-batch/)
+})
+
+// ─── Chat-gone handling ──────────────────────────────────────────────────────
+
+test('sync handler disables the chat on TelegramChatGoneError (terminal)', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    // No entry for -100 → mock throws TelegramChatGoneError
+    messages: {},
+  })
+  const result = await telegramSyncHandler(
+    { chatId: 'chat_1' },
+    deps(fake.db, provider),
+  )
+  assert.equal(result.status, 'FAILED')
+  assert.equal(fake.chat.isEnabled, false)
+  assert.match(fake.chat.disabledReason ?? '', /unknown chat/)
+  assert.equal(fake.runs[0]!.status, 'FAILED')
+})
+
+test('sync handler rethrows retryable TelegramTransportError so pg-boss retries', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = {
+    code: 'mock' as const,
+    async fetchChats() {
+      return { chats: [] }
+    },
+    async fetchMessages() {
+      throw new TelegramTransportError('sidecar boom', 503)
+    },
+    async fetchMedia() {
+      throw new Error('not used')
+    },
+  }
+  await assert.rejects(
+    telegramSyncHandler({ chatId: 'chat_1' }, deps(fake.db, provider)),
+    TelegramTransportError,
+  )
+  // Chat is NOT disabled — transient faults must not taint state.
+  assert.equal(fake.chat.isEnabled, true)
+  assert.equal(fake.runs[0]!.status, 'FAILED')
+})
+
+// ─── Media fan-out ───────────────────────────────────────────────────────────
+
+test('sync handler enqueues one media-download per PENDING media row (dedupe by fileUniqueId)', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    messages: {
+      '-100': [
+        msg('1', { mediaId: 'file-A' }),
+        msg('2', { mediaId: 'file-A' }), // same file — dedupe
+        msg('3', { mediaId: 'file-B' }),
+      ],
+    },
+  })
+  const enqueued: Array<{ messageMediaId: string; fileUniqueId: string }> = []
+  const result = await telegramSyncHandler(
+    { chatId: 'chat_1' },
+    deps(fake.db, provider, {
+      enqueueMediaDownload: async ({ messageMediaId, fileUniqueId }) => {
+        enqueued.push({ messageMediaId, fileUniqueId })
+      },
+    }),
+  )
+  assert.equal(result.status, 'OK')
+  assert.equal(fake.media.length, 2, 'two media rows despite three references')
+  assert.equal(enqueued.length, 2)
+  assert.deepEqual(
+    enqueued.map((e) => e.fileUniqueId).sort(),
+    ['file-A', 'file-B'],
+  )
+})
+
+test('sync handler succeeds when media enqueue fails (partial failure tolerated)', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    messages: { '-100': [msg('1', { mediaId: 'f1' })] },
+  })
+  const result = await telegramSyncHandler(
+    { chatId: 'chat_1' },
+    deps(fake.db, provider, {
+      enqueueMediaDownload: async () => {
+        throw new Error('queue down')
+      },
+    }),
+  )
+  assert.equal(result.status, 'OK', 'sync still succeeds')
+  assert.equal(result.mediaQueued, 0)
+  assert.equal(fake.messages.length, 1, 'message still persisted')
+  // Media row exists; sweeper (Phase 6) can pick it up later.
+  assert.equal(fake.media.length, 1)
+  assert.equal(fake.media[0]!.status, 'PENDING')
+})
+
+// ─── Correlation ─────────────────────────────────────────────────────────────
+
+test('sync handler threads correlationId through the sync run row', async () => {
+  const fake = createFakeDb({ chat: chatFixture() })
+  const provider = createMockProvider({
+    chats: [],
+    messages: { '-100': [msg('1')] },
+  })
+  const cid = 'cid-test-1234'
+  const result = await telegramSyncHandler(
+    { chatId: 'chat_1', correlationId: cid },
+    deps(fake.db, provider),
+  )
+  assert.equal(result.correlationId, cid)
+  assert.equal(fake.runs[0]!.correlationId, cid)
+})
+
+// Silence unused-var lint for the narrow helper that only exists for
+// discoverability in error messages — ts-unused-exports doesn't run
+// in test files, but keep the reference explicit here.
+void ({} as MessageMediaWithMessage)


### PR DESCRIPTION
Stacked on **#675** (PR-B). Target will rebase automatically as earlier PRs merge.

Part of epic **#657** · Phase 1 parent **#658** · Resolves partial **#663** **#664**. Observability hardening (#669) is finalised in PR-D.

## Scope — closes the Phase 1 technical loop

`Telegram → provider → worker → raw DB → logs`. Nothing business-side. Still off by default: `kill-ingestion-telegram = true` (killed) and `INGESTION_TELEGRAM_PROVIDER = mock`.

## Cumplimiento de las 6 condiciones críticas

| # | Condición | Implementación pinned by tests |
|---|---|---|
| 1 | Kill switch blindado: primer early-exit, antes de cualquier I/O | `sync.ts:77` + `media-download.ts:85`. Test: "returns KILLED before any I/O" asserts provider not called, no run row, no mutation. |
| 2 | Concurrencia limitada: batch chico, workers 1–2, rate limit | `config.ts`: batch 100 (max 500), sync/media concurrency 1 (max 4), media cap 20 MB (max 256 MB). Provider retry policy already in PR-B. |
| 3 | Sync estrictamente incremental | `fromMessageId = chat.lastMessageId`; cursor advance inside the transaction. Test: "never backfills past the stored cursor". No automatic backfill path exists. |
| 4 | Media controlado: dedup + streaming + cap + timeouts | Dedup by `blobKey` (ALREADY_DONE) + by `fileUniqueId` within batch. Streaming via async iterable, running-total cap via `MediaOversizeError`. Timeouts inherited from provider (PR-B AbortController). |
| 5 | Observabilidad real (no solo logs) | Every log line carries `correlationId` + `syncRunId` where applicable. `TelegramIngestionSyncRun` row captures `messagesFetched`, `mediaFetched`, `fromMessageId`, `toMessageId`, `errorMessage`, `status`. Typed errors (5 classes) drive dispatch. |
| 6 | Sin efectos colaterales | Handlers only touch `TelegramIngestion*` + `IngestionJob`. Zero imports of catalog/vendors/orders. Audit passes. |

## Tests (22 new, suite 1106 → 1128)

**`ingestion-sync-handler.test.ts`** (14 tests):
- Kill switch returns KILLED before any I/O — asserts provider not called, no run row, no mutation.
- Disabled chat → skip, no run row.
- Non-ACTIVE connection → skip, no run row.
- Unknown chatId → CHAT_DISABLED.
- Happy path: messages persisted, cursor advanced, one transaction.
- **Idempotency**: re-running with same cursor creates no duplicates.
- **No backfill**: cursor=5, provider returns 1..7 — only 6,7 persisted.
- **Transaction rollback**: mid-batch throw → zero partial rows, cursor unchanged, run FAILED.
- ChatGone disables chat (terminal state).
- TransportError rethrows for pg-boss retry, chat stays enabled.
- Media fan-out dedupes within batch (2 messages same fileUniqueId → 1 enqueue).
- Media enqueue failure after commit does NOT fail the sync (media row stays PENDING).
- correlationId threading into `TelegramIngestionSyncRun`.

**`ingestion-media-handler.test.ts`** (9 tests):
- Kill switch → KILLED before any I/O.
- ALREADY_DONE when blobKey is set (dedupe invariant).
- SKIPPED_OVERSIZE on pre-check (provider-reported size > cap).
- SKIPPED_OVERSIZE mid-stream (chunks exceed cap) — no blobKey written.
- Happy path: OK + DOWNLOADED + blobKey recorded.
- SOURCE_GONE on ChatGone (terminal).
- AuthRequired sets FAILED and rethrows (oncall alert).
- TransportError retries: row stays PENDING, error rethrows.
- Missing row → FAILED (returns cleanly).

All pure-function tests using injected `db`/`provider`/`store` fakes. No DB required. An integration test against a live Postgres lands in PR-D.

## Safety notes

- `prisma/schema.prisma`: not touched.
- Web graph: `src/workers/**` still imported by nobody outside itself. Verified via grep.
- `src/app/**`: not touched.
- Kill switch behaviour: even with `INGESTION_TELEGRAM_PROVIDER=telethon` and a real sidecar, flipping the flag to killed stops all job work within one poll cycle.
- Media storage uses the existing `getBlobUploader()` abstraction with a new `ingestion/telegram` prefix; no new storage provider introduced.

## Test plan

- [x] `npm run audit:contracts` — passes (528 files scanned, 0 violations).
- [x] `npx tsc --noEmit` — passes.
- [x] `npm test` — 1128/1128 passing (+22).
- [ ] Reviewer: skim `sync.ts:persistBatch` transaction structure and confirm the cursor advance is inside the tx block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)