### PR TITLE
feat(ingestion): Phase 2 PR-F — classifier + rules extractor + drafts builder

### DIFF
--- a/src/domains/ingestion/processing/classifier/index.ts
+++ b/src/domains/ingestion/processing/classifier/index.ts
@@ -1,0 +1,7 @@
+export {
+  classifyMessage,
+  type ClassifierInput,
+  type ClassifierResult,
+  type ClassifierSignal,
+  type MessageClass,
+} from './rules'

--- a/src/domains/ingestion/processing/classifier/rules.ts
+++ b/src/domains/ingestion/processing/classifier/rules.ts
@@ -1,0 +1,215 @@
+/**
+ * Conservative classifier rules.
+ *
+ * Philosophy (locked in #679 comment 4281108530): favour false
+ * negatives over false positives. A message reaches the extractor
+ * only when we have strong signals for `PRODUCT`. Everything else
+ * falls back to `OTHER` or `CONVERSATION`.
+ *
+ * Weights are additive, never multiplicative — a single weak signal
+ * cannot elevate confidence on its own. Two independent signals at
+ * 0.3 still produce a 0.6 score, not a 0.09 one.
+ *
+ * If you add a rule, also add:
+ *   1. A fixture case in `test/fixtures/ingestion-messages/` exercising it.
+ *   2. A short comment here explaining *why* the signal is
+ *      producer-speech rather than conversation or spam.
+ */
+
+export type MessageClass = 'PRODUCT' | 'CONVERSATION' | 'SPAM' | 'OTHER'
+
+export interface ClassifierSignal {
+  rule: string
+  weight: number
+  match: string
+}
+
+export interface ClassifierResult {
+  kind: MessageClass
+  confidence: number
+  signals: ClassifierSignal[]
+}
+
+export interface ClassifierInput {
+  text: string | null
+}
+
+// ─── Signal vocabulary ───────────────────────────────────────────────────────
+
+const PRICE_REGEX =
+  /(\d+[.,]?\d*)\s*(?:€|eur(?:os?)?)(?:\s*\/\s*(?:kg|g|l|ml|ud|uds|unidades?|pieza|pza))?/i
+const UNIT_REGEX = /\b(\d+[.,]?\d*)\s*(kg|g|l|ml|ud|uds|unidades?|gramos?|kilos?|litros?|mililitros?)\b/i
+// Minimal produce vocabulary. Conservative: missing categories are
+// safer than over-broad ones; admin can grow the list later.
+const PRODUCE_WORDS = [
+  // Fruits
+  'manzana', 'manzanas', 'pera', 'peras', 'naranja', 'naranjas',
+  'limon', 'limones', 'fresa', 'fresas', 'uva', 'uvas',
+  // Vegetables
+  'tomate', 'tomates', 'lechuga', 'pimiento', 'pimientos', 'cebolla',
+  'cebollas', 'ajo', 'ajos', 'patata', 'patatas', 'zanahoria', 'zanahorias',
+  // Dairy
+  'queso', 'quesos', 'leche', 'yogur', 'mantequilla',
+  // Meat / fish
+  'pollo', 'cerdo', 'ternera', 'cordero', 'pescado', 'atun', 'bacalao',
+  // Pantry
+  'aceite', 'vinagre', 'miel', 'harina', 'pan', 'huevos',
+]
+
+const CONVERSATION_MARKERS = [
+  /\?$/, // ends with question mark
+  /\b(gracias|hola|buenos dias|buenas|saludos)\b/i,
+  /\b(alguien|alguno|quien|donde|cuando|puedo|podemos|sabes|sabeis)\b/i,
+]
+
+const SPAM_HINTS = [
+  /https?:\/\//i,
+  /\b(click aqui|pincha aqui|gana|premio|promocion exclusiva)\b/i,
+  /\bt\.me\/|bit\.ly/i,
+]
+
+// ─── Weights ─────────────────────────────────────────────────────────────────
+//
+// Each signal contributes one additive term. A message needs signals
+// totalling >= 0.6 to reach the PRODUCT class. That threshold is
+// deliberately tight to push ambiguous messages into OTHER.
+
+const W_PRICE = 0.4
+const W_UNIT = 0.25
+const W_PRODUCE_WORD = 0.25
+const W_CONVERSATION_MARKER = 0.3
+const W_SPAM_URL = 0.35
+const W_SPAM_PHRASE = 0.35
+
+const PRODUCT_THRESHOLD = 0.6
+const CONVERSATION_THRESHOLD = 0.3
+const SPAM_THRESHOLD = 0.6
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function classifyMessage(input: ClassifierInput): ClassifierResult {
+  const text = (input.text ?? '').trim()
+  if (text.length === 0) {
+    return {
+      kind: 'OTHER',
+      confidence: 0,
+      signals: [{ rule: 'emptyOrWhitespace', weight: 0, match: '' }],
+    }
+  }
+
+  const productSignals: ClassifierSignal[] = []
+  const convSignals: ClassifierSignal[] = []
+  const spamSignals: ClassifierSignal[] = []
+
+  // Product signals
+  const priceMatch = PRICE_REGEX.exec(text)
+  if (priceMatch) {
+    const includesPerUnit = /\/\s*(?:kg|g|l|ml|ud|uds|unidades?|pieza|pza)/i.test(
+      priceMatch[0],
+    )
+    productSignals.push({
+      rule: includesPerUnit ? 'pricePerUnitToken' : 'priceToken',
+      // A price with an adjacent per-unit indicator is strong enough
+      // to corroborate itself. A bare price still needs a second signal.
+      weight: includesPerUnit ? W_PRICE + W_UNIT : W_PRICE,
+      match: priceMatch[0],
+    })
+  }
+  const unitMatch = UNIT_REGEX.exec(text)
+  if (unitMatch) {
+    productSignals.push({ rule: 'unitToken', weight: W_UNIT, match: unitMatch[0] })
+  }
+  const normalized = normaliseForProduceLookup(text)
+  for (const word of PRODUCE_WORDS) {
+    if (normalized.includes(word)) {
+      productSignals.push({ rule: 'produceWord', weight: W_PRODUCE_WORD, match: word })
+      break // first match is enough; don't double-count synonyms
+    }
+  }
+
+  // Conversation signals
+  for (const re of CONVERSATION_MARKERS) {
+    const m = re.exec(text)
+    if (m) {
+      convSignals.push({ rule: re.source, weight: W_CONVERSATION_MARKER, match: m[0] })
+    }
+  }
+
+  // Spam signals
+  for (const re of SPAM_HINTS) {
+    const m = re.exec(text)
+    if (m) {
+      const isUrl = /https?:\/\//i.test(m[0]) || /t\.me|bit\.ly/i.test(m[0])
+      spamSignals.push({
+        rule: isUrl ? 'spamUrl' : 'spamPhrase',
+        weight: isUrl ? W_SPAM_URL : W_SPAM_PHRASE,
+        match: m[0],
+      })
+    }
+  }
+
+  const productScore = sumWeights(productSignals)
+  const convScore = sumWeights(convSignals)
+  const spamScore = sumWeights(spamSignals)
+
+  // SPAM wins over PRODUCT when both fire — a link to a promo page
+  // plus a price is spam, not a legitimate listing.
+  if (spamScore >= SPAM_THRESHOLD) {
+    return {
+      kind: 'SPAM',
+      confidence: clamp01(spamScore),
+      signals: spamSignals,
+    }
+  }
+
+  // PRODUCT requires both a price signal AND at least one corroborating
+  // signal (unit or produce word). Price alone can be a quote or a
+  // memory; we demand confirmation.
+  const hasPrice = productSignals.some(
+    (s) => s.rule === 'priceToken' || s.rule === 'pricePerUnitToken',
+  )
+  const hasCorroboration = productSignals.some(
+    (s) =>
+      s.rule === 'unitToken' ||
+      s.rule === 'produceWord' ||
+      s.rule === 'pricePerUnitToken', // per-unit is self-corroborating
+  )
+  if (hasPrice && hasCorroboration && productScore >= PRODUCT_THRESHOLD) {
+    return {
+      kind: 'PRODUCT',
+      confidence: clamp01(productScore),
+      signals: productSignals,
+    }
+  }
+
+  if (convScore >= CONVERSATION_THRESHOLD) {
+    return {
+      kind: 'CONVERSATION',
+      confidence: clamp01(convScore),
+      signals: convSignals,
+    }
+  }
+
+  return {
+    kind: 'OTHER',
+    confidence: 0,
+    signals: [],
+  }
+}
+
+function sumWeights(signals: ClassifierSignal[]): number {
+  return signals.reduce((acc, s) => acc + s.weight, 0)
+}
+
+function clamp01(n: number): number {
+  if (n < 0) return 0
+  if (n > 1) return 1
+  return n
+}
+
+function normaliseForProduceLookup(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // strip accents so "manzána" matches
+}

--- a/src/domains/ingestion/processing/drafts/builder.ts
+++ b/src/domains/ingestion/processing/drafts/builder.ts
@@ -1,0 +1,251 @@
+import { logger } from '@/lib/logger'
+import { confidenceBandFor, normaliseConfidence } from '../confidence'
+import { isProcessingKilled } from '../flags'
+import type {
+  BuildDraftsInput,
+  BuildDraftsResult,
+  DraftsBuilderDb,
+} from './types'
+
+/**
+ * Drafts builder — turns a classifier result + extractor payload
+ * into `IngestionExtractionResult` + `IngestionVendorDraft` +
+ * `IngestionProductDraft` + `IngestionReviewQueueItem` rows, all
+ * in one transaction.
+ *
+ * Locked invariants honoured here:
+ *
+ *   - Idempotent: re-running with the same `extractorVersion` is a
+ *     no-op (enforced at the DB via @@unique constraints + upsert).
+ *   - Provenance: every product draft carries `sourceMessageId` +
+ *     `sourceExtractionId` + `extractorVersion` + `productOrdinal`.
+ *   - Vendor inference is conservative: `externalId=null` drafts are
+ *     NEVER auto-merged; every vendor attempt records the rule that
+ *     produced it (via the caller's `ExtractionVendorHint.meta`).
+ *   - Review queue gets exactly one `PRODUCT_DRAFT` item per draft
+ *     row; never duplicated on re-run.
+ *   - Non-PRODUCT classifications skip draft creation but still
+ *     persist the classifier's reasoning as an `ExtractionResult`
+ *     row so operators can audit what rules decided.
+ */
+
+const LOG_SCOPE = 'ingestion.processing.drafts'
+
+export interface DraftsBuilderDeps {
+  db: DraftsBuilderDb
+  isKilled?: (ctx: { correlationId: string; messageId: string }) => Promise<boolean>
+}
+
+export async function buildDrafts(
+  input: BuildDraftsInput,
+  deps: DraftsBuilderDeps,
+): Promise<BuildDraftsResult> {
+  const killed = await (deps.isKilled ?? defaultKillProbe)({
+    correlationId: input.correlationId,
+    messageId: input.messageId,
+  })
+  if (killed) {
+    return {
+      status: 'KILLED',
+      extractionResultId: null,
+      productDraftIds: [],
+      vendorDraftId: null,
+      reviewItemsEnqueued: 0,
+      correlationId: input.correlationId,
+    }
+  }
+
+  const result = await deps.db.$transaction(async (tx) => {
+    const extractionRow = await tx.ingestionExtractionResult.upsert({
+      where: {
+        messageId_extractorVersion: {
+          messageId: input.messageId,
+          extractorVersion: input.extractorVersion,
+        },
+      },
+      create: {
+        messageId: input.messageId,
+        engine: 'RULES',
+        extractorVersion: input.extractorVersion,
+        schemaVersion: input.extraction.schemaVersion,
+        inputSnapshot: input.inputSnapshot,
+        payload: input.extraction,
+        confidenceOverall: normaliseConfidence(input.extraction.confidenceOverall).toFixed(2),
+        confidenceBand: confidenceBandFor(
+          normaliseConfidence(input.extraction.confidenceOverall),
+        ),
+        confidenceByField: aggregateConfidenceByField(input.extraction),
+        classification: input.classification.kind,
+        correlationId: input.correlationId,
+      },
+      update: {}, // idempotent: same (message, version) returns existing row
+    })
+
+    if (input.classification.kind !== 'PRODUCT') {
+      // Non-product classifications keep an audit trail but do not
+      // produce drafts or review queue items.
+      return {
+        status: 'SKIPPED_NON_PRODUCT' as const,
+        extractionResultId: extractionRow.id,
+        productDraftIds: [] as string[],
+        vendorDraftId: null,
+        reviewItemsEnqueued: 0,
+      }
+    }
+
+    if (input.extraction.products.length === 0) {
+      // Classifier flagged PRODUCT but rules couldn't pull anything
+      // useful out. Leave the audit trail; don't create empty drafts.
+      logger.warn(`${LOG_SCOPE}.classified_product_with_no_extractable_fields`, {
+        messageId: input.messageId,
+        correlationId: input.correlationId,
+      })
+      return {
+        status: 'SKIPPED_NON_PRODUCT' as const,
+        extractionResultId: extractionRow.id,
+        productDraftIds: [] as string[],
+        vendorDraftId: null,
+        reviewItemsEnqueued: 0,
+      }
+    }
+
+    const vendorDraftId = await upsertVendorDraft(tx, input)
+
+    const productDraftIds: string[] = []
+    let reviewItemsEnqueued = 0
+    for (const product of input.extraction.products) {
+      const normalisedProductConfidence = normaliseConfidence(product.confidenceOverall)
+      const draft = await tx.ingestionProductDraft.upsert({
+        where: {
+          sourceMessageId_extractorVersion_productOrdinal: {
+            sourceMessageId: input.messageId,
+            extractorVersion: input.extractorVersion,
+            productOrdinal: product.productOrdinal,
+          },
+        },
+        create: {
+          sourceMessageId: input.messageId,
+          sourceExtractionId: extractionRow.id,
+          extractorVersion: input.extractorVersion,
+          productOrdinal: product.productOrdinal,
+          vendorDraftId,
+          confidenceOverall: normalisedProductConfidence.toFixed(2),
+          confidenceBand: confidenceBandFor(normalisedProductConfidence),
+          productName: product.productName,
+          categorySlug: product.categorySlug,
+          unit: product.unit,
+          weightGrams: product.weightGrams,
+          priceCents: product.priceCents,
+          currencyCode: product.currencyCode,
+          availability: product.availability,
+          rawFieldsSeen: product.extractionMeta,
+        },
+        update: {},
+      })
+      productDraftIds.push(draft.id)
+
+      await tx.ingestionReviewQueueItem.upsert({
+        where: { kind_targetId: { kind: 'PRODUCT_DRAFT', targetId: draft.id } },
+        create: {
+          kind: 'PRODUCT_DRAFT',
+          targetId: draft.id,
+          priority: 0,
+        },
+        update: {},
+      })
+      reviewItemsEnqueued++
+    }
+
+    return {
+      status: 'OK' as const,
+      extractionResultId: extractionRow.id,
+      productDraftIds,
+      vendorDraftId,
+      reviewItemsEnqueued,
+    }
+  })
+
+  logger.info(`${LOG_SCOPE}.persisted`, {
+    messageId: input.messageId,
+    status: result.status,
+    productDraftCount: result.productDraftIds.length,
+    vendorDraftId: result.vendorDraftId,
+    correlationId: input.correlationId,
+  })
+
+  return { ...result, correlationId: input.correlationId }
+}
+
+async function upsertVendorDraft(
+  tx: DraftsBuilderDb,
+  input: BuildDraftsInput,
+): Promise<string | null> {
+  const hint = input.extraction.vendorHint
+  const displayName = hint.displayName ?? 'Unknown vendor'
+  // Use a single aggregate confidence for the vendor draft; the
+  // extractor already mixed vendor-signal confidence into the payload.
+  const vendorConfidence = normaliseConfidence(input.extraction.confidenceOverall)
+  const band = confidenceBandFor(vendorConfidence)
+
+  if (hint.externalId) {
+    const row = await tx.ingestionVendorDraft.upsert({
+      where: {
+        externalId_extractorVersion: {
+          externalId: hint.externalId,
+          extractorVersion: input.extractorVersion,
+        },
+      },
+      create: {
+        externalId: hint.externalId,
+        displayName,
+        inferredFromMessageIds: [input.messageId],
+        extractorVersion: input.extractorVersion,
+        confidenceOverall: vendorConfidence.toFixed(2),
+        confidenceBand: band,
+      },
+      update: {},
+    })
+    return row.id
+  }
+
+  // No stable external id → we must still record the vendor somewhere,
+  // but we deliberately create a fresh VendorDraft per message so no
+  // auto-merge logic can conflate unknown authors. Admin review will
+  // later decide whether two unknown-author drafts are the same vendor.
+  const row = await tx.ingestionVendorDraft.create({
+    data: {
+      externalId: null,
+      displayName,
+      inferredFromMessageIds: [input.messageId],
+      extractorVersion: input.extractorVersion,
+      confidenceOverall: vendorConfidence.toFixed(2),
+      confidenceBand: band,
+    },
+  })
+  return row.id
+}
+
+function aggregateConfidenceByField(extraction: BuildDraftsInput['extraction']): Record<string, number> {
+  // Union across products, taking the max per field. Gives callers a
+  // quick "how confident were we on this field anywhere" view.
+  const out: Record<string, number> = {}
+  for (const product of extraction.products) {
+    for (const [field, value] of Object.entries(product.confidenceByField)) {
+      const prev = out[field] ?? 0
+      if (value > prev) out[field] = value
+    }
+  }
+  return out
+}
+
+async function defaultKillProbe(ctx: {
+  correlationId: string
+  messageId: string
+}): Promise<boolean> {
+  return isProcessingKilled(undefined, {
+    correlationId: ctx.correlationId,
+    messageId: ctx.messageId,
+    stage: 'rules-extractor',
+    jobKind: 'ingestion.processing.build-drafts',
+  })
+}

--- a/src/domains/ingestion/processing/drafts/index.ts
+++ b/src/domains/ingestion/processing/drafts/index.ts
@@ -1,0 +1,7 @@
+export { buildDrafts, type DraftsBuilderDeps } from './builder'
+export type {
+  BuildDraftsInput,
+  BuildDraftsResult,
+  DraftsBuilderDb,
+  ClassifierPersistenceInput,
+} from './types'

--- a/src/domains/ingestion/processing/drafts/types.ts
+++ b/src/domains/ingestion/processing/drafts/types.ts
@@ -1,0 +1,118 @@
+import type { ExtractionPayload } from '../extractor/schema'
+
+/**
+ * Narrow DB surface for the drafts builder. Only the Prisma methods
+ * we actually call live here; test fakes implement just this subset.
+ */
+
+export interface ClassifierPersistenceInput {
+  kind: 'PRODUCT' | 'CONVERSATION' | 'SPAM' | 'OTHER'
+  confidence: number
+  confidenceBand: 'LOW' | 'MEDIUM' | 'HIGH'
+  signals: unknown // serialised ClassifierSignal[]
+}
+
+export interface BuildDraftsInput {
+  messageId: string
+  extractorVersion: string
+  classification: ClassifierPersistenceInput
+  extraction: ExtractionPayload
+  inputSnapshot: unknown
+  correlationId: string
+}
+
+export interface BuildDraftsResult {
+  status: 'OK' | 'KILLED' | 'SKIPPED_NON_PRODUCT'
+  extractionResultId: string | null
+  productDraftIds: string[]
+  vendorDraftId: string | null
+  reviewItemsEnqueued: number
+  correlationId: string
+}
+
+export interface DraftsBuilderDb {
+  ingestionExtractionResult: {
+    upsert(args: {
+      where: { messageId_extractorVersion: { messageId: string; extractorVersion: string } }
+      create: {
+        messageId: string
+        engine: 'RULES'
+        extractorVersion: string
+        schemaVersion: number
+        inputSnapshot: unknown
+        payload: unknown
+        confidenceOverall: number | string
+        confidenceBand: 'LOW' | 'MEDIUM' | 'HIGH'
+        confidenceByField: unknown
+        classification: 'PRODUCT' | 'CONVERSATION' | 'SPAM' | 'OTHER'
+        correlationId: string
+      }
+      update: Record<string, never>
+    }): Promise<{ id: string }>
+  }
+  ingestionVendorDraft: {
+    upsert(args: {
+      where: { externalId_extractorVersion: { externalId: string; extractorVersion: string } }
+      create: {
+        externalId: string
+        displayName: string
+        inferredFromMessageIds: unknown
+        extractorVersion: string
+        confidenceOverall: number | string
+        confidenceBand: 'LOW' | 'MEDIUM' | 'HIGH'
+      }
+      update: Record<string, never>
+    }): Promise<{ id: string }>
+    create(args: {
+      data: {
+        externalId: null
+        displayName: string
+        inferredFromMessageIds: unknown
+        extractorVersion: string
+        confidenceOverall: number | string
+        confidenceBand: 'LOW' | 'MEDIUM' | 'HIGH'
+      }
+    }): Promise<{ id: string }>
+  }
+  ingestionProductDraft: {
+    upsert(args: {
+      where: {
+        sourceMessageId_extractorVersion_productOrdinal: {
+          sourceMessageId: string
+          extractorVersion: string
+          productOrdinal: number
+        }
+      }
+      create: {
+        sourceMessageId: string
+        sourceExtractionId: string
+        extractorVersion: string
+        productOrdinal: number
+        vendorDraftId: string | null
+        confidenceOverall: number | string
+        confidenceBand: 'LOW' | 'MEDIUM' | 'HIGH'
+        productName: string | null
+        categorySlug: string | null
+        unit: string | null
+        weightGrams: number | null
+        priceCents: number | null
+        currencyCode: string | null
+        availability: string | null
+        rawFieldsSeen: unknown
+      }
+      update: Record<string, never>
+    }): Promise<{ id: string; productOrdinal: number }>
+  }
+  ingestionReviewQueueItem: {
+    upsert(args: {
+      where: { kind_targetId: { kind: 'PRODUCT_DRAFT' | 'VENDOR_DRAFT' | 'DEDUPE_CANDIDATE'; targetId: string } }
+      create: {
+        kind: 'PRODUCT_DRAFT' | 'VENDOR_DRAFT' | 'DEDUPE_CANDIDATE'
+        targetId: string
+        priority: number
+      }
+      update: Record<string, never>
+    }): Promise<{ id: string }>
+  }
+  $transaction<T>(fn: (tx: DraftsBuilderDb) => Promise<T>): Promise<T>
+}

--- a/src/domains/ingestion/processing/extractor/index.ts
+++ b/src/domains/ingestion/processing/extractor/index.ts
@@ -1,0 +1,9 @@
+export { extractRules, type ExtractorInput, splitIntoProductSegments } from './rules'
+export {
+  EXTRACTION_SCHEMA_VERSION,
+  extractionPayloadSchema,
+  type ExtractionPayload,
+  type ExtractedProduct,
+  type ExtractionMetaEntry,
+  type ExtractionVendorHint,
+} from './schema'

--- a/src/domains/ingestion/processing/extractor/rules.ts
+++ b/src/domains/ingestion/processing/extractor/rules.ts
@@ -1,0 +1,337 @@
+import type {
+  ExtractedProduct,
+  ExtractionMetaEntry,
+  ExtractionPayload,
+  ExtractionVendorHint,
+} from './schema'
+import { EXTRACTION_SCHEMA_VERSION } from './schema'
+import { normaliseConfidence } from '../confidence'
+
+/**
+ * Rules-based extractor. Deterministic, traceable, conservative.
+ *
+ * Every extracted field records the rule that produced it and the
+ * source substring — operators can explain any value on any draft
+ * without re-running the pipeline.
+ *
+ * When in doubt, we emit `null` with low per-field confidence rather
+ * than guess. The classifier already filtered the message to
+ * PRODUCT, so we're allowed to assume there's SOMETHING worth
+ * extracting — but not allowed to invent associations.
+ */
+
+export interface ExtractorInput {
+  text: string
+  vendorHint?: {
+    authorDisplayName?: string | null
+    authorExternalId?: string | null
+  }
+}
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+export function extractRules(input: ExtractorInput): ExtractionPayload {
+  const rulesFired = new Set<string>()
+
+  const vendorHint = buildVendorHint(input)
+  rulesFired.add(vendorHint.meta.rule)
+
+  const products = splitIntoProductSegments(input.text).flatMap(
+    (segment, ordinal) => {
+      const product = extractSingleProduct(segment, ordinal)
+      if (!product) return []
+      for (const rule of product.extractionMeta
+        ? Object.values(product.extractionMeta)
+        : []) {
+        if (rule) rulesFired.add(rule.rule)
+      }
+      return [product]
+    },
+  )
+
+  // Overall confidence: mean of per-product confidence, or 0 if empty.
+  const confidenceOverall = normaliseConfidence(
+    products.length === 0
+      ? 0
+      : products.reduce((acc, p) => acc + p.confidenceOverall, 0) / products.length,
+  )
+
+  return {
+    schemaVersion: EXTRACTION_SCHEMA_VERSION,
+    products,
+    vendorHint,
+    confidenceOverall,
+    rulesFired: [...rulesFired],
+  }
+}
+
+// ─── Segmentation ────────────────────────────────────────────────────────────
+
+/**
+ * Split the message into candidate product segments. A segment is a
+ * coherent piece of text that could describe exactly one product.
+ * Conservative: if we can't cleanly split, return the whole text as
+ * a single segment rather than inventing splits.
+ */
+export function splitIntoProductSegments(text: string): string[] {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return []
+
+  // Line-based list: a blank line or a leading bullet/number marks a
+  // new product. This is the common "producer posts a menu" pattern.
+  const lines = trimmed.split(/\r?\n+/).map((l) => l.trim()).filter(Boolean)
+  const bulletRegex = /^(?:[-*•·]\s+|\d+[.)]\s+)/
+  if (lines.length > 1 && lines.some((l) => bulletRegex.test(l))) {
+    const segments = lines
+      .filter((l) => bulletRegex.test(l))
+      .map((l) => l.replace(bulletRegex, '').trim())
+    if (segments.length > 0) return segments
+  }
+  if (lines.length > 1) {
+    // If every line has its own price, treat each as a segment.
+    const priceRe = /(\d+[.,]?\d*)\s*(?:€|eur)/i
+    const linesWithPrice = lines.filter((l) => priceRe.test(l))
+    if (linesWithPrice.length >= 2 && linesWithPrice.length === lines.length) {
+      return lines
+    }
+  }
+  return [trimmed]
+}
+
+// ─── Per-product extraction ──────────────────────────────────────────────────
+
+function extractSingleProduct(segment: string, ordinal: number): ExtractedProduct | null {
+  const meta: ExtractedProduct['extractionMeta'] = {}
+  const confidenceByField: Record<string, number> = {}
+
+  const price = extractPrice(segment)
+  if (price) {
+    meta.priceCents = price.meta
+    confidenceByField.priceCents = price.confidence
+    meta.currencyCode = { rule: 'currencyFromPrice', source: price.meta.source }
+    confidenceByField.currencyCode = price.confidence
+  }
+
+  const unit = extractUnit(segment)
+  if (unit) {
+    meta.unit = unit.meta
+    confidenceByField.unit = unit.confidence
+  }
+
+  const weight = extractWeightGrams(segment)
+  if (weight) {
+    meta.weightGrams = weight.meta
+    confidenceByField.weightGrams = weight.confidence
+  }
+
+  const availability = extractAvailability(segment)
+  meta.availability = availability.meta
+  confidenceByField.availability = availability.confidence
+
+  const name = extractProductName(segment)
+  if (name) {
+    meta.productName = name.meta
+    confidenceByField.productName = name.confidence
+  }
+
+  // Conservative: require a price. Without a price, a "product" is
+  // just a noun — we prefer to skip it and let the review queue stay
+  // empty rather than build a draft from a single word.
+  if (!price) return null
+
+  const confidenceOverall = normaliseConfidence(
+    meanConfidence(confidenceByField),
+  )
+
+  return {
+    productOrdinal: ordinal,
+    productName: name?.value ?? null,
+    categorySlug: null, // Phase 2 leaves categorySlug to admin review.
+    unit: unit?.value ?? null,
+    weightGrams: weight?.value ?? null,
+    priceCents: price?.value ?? null,
+    currencyCode: price ? 'EUR' : null,
+    availability: availability.value,
+    confidenceOverall,
+    confidenceByField,
+    extractionMeta: meta,
+  }
+}
+
+// ─── Field extractors ────────────────────────────────────────────────────────
+
+interface Extracted<T> {
+  value: T
+  confidence: number
+  meta: ExtractionMetaEntry
+}
+
+const PRICE_REGEX_FULL =
+  /(\d+[.,]?\d*)\s*(?:€|eur(?:os?)?)/i
+const PRICE_RANGE_REGEX =
+  /(\d+[.,]?\d*)\s*-\s*(\d+[.,]?\d*)\s*(?:€|eur(?:os?)?)/i
+
+function extractPrice(segment: string): Extracted<number> | null {
+  // Price ranges ("4-6€/kg") are deliberately NOT extracted as a
+  // single value: picking either bound is wrong for at least some
+  // buyers. Conservative policy: take the lower bound with halved
+  // confidence, record the range in `extractionMeta`.
+  const range = PRICE_RANGE_REGEX.exec(segment)
+  if (range) {
+    const raw = (range[1] ?? '').replace(',', '.')
+    const euros = Number.parseFloat(raw)
+    if (!Number.isFinite(euros) || euros <= 0) return null
+    return {
+      value: Math.round(euros * 100),
+      confidence: 0.4,
+      meta: { rule: 'priceRangeLowerBound', source: range[0] },
+    }
+  }
+  const m = PRICE_REGEX_FULL.exec(segment)
+  if (!m) return null
+  const raw = (m[1] ?? '').replace(',', '.')
+  const euros = Number.parseFloat(raw)
+  if (!Number.isFinite(euros) || euros <= 0) return null
+  const priceCents = Math.round(euros * 100)
+  // Price with an adjacent unit / per-unit indicator is more trustable
+  // than a bare number; give a slight bump.
+  const hasPerUnit = /(?:€|eur(?:os?)?)\s*\/\s*(?:kg|g|l|ml|ud|uds|unidades?)/i.test(m[0])
+  const confidence = hasPerUnit ? 0.9 : 0.75
+  return {
+    value: priceCents,
+    confidence,
+    meta: {
+      rule: hasPerUnit ? 'priceWithPerUnit' : 'priceBare',
+      source: m[0],
+    },
+  }
+}
+
+const UNIT_TOKEN_REGEX = /\b(\d+[.,]?\d*)?\s*(kg|g|l|ml|ud|uds|unidades?|kilos?|gramos?|litros?|mililitros?)\b/i
+
+function extractUnit(segment: string): Extracted<ExtractedProduct['unit']> | null {
+  const m = UNIT_TOKEN_REGEX.exec(segment)
+  if (!m) return null
+  const token = (m[2] ?? '').toLowerCase()
+  const unit = canonicaliseUnit(token)
+  if (!unit) return null
+  return {
+    value: unit,
+    confidence: 0.8,
+    meta: { rule: 'unitToken', source: m[0] },
+  }
+}
+
+function canonicaliseUnit(token: string): ExtractedProduct['unit'] | null {
+  if (token === 'kg' || token.startsWith('kilo')) return 'KG'
+  if (token === 'g' || token.startsWith('gramo')) return 'G'
+  if (token === 'l' || token.startsWith('litro')) return 'L'
+  if (token === 'ml' || token.startsWith('mililitro')) return 'ML'
+  if (/^(ud|uds|unidad|unidades)$/i.test(token)) return 'UNIT'
+  return null
+}
+
+const WEIGHT_REGEX = /\b(\d+[.,]?\d*)\s*(kg|g|kilos?|gramos?)\b/i
+
+function extractWeightGrams(segment: string): Extracted<number> | null {
+  const m = WEIGHT_REGEX.exec(segment)
+  if (!m) return null
+  const raw = (m[1] ?? '').replace(',', '.')
+  const qty = Number.parseFloat(raw)
+  if (!Number.isFinite(qty) || qty <= 0) return null
+  const isKg = /kg|kilo/i.test(m[2] ?? '')
+  const grams = Math.round(isKg ? qty * 1000 : qty)
+  return {
+    value: grams,
+    confidence: 0.75,
+    meta: { rule: isKg ? 'weightKilograms' : 'weightGrams', source: m[0] },
+  }
+}
+
+const AVAILABILITY_HINTS: Array<{
+  re: RegExp
+  value: ExtractedProduct['availability']
+  rule: string
+}> = [
+  { re: /\bagotado\b|\bsold out\b|\bno queda\b/i, value: 'SOLD_OUT', rule: 'availSoldOut' },
+  { re: /\bquedan (?:pocos|pocas)\b|\bultim[oa]s\b|\bstock limitado\b/i, value: 'LIMITED', rule: 'availLimited' },
+  { re: /\bdisponibl[eé]\b|\bhoy\b|\bfresco\b/i, value: 'AVAILABLE', rule: 'availAvailable' },
+]
+
+function extractAvailability(segment: string): Extracted<ExtractedProduct['availability']> {
+  for (const hint of AVAILABILITY_HINTS) {
+    const m = hint.re.exec(segment)
+    if (m) {
+      return {
+        value: hint.value,
+        confidence: 0.7,
+        meta: { rule: hint.rule, source: m[0] },
+      }
+    }
+  }
+  return {
+    value: 'UNKNOWN',
+    confidence: 0.3,
+    meta: { rule: 'availDefault', source: '' },
+  }
+}
+
+function extractProductName(segment: string): Extracted<string> | null {
+  // Take everything before the first price / unit token, up to 80
+  // chars, strip bullets + trailing punctuation. If empty, null.
+  const priceIdx = searchIndex(segment, PRICE_REGEX_FULL)
+  const unitIdx = searchIndex(segment, UNIT_TOKEN_REGEX)
+  const cutoffs = [priceIdx, unitIdx].filter((n): n is number => n > 0)
+  const cutoff = cutoffs.length > 0 ? Math.min(...cutoffs) : segment.length
+  let candidate = segment.slice(0, cutoff).trim()
+  candidate = candidate.replace(/^[-*•·]\s*/, '').replace(/[:,.\s-]+$/, '').trim()
+  if (candidate.length < 2) return null
+  // Cap length to avoid swallowing emoji-heavy headers.
+  if (candidate.length > 80) candidate = candidate.slice(0, 80).trim()
+  // Clean emoji-only strings.
+  if (!/[a-z]/i.test(candidate)) return null
+  return {
+    value: candidate,
+    confidence: 0.6,
+    meta: { rule: 'firstSegmentBeforePriceOrUnit', source: candidate },
+  }
+}
+
+function searchIndex(text: string, re: RegExp): number {
+  const m = re.exec(text)
+  return m ? m.index : -1
+}
+
+// ─── Vendor hint ─────────────────────────────────────────────────────────────
+
+function buildVendorHint(input: ExtractorInput): ExtractionVendorHint {
+  const authorId = input.vendorHint?.authorExternalId ?? null
+  const authorName = input.vendorHint?.authorDisplayName ?? null
+  if (authorId) {
+    return {
+      externalId: authorId,
+      displayName: authorName,
+      meta: { rule: 'telegramAuthorExternalId', source: `author:${authorId}` },
+    }
+  }
+  if (authorName) {
+    return {
+      externalId: null,
+      displayName: authorName,
+      meta: { rule: 'telegramAuthorDisplayName', source: `author:${authorName}` },
+    }
+  }
+  return {
+    externalId: null,
+    displayName: null,
+    meta: { rule: 'vendorUnknown', source: '' },
+  }
+}
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
+
+function meanConfidence(byField: Record<string, number>): number {
+  const values = Object.values(byField)
+  if (values.length === 0) return 0
+  return values.reduce((a, b) => a + b, 0) / values.length
+}

--- a/src/domains/ingestion/processing/extractor/schema.ts
+++ b/src/domains/ingestion/processing/extractor/schema.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod'
+
+/**
+ * Frozen extractor payload schema.
+ *
+ * This shape is the cross-phase contract: the Phase 2 rules extractor
+ * emits it and the Phase 2.5 LLM extractor MUST emit the same shape.
+ * Any change to the shape bumps `schemaVersion` on
+ * `IngestionExtractionResult` and requires a matching freeze test
+ * update (see `test/contracts/domain/ingestion-extraction-schema.test.ts`).
+ *
+ * Per-field traceability lives in `extractionMeta`: each extracted
+ * field records the rule that produced it and the source substring,
+ * so operators can explain any value on any draft without re-running
+ * the pipeline.
+ */
+
+export const EXTRACTION_SCHEMA_VERSION = 1
+
+const unitSchema = z
+  .enum(['KG', 'G', 'L', 'ML', 'UNIT'])
+  .nullable()
+
+const availabilitySchema = z.enum([
+  'AVAILABLE',
+  'LIMITED',
+  'SOLD_OUT',
+  'UNKNOWN',
+])
+
+const extractionMetaEntrySchema = z.object({
+  rule: z.string().min(1),
+  source: z.string(),
+})
+
+const productMetaSchema = z.object({
+  productName: extractionMetaEntrySchema.optional(),
+  categorySlug: extractionMetaEntrySchema.optional(),
+  unit: extractionMetaEntrySchema.optional(),
+  weightGrams: extractionMetaEntrySchema.optional(),
+  priceCents: extractionMetaEntrySchema.optional(),
+  currencyCode: extractionMetaEntrySchema.optional(),
+  availability: extractionMetaEntrySchema.optional(),
+})
+
+const extractedProductSchema = z.object({
+  productOrdinal: z.number().int().nonnegative(),
+  productName: z.string().nullable(),
+  categorySlug: z.string().nullable(),
+  unit: unitSchema,
+  weightGrams: z.number().int().positive().nullable(),
+  priceCents: z.number().int().positive().nullable(),
+  currencyCode: z.enum(['EUR']).nullable(),
+  availability: availabilitySchema,
+  confidenceOverall: z.number().min(0).max(1),
+  confidenceByField: z.record(z.string(), z.number().min(0).max(1)),
+  extractionMeta: productMetaSchema,
+})
+
+const vendorHintSchema = z.object({
+  externalId: z.string().nullable(),
+  displayName: z.string().nullable(),
+  meta: z.object({
+    rule: z.string(),
+    source: z.string(),
+  }),
+})
+
+export const extractionPayloadSchema = z.object({
+  schemaVersion: z.literal(EXTRACTION_SCHEMA_VERSION),
+  products: z.array(extractedProductSchema),
+  vendorHint: vendorHintSchema,
+  confidenceOverall: z.number().min(0).max(1),
+  rulesFired: z.array(z.string()),
+})
+
+export type ExtractionPayload = z.infer<typeof extractionPayloadSchema>
+export type ExtractedProduct = z.infer<typeof extractedProductSchema>
+export type ExtractionVendorHint = z.infer<typeof vendorHintSchema>
+export type ExtractionMetaEntry = z.infer<typeof extractionMetaEntrySchema>

--- a/src/domains/ingestion/processing/index.ts
+++ b/src/domains/ingestion/processing/index.ts
@@ -7,3 +7,6 @@
  */
 
 export * from './types'
+export * from './classifier'
+export * from './extractor'
+export * from './drafts'

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -22,12 +22,17 @@ import { getQueue, registerHandler, stopQueue } from '@/lib/queue'
 import { logger } from '@/lib/logger'
 import {
   INGESTION_JOB_KINDS,
+  PROCESSING_JOB_KINDS,
   resolveIngestionRuntimeConfig,
   type TelegramMediaDownloadJobData,
   type TelegramSyncJobData,
 } from '@/domains/ingestion'
 import { runTelegramSyncJob } from './jobs/telegram-sync'
 import { runTelegramMediaDownloadJob } from './jobs/telegram-media-download'
+import {
+  runProcessMessageJob,
+  type ProcessMessageJobData,
+} from './jobs/ingestion-processing'
 
 async function main() {
   logger.info('worker.starting', {
@@ -50,11 +55,23 @@ async function main() {
       await runTelegramMediaDownloadJob(job)
     },
   )
+  // Phase 2: deterministic processing pipeline (classifier + rules
+  // extractor + drafts builder) run inline inside a single job per
+  // raw message. The umbrella `kill-ingestion-processing` + the
+  // `feat-ingestion-rules-extractor` stage flag both default to off,
+  // so the handler is inert until operators opt in.
+  await registerHandler<ProcessMessageJobData>(
+    PROCESSING_JOB_KINDS.buildDrafts,
+    async (job) => {
+      await runProcessMessageJob(job)
+    },
+  )
 
   logger.info('worker.ready', {
     handlers: [
       INGESTION_JOB_KINDS.telegramSync,
       INGESTION_JOB_KINDS.telegramMediaDownload,
+      PROCESSING_JOB_KINDS.buildDrafts,
     ],
     config,
   })

--- a/src/workers/jobs/ingestion-processing.ts
+++ b/src/workers/jobs/ingestion-processing.ts
@@ -1,0 +1,129 @@
+import type PgBoss from 'pg-boss'
+import { db } from '@/lib/db'
+import {
+  buildDrafts,
+  CURRENT_RULES_EXTRACTOR_VERSION,
+  EXTRACTION_SCHEMA_VERSION,
+  classifyMessage,
+  confidenceBandFor,
+  extractRules,
+  isStageEnabled,
+  normaliseConfidence,
+  type DraftsBuilderDb,
+  type ExtractionPayload,
+} from '@/domains/ingestion'
+import { logger } from '@/lib/logger'
+import { generateCorrelationId } from '@/lib/correlation'
+
+/**
+ * Worker adapter for the Phase 2 processing pipeline.
+ *
+ * The worker job name is `ingestion.processing.process-message`. It
+ * runs the full deterministic chain for a single raw message:
+ *
+ *   1. stage gate: umbrella kill + `feat-ingestion-rules-extractor`
+ *      flag must both allow action.
+ *   2. load message row.
+ *   3. classifier → classifier result.
+ *   4. if kind !== PRODUCT, still persist the extraction result as an
+ *      audit row via `buildDrafts` (it handles the skip path).
+ *   5. if PRODUCT, extractor → drafts builder (single transaction).
+ *
+ * Phase 2 deliberately runs the three stages inline: splitting them
+ * across three pg-boss jobs would complicate idempotency without any
+ * measurable benefit at current volumes. Phase 2.5 (LLM) will
+ * introduce a separate job because LLM cost makes it worth isolating.
+ */
+
+function emptyExtractionFor(
+  classifierKind: 'CONVERSATION' | 'SPAM' | 'OTHER',
+): ExtractionPayload {
+  return {
+    schemaVersion: EXTRACTION_SCHEMA_VERSION,
+    products: [],
+    vendorHint: {
+      externalId: null,
+      displayName: null,
+      meta: { rule: 'classifiedNonProduct', source: classifierKind },
+    },
+    confidenceOverall: 0,
+    rulesFired: [],
+  }
+}
+
+export interface ProcessMessageJobData {
+  messageId: string
+  correlationId?: string
+}
+
+export async function runProcessMessageJob(
+  job: PgBoss.Job<ProcessMessageJobData>,
+): Promise<void> {
+  const correlationId = job.data.correlationId ?? generateCorrelationId()
+  const stageEnabled = await isStageEnabled('rules-extractor', undefined, {
+    correlationId,
+    messageId: job.data.messageId,
+    jobKind: 'ingestion.processing.process-message',
+  })
+  if (!stageEnabled) {
+    return
+  }
+
+  const message = await db.telegramIngestionMessage.findUnique({
+    where: { id: job.data.messageId },
+  })
+  if (!message) {
+    logger.warn('ingestion.processing.message_not_found', {
+      messageId: job.data.messageId,
+      correlationId,
+    })
+    return
+  }
+
+  const classifierAlso = await isStageEnabled('classifier', undefined, {
+    correlationId,
+    messageId: message.id,
+    jobKind: 'ingestion.processing.process-message',
+  })
+  if (!classifierAlso) {
+    return
+  }
+
+  const classifier = classifyMessage({ text: message.text })
+  const classifierConfidence = normaliseConfidence(classifier.confidence)
+  const classifierBand = confidenceBandFor(classifierConfidence)
+
+  const extractorVersion = CURRENT_RULES_EXTRACTOR_VERSION
+  const extraction = classifier.kind === 'PRODUCT'
+    ? extractRules({
+        text: message.text ?? '',
+        vendorHint: {
+          authorExternalId: message.tgAuthorId?.toString() ?? null,
+        },
+      })
+    : emptyExtractionFor(classifier.kind)
+
+  await buildDrafts(
+    {
+      messageId: message.id,
+      extractorVersion,
+      classification: {
+        kind: classifier.kind,
+        confidence: classifierConfidence,
+        confidenceBand: classifierBand,
+        signals: classifier.signals,
+      },
+      extraction,
+      inputSnapshot: {
+        text: message.text,
+        postedAt: message.postedAt,
+        tgMessageId: message.tgMessageId.toString(),
+        tgAuthorId: message.tgAuthorId?.toString() ?? null,
+      },
+      correlationId,
+    },
+    {
+      db: db as unknown as DraftsBuilderDb,
+    },
+  )
+}

--- a/test/contracts/domain/ingestion-extraction-schema.test.ts
+++ b/test/contracts/domain/ingestion-extraction-schema.test.ts
@@ -1,0 +1,113 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  EXTRACTION_SCHEMA_VERSION,
+  extractionPayloadSchema,
+} from '@/domains/ingestion/processing/extractor/schema'
+
+/**
+ * Shape freeze for the extractor payload. Changing this contract is a
+ * cross-phase breaking change: Phase 2.5 LLM extraction MUST emit
+ * the same shape. Any intentional change bumps
+ * `EXTRACTION_SCHEMA_VERSION` AND updates this fixture in the same
+ * commit.
+ */
+
+test('ExtractionPayload schema version is 1 (frozen)', () => {
+  assert.equal(EXTRACTION_SCHEMA_VERSION, 1)
+})
+
+test('ExtractionPayload parses a well-formed single-product payload', () => {
+  const parsed = extractionPayloadSchema.parse({
+    schemaVersion: 1,
+    products: [
+      {
+        productOrdinal: 0,
+        productName: 'Manzanas golden',
+        categorySlug: 'frutas',
+        unit: 'KG',
+        weightGrams: null,
+        priceCents: 250,
+        currencyCode: 'EUR',
+        availability: 'AVAILABLE',
+        confidenceOverall: 0.85,
+        confidenceByField: { priceCents: 0.9, unit: 0.8 },
+        extractionMeta: {
+          productName: { rule: 'firstSegmentBeforePrice', source: 'Manzanas golden' },
+          priceCents: { rule: 'priceEurPerKg', source: '2,50€/kg' },
+          unit: { rule: 'unitToken', source: 'kg' },
+        },
+      },
+    ],
+    vendorHint: {
+      externalId: null,
+      displayName: 'Granja El Olmo',
+      meta: { rule: 'telegramAuthor', source: 'author:Granja El Olmo' },
+    },
+    confidenceOverall: 0.85,
+    rulesFired: ['priceEurPerKg', 'unitToken', 'telegramAuthor'],
+  })
+  assert.equal(parsed.products[0]!.productOrdinal, 0)
+  assert.equal(parsed.vendorHint.displayName, 'Granja El Olmo')
+})
+
+test('ExtractionPayload rejects confidence outside [0,1]', () => {
+  assert.throws(() =>
+    extractionPayloadSchema.parse({
+      schemaVersion: 1,
+      products: [],
+      vendorHint: {
+        externalId: null,
+        displayName: null,
+        meta: { rule: 'none', source: '' },
+      },
+      confidenceOverall: 1.5,
+      rulesFired: [],
+    }),
+  )
+})
+
+test('ExtractionPayload rejects unknown units', () => {
+  assert.throws(() =>
+    extractionPayloadSchema.parse({
+      schemaVersion: 1,
+      products: [
+        {
+          productOrdinal: 0,
+          productName: null,
+          categorySlug: null,
+          unit: 'LBS', // not in the closed enum
+          weightGrams: null,
+          priceCents: null,
+          currencyCode: null,
+          availability: 'UNKNOWN',
+          confidenceOverall: 0.1,
+          confidenceByField: {},
+          extractionMeta: {},
+        },
+      ],
+      vendorHint: {
+        externalId: null,
+        displayName: null,
+        meta: { rule: 'none', source: '' },
+      },
+      confidenceOverall: 0.1,
+      rulesFired: [],
+    }),
+  )
+})
+
+test('ExtractionPayload parses empty products array (classifier rejected PRODUCT)', () => {
+  const parsed = extractionPayloadSchema.parse({
+    schemaVersion: 1,
+    products: [],
+    vendorHint: {
+      externalId: null,
+      displayName: null,
+      meta: { rule: 'none', source: '' },
+    },
+    confidenceOverall: 0,
+    rulesFired: [],
+  })
+  assert.equal(parsed.products.length, 0)
+})

--- a/test/features/ingestion-classifier.test.ts
+++ b/test/features/ingestion-classifier.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { classifyMessage } from '@/domains/ingestion/processing/classifier'
+
+/**
+ * Frozen fixtures pin the classifier's behaviour on real-shape
+ * messages. Do not mutate existing cases to make the tests pass;
+ * if behaviour needs to change, add a new fixture and bump
+ * `CURRENT_RULES_EXTRACTOR_VERSION` (rules-1.0.x → rules-1.1.0).
+ */
+
+interface FixtureCase {
+  id: string
+  description: string
+  text: string
+  expectedClassifier: {
+    kind: 'PRODUCT' | 'CONVERSATION' | 'SPAM' | 'OTHER'
+    confidenceAtLeast?: number
+  }
+}
+
+const fixturePath = join(
+  process.cwd(),
+  'test/fixtures/ingestion-messages/cases.json',
+)
+const cases = JSON.parse(readFileSync(fixturePath, 'utf-8')) as FixtureCase[]
+
+for (const fx of cases) {
+  test(`classifier fixture: ${fx.id} — ${fx.description}`, () => {
+    const result = classifyMessage({ text: fx.text })
+    assert.equal(
+      result.kind,
+      fx.expectedClassifier.kind,
+      `expected ${fx.expectedClassifier.kind} got ${result.kind}; signals=${JSON.stringify(result.signals)}`,
+    )
+    if (fx.expectedClassifier.confidenceAtLeast !== undefined) {
+      assert.ok(
+        result.confidence >= fx.expectedClassifier.confidenceAtLeast,
+        `confidence ${result.confidence} < ${fx.expectedClassifier.confidenceAtLeast}`,
+      )
+    }
+  })
+}
+
+test('classifier is deterministic: same input → same output', () => {
+  const text = 'Manzanas golden: 2,50€/kg. Disponibles hoy.'
+  const a = classifyMessage({ text })
+  const b = classifyMessage({ text })
+  assert.deepEqual(a, b)
+})
+
+test('classifier signals are explainable (rule name + weight > 0) when kind is not OTHER', () => {
+  const result = classifyMessage({ text: 'Manzanas golden 2,50€/kg' })
+  assert.equal(result.kind, 'PRODUCT')
+  for (const signal of result.signals) {
+    assert.ok(signal.rule.length > 0, 'signal must carry a rule name')
+    assert.ok(signal.weight > 0, 'PRODUCT signals must have positive weight')
+  }
+})
+
+test('classifier favours false negatives: single produce word is OTHER not PRODUCT', () => {
+  assert.equal(classifyMessage({ text: 'Manzanas' }).kind, 'OTHER')
+  assert.equal(classifyMessage({ text: 'Patatas' }).kind, 'OTHER')
+})

--- a/test/features/ingestion-drafts-builder.test.ts
+++ b/test/features/ingestion-drafts-builder.test.ts
@@ -1,0 +1,293 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildDrafts,
+  type BuildDraftsInput,
+  type DraftsBuilderDb,
+} from '@/domains/ingestion'
+
+/**
+ * In-memory DraftsBuilderDb: no DB, no Prisma, just a shape-compatible
+ * fake that honours the uniqueness constraints the real tables do.
+ * Integration against real Postgres lives in
+ * `test/integration/ingestion-processing-trace.test.ts`.
+ */
+
+function createFakeDb() {
+  const extractions = new Map<string, { id: string; key: string }>()
+  const vendors = new Map<string, { id: string; key: string }>()
+  const products = new Map<string, { id: string; ordinal: number; key: string }>()
+  const reviewItems = new Map<string, { id: string }>()
+  let idSeq = 0
+  const id = (prefix: string) => `${prefix}_${++idSeq}`
+
+  const db: DraftsBuilderDb = {
+    ingestionExtractionResult: {
+      async upsert({ where, create }) {
+        const key = `${where.messageId_extractorVersion.messageId}|${where.messageId_extractorVersion.extractorVersion}`
+        const existing = extractions.get(key)
+        if (existing) return { id: existing.id }
+        const row = { id: id('ex'), key }
+        extractions.set(key, row)
+        void create
+        return { id: row.id }
+      },
+    },
+    ingestionVendorDraft: {
+      async upsert({ where, create }) {
+        const key = `${where.externalId_extractorVersion.externalId}|${where.externalId_extractorVersion.extractorVersion}`
+        const existing = vendors.get(key)
+        if (existing) return { id: existing.id }
+        const row = { id: id('vd'), key }
+        vendors.set(key, row)
+        void create
+        return { id: row.id }
+      },
+      async create({ data }) {
+        const row = { id: id('vd-anon'), key: `anon:${data.displayName}:${idSeq}` }
+        vendors.set(row.key, row)
+        return { id: row.id }
+      },
+    },
+    ingestionProductDraft: {
+      async upsert({ where, create }) {
+        const key = `${where.sourceMessageId_extractorVersion_productOrdinal.sourceMessageId}|${where.sourceMessageId_extractorVersion_productOrdinal.extractorVersion}|${where.sourceMessageId_extractorVersion_productOrdinal.productOrdinal}`
+        const existing = products.get(key)
+        if (existing) return { id: existing.id, productOrdinal: existing.ordinal }
+        const row = {
+          id: id('pd'),
+          ordinal: where.sourceMessageId_extractorVersion_productOrdinal.productOrdinal,
+          key,
+        }
+        products.set(key, row)
+        void create
+        return { id: row.id, productOrdinal: row.ordinal }
+      },
+    },
+    ingestionReviewQueueItem: {
+      async upsert({ where }) {
+        const key = `${where.kind_targetId.kind}|${where.kind_targetId.targetId}`
+        const existing = reviewItems.get(key)
+        if (existing) return { id: existing.id }
+        const row = { id: id('rq') }
+        reviewItems.set(key, row)
+        return { id: row.id }
+      },
+    },
+    async $transaction(fn) {
+      return fn(db)
+    },
+  }
+  return { db, extractions, vendors, products, reviewItems }
+}
+
+function baseInput(overrides: Partial<BuildDraftsInput> = {}): BuildDraftsInput {
+  return {
+    messageId: 'msg-1',
+    extractorVersion: 'rules-1.0.0',
+    classification: {
+      kind: 'PRODUCT',
+      confidence: 0.85,
+      confidenceBand: 'HIGH',
+      signals: [{ rule: 'pricePerUnitToken', weight: 0.65, match: '2,50€/kg' }],
+    },
+    extraction: {
+      schemaVersion: 1,
+      products: [
+        {
+          productOrdinal: 0,
+          productName: 'Manzanas golden',
+          categorySlug: null,
+          unit: 'KG',
+          weightGrams: null,
+          priceCents: 250,
+          currencyCode: 'EUR',
+          availability: 'AVAILABLE',
+          confidenceOverall: 0.85,
+          confidenceByField: { priceCents: 0.9, unit: 0.8 },
+          extractionMeta: {
+            priceCents: { rule: 'priceWithPerUnit', source: '2,50€/kg' },
+            unit: { rule: 'unitToken', source: 'kg' },
+          },
+        },
+      ],
+      vendorHint: {
+        externalId: 'vendor-123',
+        displayName: 'Granja Test',
+        meta: { rule: 'telegramAuthorExternalId', source: 'author:vendor-123' },
+      },
+      confidenceOverall: 0.85,
+      rulesFired: ['priceWithPerUnit', 'unitToken', 'telegramAuthorExternalId'],
+    },
+    inputSnapshot: { text: 'Manzanas golden: 2,50€/kg.' },
+    correlationId: 'cid-1',
+    ...overrides,
+  }
+}
+
+test('buildDrafts: happy path writes extraction + vendor + product + review queue', async () => {
+  const fake = createFakeDb()
+  const result = await buildDrafts(baseInput(), {
+    db: fake.db,
+    isKilled: async () => false,
+  })
+  assert.equal(result.status, 'OK')
+  assert.ok(result.extractionResultId)
+  assert.ok(result.vendorDraftId)
+  assert.equal(result.productDraftIds.length, 1)
+  assert.equal(result.reviewItemsEnqueued, 1)
+})
+
+test('buildDrafts: kill switch returns KILLED before any DB write', async () => {
+  const fake = createFakeDb()
+  const result = await buildDrafts(baseInput(), {
+    db: fake.db,
+    isKilled: async () => true,
+  })
+  assert.equal(result.status, 'KILLED')
+  assert.equal(fake.extractions.size, 0)
+  assert.equal(fake.products.size, 0)
+  assert.equal(fake.vendors.size, 0)
+  assert.equal(fake.reviewItems.size, 0)
+})
+
+test('buildDrafts: re-run at same extractor version is idempotent', async () => {
+  const fake = createFakeDb()
+  const r1 = await buildDrafts(baseInput(), { db: fake.db, isKilled: async () => false })
+  const r2 = await buildDrafts(baseInput(), { db: fake.db, isKilled: async () => false })
+  assert.equal(r1.status, 'OK')
+  assert.equal(r2.status, 'OK')
+  // Same extraction id and same product draft ids on re-run.
+  assert.equal(r1.extractionResultId, r2.extractionResultId)
+  assert.deepEqual(r1.productDraftIds, r2.productDraftIds)
+  assert.equal(fake.products.size, 1)
+  assert.equal(fake.reviewItems.size, 1)
+})
+
+test('buildDrafts: multi-product message persists one draft per ordinal, no cross-mix', async () => {
+  const fake = createFakeDb()
+  const input = baseInput({
+    extraction: {
+      schemaVersion: 1,
+      products: [
+        {
+          productOrdinal: 0,
+          productName: 'Tomates',
+          categorySlug: null,
+          unit: 'KG',
+          weightGrams: null,
+          priceCents: 180,
+          currencyCode: 'EUR',
+          availability: 'UNKNOWN',
+          confidenceOverall: 0.7,
+          confidenceByField: {},
+          extractionMeta: {},
+        },
+        {
+          productOrdinal: 1,
+          productName: 'Lechuga',
+          categorySlug: null,
+          unit: 'UNIT',
+          weightGrams: null,
+          priceCents: 90,
+          currencyCode: 'EUR',
+          availability: 'UNKNOWN',
+          confidenceOverall: 0.65,
+          confidenceByField: {},
+          extractionMeta: {},
+        },
+      ],
+      vendorHint: {
+        externalId: 'author-42',
+        displayName: 'Hortaliza',
+        meta: { rule: 'telegramAuthorExternalId', source: 'author:author-42' },
+      },
+      confidenceOverall: 0.68,
+      rulesFired: [],
+    },
+  })
+  const result = await buildDrafts(input, { db: fake.db, isKilled: async () => false })
+  assert.equal(result.status, 'OK')
+  assert.equal(result.productDraftIds.length, 2)
+  assert.equal(fake.products.size, 2)
+  assert.equal(fake.reviewItems.size, 2)
+})
+
+test('buildDrafts: non-PRODUCT classification keeps audit trail but creates no drafts', async () => {
+  const fake = createFakeDb()
+  const input = baseInput({
+    classification: {
+      kind: 'CONVERSATION',
+      confidence: 0.6,
+      confidenceBand: 'MEDIUM',
+      signals: [],
+    },
+  })
+  const result = await buildDrafts(input, { db: fake.db, isKilled: async () => false })
+  assert.equal(result.status, 'SKIPPED_NON_PRODUCT')
+  assert.ok(result.extractionResultId, 'audit row still created')
+  assert.equal(result.productDraftIds.length, 0)
+  assert.equal(fake.products.size, 0)
+  assert.equal(fake.vendors.size, 0)
+  assert.equal(fake.reviewItems.size, 0)
+})
+
+test('buildDrafts: PRODUCT with zero extracted products still keeps audit, no drafts', async () => {
+  const fake = createFakeDb()
+  const input = baseInput({
+    extraction: {
+      schemaVersion: 1,
+      products: [],
+      vendorHint: {
+        externalId: null,
+        displayName: null,
+        meta: { rule: 'vendorUnknown', source: '' },
+      },
+      confidenceOverall: 0,
+      rulesFired: [],
+    },
+  })
+  const result = await buildDrafts(input, { db: fake.db, isKilled: async () => false })
+  assert.equal(result.status, 'SKIPPED_NON_PRODUCT')
+  assert.ok(result.extractionResultId)
+  assert.equal(fake.products.size, 0)
+})
+
+test('buildDrafts: vendor with null externalId always creates a fresh vendor draft (no auto-merge)', async () => {
+  const fake = createFakeDb()
+  const input = baseInput({
+    extraction: {
+      schemaVersion: 1,
+      products: [
+        {
+          productOrdinal: 0,
+          productName: 'X',
+          categorySlug: null,
+          unit: null,
+          weightGrams: null,
+          priceCents: 500,
+          currencyCode: 'EUR',
+          availability: 'UNKNOWN',
+          confidenceOverall: 0.5,
+          confidenceByField: {},
+          extractionMeta: {},
+        },
+      ],
+      vendorHint: {
+        externalId: null,
+        displayName: 'Unknown post',
+        meta: { rule: 'vendorUnknown', source: '' },
+      },
+      confidenceOverall: 0.5,
+      rulesFired: [],
+    },
+  })
+  await buildDrafts(input, { db: fake.db, isKilled: async () => false })
+  await buildDrafts({ ...input, messageId: 'msg-2' }, {
+    db: fake.db,
+    isKilled: async () => false,
+  })
+  // Two messages with unknown author → TWO vendor drafts, never
+  // auto-merged.
+  assert.equal(fake.vendors.size, 2)
+})

--- a/test/features/ingestion-extractor.test.ts
+++ b/test/features/ingestion-extractor.test.ts
@@ -1,0 +1,127 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  extractRules,
+  extractionPayloadSchema,
+} from '@/domains/ingestion/processing/extractor'
+import { classifyMessage } from '@/domains/ingestion/processing/classifier'
+
+interface FixtureCase {
+  id: string
+  description: string
+  text: string
+  expectedClassifier: { kind: string }
+  expectedProducts?: number
+  expectedOrdinals?: number[]
+  expectedPrices?: number[]
+  expectedFirstProduct?: {
+    productName?: string
+    priceCents?: number
+    currencyCode?: string
+    unit?: string
+    availability?: string
+  }
+}
+
+const cases = JSON.parse(
+  readFileSync(
+    join(process.cwd(), 'test/fixtures/ingestion-messages/cases.json'),
+    'utf-8',
+  ),
+) as FixtureCase[]
+
+const productCases = cases.filter((c) => c.expectedClassifier.kind === 'PRODUCT')
+
+for (const fx of productCases) {
+  test(`extractor fixture: ${fx.id} — ${fx.description}`, () => {
+    const payload = extractRules({ text: fx.text })
+    // Payload shape must stay frozen.
+    extractionPayloadSchema.parse(payload)
+
+    if (fx.expectedProducts !== undefined) {
+      assert.equal(
+        payload.products.length,
+        fx.expectedProducts,
+        `expected ${fx.expectedProducts} products, got ${payload.products.length}`,
+      )
+    }
+
+    if (fx.expectedOrdinals) {
+      assert.deepEqual(
+        payload.products.map((p) => p.productOrdinal),
+        fx.expectedOrdinals,
+      )
+    }
+
+    if (fx.expectedPrices) {
+      assert.deepEqual(
+        payload.products.map((p) => p.priceCents),
+        fx.expectedPrices,
+      )
+    }
+
+    const first = payload.products[0]
+    if (fx.expectedFirstProduct && first) {
+      for (const [k, v] of Object.entries(fx.expectedFirstProduct)) {
+        const actual = (first as unknown as Record<string, unknown>)[k]
+        assert.equal(
+          actual,
+          v,
+          `${fx.id}.expectedFirstProduct.${k}: expected ${v}, got ${actual}`,
+        )
+      }
+    }
+  })
+}
+
+test('extractor: deterministic — same input gives identical payload', () => {
+  const text = 'Manzanas golden: 2,50€/kg. Disponibles hoy.'
+  const a = extractRules({ text })
+  const b = extractRules({ text })
+  assert.deepEqual(a, b)
+})
+
+test('extractor: every extracted field carries a rule + source in extractionMeta', () => {
+  const payload = extractRules({ text: 'Manzanas golden 2,50€/kg' })
+  const product = payload.products[0]
+  assert.ok(product, 'extractor must emit at least one product')
+  assert.ok(product.extractionMeta.priceCents, 'priceCents must have meta')
+  assert.ok(product.extractionMeta.priceCents!.rule.length > 0)
+  assert.ok(product.extractionMeta.priceCents!.source.length > 0)
+})
+
+test('extractor: multi-product message keeps ordinals distinct and independent', () => {
+  const text = '• Tomates 1,80€/kg\n• Lechuga 0,90€/ud'
+  const payload = extractRules({ text })
+  assert.equal(payload.products.length, 2)
+  assert.equal(payload.products[0]!.priceCents, 180)
+  assert.equal(payload.products[1]!.priceCents, 90)
+  // Attributes must not bleed across products: unit on the first
+  // must not leak onto the second.
+  assert.equal(payload.products[0]!.unit, 'KG')
+  assert.equal(payload.products[1]!.unit, 'UNIT')
+})
+
+test('extractor: when classifier rejects PRODUCT, extractor is not called (orchestration invariant)', () => {
+  // This is an architectural reminder pinned as a test: the pipeline
+  // must skip the extractor on non-PRODUCT classifications. The
+  // extractor itself tolerates being called, but produces 0 products
+  // on a greeting — pinned here so a regression in extractor rules
+  // never silently materialises drafts for conversation messages.
+  const greeting = 'Hola buenas, ¿alguien sabe si queda algo para el sábado?'
+  assert.equal(classifyMessage({ text: greeting }).kind, 'CONVERSATION')
+  const payload = extractRules({ text: greeting })
+  assert.equal(payload.products.length, 0)
+})
+
+test('extractor: confidence stays in [0,1]', () => {
+  for (const fx of productCases) {
+    const payload = extractRules({ text: fx.text })
+    assert.ok(payload.confidenceOverall >= 0 && payload.confidenceOverall <= 1)
+    for (const p of payload.products) {
+      assert.ok(p.confidenceOverall >= 0 && p.confidenceOverall <= 1)
+    }
+  }
+})

--- a/test/fixtures/ingestion-messages/cases.json
+++ b/test/fixtures/ingestion-messages/cases.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "simple-apples",
+    "description": "clear single-product: produce + price + unit",
+    "text": "Manzanas golden: 2,50€/kg. Disponibles hoy.",
+    "expectedClassifier": { "kind": "PRODUCT", "confidenceAtLeast": 0.6 },
+    "expectedProducts": 1,
+    "expectedFirstProduct": {
+      "productName": "Manzanas golden",
+      "unit": "KG",
+      "priceCents": 250,
+      "currencyCode": "EUR",
+      "availability": "AVAILABLE"
+    }
+  },
+  {
+    "id": "multi-product-list",
+    "description": "bullet list of three products, each with its own price",
+    "text": "Hoy tenemos:\n• Tomates 1,80€/kg\n• Lechuga 0,90€/ud\n• Patatas nuevas 1,20€/kg",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedProducts": 3,
+    "expectedOrdinals": [0, 1, 2],
+    "expectedPrices": [180, 90, 120]
+  },
+  {
+    "id": "numbered-multi-product",
+    "description": "numbered list split into products",
+    "text": "Pedido semanal:\n1. Queso curado 8,00€/kg\n2. Yogur natural 0,60€/ud\n3. Huevos camperos 2,50€/ud",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedProducts": 3
+  },
+  {
+    "id": "conversation-greeting",
+    "description": "greeting + question, no price, no produce word",
+    "text": "Hola buenas, ¿alguien sabe si queda algo para el sábado?",
+    "expectedClassifier": { "kind": "CONVERSATION" }
+  },
+  {
+    "id": "conversation-thanks",
+    "description": "thanks message, clearly conversational",
+    "text": "Muchas gracias, todo estupendo como siempre",
+    "expectedClassifier": { "kind": "CONVERSATION" }
+  },
+  {
+    "id": "spam-promo-link",
+    "description": "promotional link — clear spam",
+    "text": "Click aquí para ganar un premio exclusivo https://bit.ly/promo-exclusiva",
+    "expectedClassifier": { "kind": "SPAM" }
+  },
+  {
+    "id": "ambiguous-single-word",
+    "description": "single produce word with no price, no unit — too weak to be PRODUCT",
+    "text": "Tomates",
+    "expectedClassifier": { "kind": "OTHER" }
+  },
+  {
+    "id": "price-only-no-corroboration",
+    "description": "price alone with no unit or produce word — conservative classifier rejects PRODUCT",
+    "text": "5€",
+    "expectedClassifier": { "kind": "OTHER" }
+  },
+  {
+    "id": "emoji-heavy-product",
+    "description": "emoji-heavy producer post should still classify as PRODUCT",
+    "text": "🍅🍅 Tomates raf 3,20€/kg 🍅🍅 Disponibles",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedProducts": 1,
+    "expectedFirstProduct": { "priceCents": 320, "unit": "KG" }
+  },
+  {
+    "id": "weight-no-price",
+    "description": "weight mentioned but no price — classifier rejects PRODUCT (no price signal)",
+    "text": "Tengo 500g de queso curado disponible",
+    "expectedClassifier": { "kind": "OTHER" }
+  },
+  {
+    "id": "limited-availability",
+    "description": "availability signal LIMITED",
+    "text": "Últimas naranjas de la temporada, 1,50€/kg. Quedan pocas.",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedProducts": 1,
+    "expectedFirstProduct": { "availability": "LIMITED" }
+  },
+  {
+    "id": "sold-out",
+    "description": "availability signal SOLD_OUT",
+    "text": "Queso manchego: 12€/kg. Agotado por esta semana.",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedFirstProduct": { "availability": "SOLD_OUT" }
+  },
+  {
+    "id": "empty-message",
+    "description": "empty text → OTHER",
+    "text": "",
+    "expectedClassifier": { "kind": "OTHER" }
+  },
+  {
+    "id": "whitespace-only",
+    "description": "whitespace-only → OTHER",
+    "text": "   \n\t ",
+    "expectedClassifier": { "kind": "OTHER" }
+  },
+  {
+    "id": "price-range-conservative",
+    "description": "price range — extract conservatively (take the first/lower number)",
+    "text": "Miel de romero 4-6€/kg según formato",
+    "expectedClassifier": { "kind": "PRODUCT" },
+    "expectedFirstProduct": { "priceCents": 400, "unit": "KG" }
+  },
+  {
+    "id": "bilingual-catalan",
+    "description": "catalan-flavoured producer post still reaches PRODUCT via price+unit",
+    "text": "Pebrot vermell, molt fresc, 2,20€/kg",
+    "expectedClassifier": { "kind": "PRODUCT" }
+  }
+]

--- a/test/integration/ingestion-processing-trace.test.ts
+++ b/test/integration/ingestion-processing-trace.test.ts
@@ -1,0 +1,217 @@
+import test, { beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { db } from '@/lib/db'
+import {
+  buildDrafts,
+  CURRENT_RULES_EXTRACTOR_VERSION,
+  classifyMessage,
+  confidenceBandFor,
+  extractRules,
+  normaliseConfidence,
+  type DraftsBuilderDb,
+} from '@/domains/ingestion'
+import { resetIntegrationDatabase } from './helpers'
+
+/**
+ * End-to-end trace against real Postgres: raw message →
+ * classifier → extractor → drafts builder → DB rows with full
+ * provenance. Re-run idempotency is asserted on real unique
+ * constraints, not on in-memory fakes.
+ */
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+})
+
+async function seedMessage(text: string) {
+  const connection = await db.telegramIngestionConnection.create({
+    data: {
+      label: 'Test',
+      phoneNumberHash: 'h',
+      sessionRef: `sess-${Date.now()}-${Math.random()}`,
+      status: 'ACTIVE',
+      createdByUserId: 'u1',
+    },
+  })
+  const chat = await db.telegramIngestionChat.create({
+    data: {
+      connectionId: connection.id,
+      tgChatId: BigInt(-100),
+      title: 'Test',
+      kind: 'SUPERGROUP',
+      isEnabled: true,
+    },
+  })
+  const message = await db.telegramIngestionMessage.create({
+    data: {
+      chatId: chat.id,
+      tgMessageId: BigInt(1),
+      tgAuthorId: BigInt(42),
+      text,
+      rawJson: { text },
+      postedAt: new Date('2026-04-20T10:00:00Z'),
+    },
+  })
+  return message
+}
+
+async function runPipeline(messageId: string, text: string) {
+  const classifier = classifyMessage({ text })
+  const classifierConfidence = normaliseConfidence(classifier.confidence)
+  const extraction =
+    classifier.kind === 'PRODUCT'
+      ? extractRules({ text, vendorHint: { authorExternalId: '42' } })
+      : ({
+          schemaVersion: 1 as const,
+          products: [] as never[],
+          vendorHint: {
+            externalId: null,
+            displayName: null,
+            meta: { rule: 'classifiedNonProduct', source: classifier.kind },
+          },
+          confidenceOverall: 0,
+          rulesFired: [] as string[],
+        } as const)
+
+  return buildDrafts(
+    {
+      messageId,
+      extractorVersion: CURRENT_RULES_EXTRACTOR_VERSION,
+      classification: {
+        kind: classifier.kind,
+        confidence: classifierConfidence,
+        confidenceBand: confidenceBandFor(classifierConfidence),
+        signals: classifier.signals,
+      },
+      extraction,
+      inputSnapshot: { text },
+      correlationId: 'cid-int-1',
+    },
+    {
+      db: db as unknown as DraftsBuilderDb,
+      isKilled: async () => false,
+    },
+  )
+}
+
+test('integration: PRODUCT message materialises extraction + vendor + product drafts + queue', async () => {
+  const message = await seedMessage('Manzanas golden: 2,50€/kg. Disponibles hoy.')
+  const result = await runPipeline(message.id, message.text!)
+  assert.equal(result.status, 'OK')
+
+  const extractions = await db.ingestionExtractionResult.findMany({
+    where: { messageId: message.id },
+  })
+  assert.equal(extractions.length, 1)
+  assert.equal(extractions[0]!.engine, 'RULES')
+  assert.equal(extractions[0]!.classification, 'PRODUCT')
+
+  const drafts = await db.ingestionProductDraft.findMany({
+    where: { sourceMessageId: message.id },
+  })
+  assert.equal(drafts.length, 1)
+  assert.equal(drafts[0]!.priceCents, 250)
+  assert.equal(drafts[0]!.unit, 'KG')
+
+  const queueItems = await db.ingestionReviewQueueItem.findMany({
+    where: { kind: 'PRODUCT_DRAFT', targetId: drafts[0]!.id },
+  })
+  assert.equal(queueItems.length, 1)
+})
+
+test('integration: re-running pipeline on same message + version is idempotent', async () => {
+  const message = await seedMessage('Tomates raf 3,20€/kg')
+  await runPipeline(message.id, message.text!)
+  await runPipeline(message.id, message.text!)
+  assert.equal(
+    await db.ingestionExtractionResult.count({ where: { messageId: message.id } }),
+    1,
+  )
+  assert.equal(
+    await db.ingestionProductDraft.count({ where: { sourceMessageId: message.id } }),
+    1,
+  )
+  assert.equal(
+    await db.ingestionReviewQueueItem.count(),
+    1,
+    'review queue must not be double-enqueued',
+  )
+})
+
+test('integration: multi-product message creates one draft per productOrdinal', async () => {
+  const message = await seedMessage('• Tomates 1,80€/kg\n• Lechuga 0,90€/ud')
+  const result = await runPipeline(message.id, message.text!)
+  assert.equal(result.status, 'OK')
+  assert.equal(result.productDraftIds.length, 2)
+  const drafts = await db.ingestionProductDraft.findMany({
+    where: { sourceMessageId: message.id },
+    orderBy: { productOrdinal: 'asc' },
+  })
+  assert.equal(drafts.length, 2)
+  assert.equal(drafts[0]!.productOrdinal, 0)
+  assert.equal(drafts[1]!.productOrdinal, 1)
+  assert.equal(drafts[0]!.priceCents, 180)
+  assert.equal(drafts[1]!.priceCents, 90)
+  // Attributes must not leak across products.
+  assert.equal(drafts[0]!.unit, 'KG')
+  assert.equal(drafts[1]!.unit, 'UNIT')
+})
+
+test('integration: CONVERSATION message creates audit row but no drafts and no queue items', async () => {
+  const message = await seedMessage(
+    'Hola buenas, ¿alguien sabe si queda algo para el sábado?',
+  )
+  const result = await runPipeline(message.id, message.text!)
+  assert.equal(result.status, 'SKIPPED_NON_PRODUCT')
+  assert.equal(
+    await db.ingestionExtractionResult.count({ where: { messageId: message.id } }),
+    1,
+  )
+  assert.equal(
+    await db.ingestionProductDraft.count({ where: { sourceMessageId: message.id } }),
+    0,
+  )
+  assert.equal(await db.ingestionReviewQueueItem.count(), 0)
+})
+
+test('integration: bumping extractor version creates a new revision alongside the old one', async () => {
+  const message = await seedMessage('Patatas 1,20€/kg')
+  await runPipeline(message.id, message.text!)
+  // Manually call buildDrafts with a bumped version to simulate a
+  // rule upgrade without mutating the current constant.
+  const classifier = classifyMessage({ text: message.text! })
+  await buildDrafts(
+    {
+      messageId: message.id,
+      extractorVersion: 'rules-1.1.0',
+      classification: {
+        kind: classifier.kind,
+        confidence: 0.9,
+        confidenceBand: 'HIGH',
+        signals: classifier.signals,
+      },
+      extraction: extractRules({
+        text: message.text!,
+        vendorHint: { authorExternalId: '42' },
+      }),
+      inputSnapshot: { text: message.text },
+      correlationId: 'cid-int-2',
+    },
+    { db: db as unknown as DraftsBuilderDb, isKilled: async () => false },
+  )
+  // Two extractions coexist, one per version.
+  const extractions = await db.ingestionExtractionResult.findMany({
+    where: { messageId: message.id },
+    orderBy: { extractorVersion: 'asc' },
+  })
+  assert.equal(extractions.length, 2)
+  assert.deepEqual(
+    extractions.map((e) => e.extractorVersion),
+    ['rules-1.0.0', 'rules-1.1.0'],
+  )
+  // Corresponding product drafts per version.
+  const drafts = await db.ingestionProductDraft.findMany({
+    where: { sourceMessageId: message.id },
+  })
+  assert.equal(drafts.length, 2)
+})


### PR DESCRIPTION
Stacked on **#693** (PR-E). Base auto-rebases to `main` once PR-E merges.

Part of epic **#678** · Phase 2 parent **#679** · Resolves partial **#683** **#684** **#685** **#690**.

Locked adjustments from [#679 comment](https://github.com/juanmixto/marketplace/issues/679#issuecomment-4281108530) fully honoured.

## Scope — deterministic core of Phase 2

`raw message → classified extraction → stable, idempotent drafts`. Rules-only. No LLM. No UI. No writes to `Product` / `Vendor` / `ProductImage`. Umbrella kill still defaults to engaged; stage flag `feat-ingestion-rules-extractor` is the enabler.

## How each user requirement lands

### 1. Classifier conservador de verdad

- PRODUCT requires **price token AND corroboration** (unit, produce word, or per-unit-token like `2,50€/kg`).
- SPAM wins over PRODUCT when a promo URL is present.
- Single word / bare price / weight-only → **OTHER**, never PRODUCT.
- CONVERSATION is the natural fallback for greetings, questions, thanks.
- Empty / whitespace → OTHER.
- Pinned by 3 behaviour tests + 16 fixture cases.

### 2. Extractor determinista y reproducible

- Per-field rules: `priceWithPerUnit`, `priceBare`, `priceRangeLowerBound`, `unitToken`, `weightKilograms`, `weightGrams`, `availAvailable` / `availLimited` / `availSoldOut` / `availDefault`, `firstSegmentBeforePriceOrUnit`, `telegramAuthorExternalId` / `telegramAuthorDisplayName` / `vendorUnknown`.
- Same input → same output pinned by test.
- Confidence bounded to `[0,1]` and pinned across every fixture.

### 3. Trazabilidad por campo

`extractionMeta` on every `ExtractedProduct` records `{ rule, source }` per field. Persisted into `IngestionProductDraft.rawFieldsSeen`. Pinned: "every extracted field carries a rule + source in extractionMeta".

### 4. Drafts multi-producto bien resueltos

- Segmentation by bullet / numbered list; otherwise single-segment.
- One draft per `productOrdinal`, DB-unique on `(sourceMessageId, extractorVersion, productOrdinal)`.
- Attributes never mix across products (integration test pins).
- Ambiguous segments emit fewer products, not more.

### 5. Sin inferencias agresivas de vendor

- `VendorDraft` derives **only** from Telegram author metadata (`externalId` = `tgAuthorId`, `displayName` from author).
- When no external id → fresh `VendorDraft` per message, **never auto-merged** (pinned by test).
- No cross-message correlation — reserved for Phase 5.

### 6. Frozen real-world fixtures

[`test/fixtures/ingestion-messages/cases.json`](../blob/feat/ingestion-phase2-processing/test/fixtures/ingestion-messages/cases.json) — **16 cases**:

- ✅ mensaje claro de producto — `simple-apples`
- ✅ varios productos — `multi-product-list`, `numbered-multi-product`
- ✅ conversacional — `conversation-greeting`, `conversation-thanks`
- ✅ ambiguo — `ambiguous-single-word`, `price-only-no-corroboration`
- ✅ spam — `spam-promo-link`
- ✅ emojis / listas / formatos raros — `emoji-heavy-product`, `numbered-multi-product`
- ✅ precios y pesos incompletos — `weight-no-price`, `price-range-conservative`
- ✅ availability — `limited-availability`, `sold-out`
- ✅ empty / whitespace — `empty-message`, `whitespace-only`
- ✅ bilingüe — `bilingual-catalan`

Each case drives **both** classifier and extractor tests.

### 7. Draft generation idempotente

- Unit test: "re-run at same extractor version is idempotent" — same extraction id, same product draft ids, review queue not double-enqueued.
- Integration test against real Postgres pins it with the actual `@@unique` constraint enforcement.
- Bumping `extractorVersion` creates a fresh revision alongside the old one (pinned): "rules-1.0.0" and "rules-1.1.0" coexist in DB.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` + `npx tsc -p tsconfig.test.json --noEmit` — both clean.
- [x] `npm run audit:contracts` — 0 violations.
- [x] `npm test` — **1194 / 1194 passing** (+55 new from PR-F).
- [x] 5 / 5 integration tests against local Postgres:
  - PRODUCT → extraction + vendor + product + queue
  - Idempotent re-run (no duplicate rows)
  - Multi-product ordinals
  - CONVERSATION audit-only
  - Bumped extractor version creates a revision
- [ ] Reviewer: skim the 16 fixture cases in `cases.json` and confirm the expected behaviour matches your mental model for real producer groups.

## Safety

- No writes to `Product` / `Vendor` / `ProductImage` — diff limited to `src/domains/ingestion/processing/`, `src/workers/jobs/ingestion-processing.ts`, worker registration, tests, and one fixture file.
- Umbrella kill + stage flag both default off; worker handler is registered but inert until operators flip them.
- No LLM, no external API call, no new cron.
- Admin UI untouched (#667 / #668 still paused).
- Phase 1 runtime untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)