### PR TITLE
feat(ingestion): admin review UI polish + server-side global sort

### DIFF
--- a/src/app/(admin)/admin/ingestion/[itemId]/page.tsx
+++ b/src/app/(admin)/admin/ingestion/[itemId]/page.tsx
@@ -27,6 +27,19 @@ function formatPriceCents(cents: number | null, currency: string | null): string
   return `${(cents / 100).toFixed(2)} ${currency ?? 'EUR'}`
 }
 
+function humaniseReason(reason: string): string {
+  switch (reason) {
+    case 'adminApproved': return 'Aprobado por admin'
+    case 'adminDiscarded': return 'Descartado por admin'
+    case 'adminDiscardedUnextractable': return 'Descartado por admin'
+    case 'adminMarkedValid': return 'Marcado como válido por admin'
+    default:
+      if (reason.startsWith('unextractableDedupe:')) return 'Fusionado automático (dedupe)'
+      if (reason.startsWith('productDedupe:')) return 'Fusionado automático (dedupe)'
+      return reason
+  }
+}
+
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
@@ -86,13 +99,13 @@ export default async function ReviewItemDetailPage({ params }: PageProps) {
           ← Volver a la cola
         </Link>
         <h1 className="mt-2 text-2xl font-semibold text-[var(--foreground)]">
-          {item.target.kind === 'PRODUCT_DRAFT' ? 'Product draft' : 'Sin precio extractado'}
+          {item.target.kind === 'PRODUCT_DRAFT' ? 'Draft de producto' : 'Sin precio extractado'}
         </h1>
         <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--muted-foreground)]">
           <Badge variant={item.state === 'ENQUEUED' ? 'outline' : 'green'}>
             {item.state === 'ENQUEUED' ? 'Por revisar' : 'Resuelto'}
           </Badge>
-          {item.autoResolvedReason && <span>· {item.autoResolvedReason}</span>}
+          {item.autoResolvedReason && <span>· {humaniseReason(item.autoResolvedReason)}</span>}
           <span>· Creado {formatDate(item.createdAt)}</span>
         </div>
       </div>
@@ -160,7 +173,21 @@ export default async function ReviewItemDetailPage({ params }: PageProps) {
           </CardHeader>
           <CardBody>
             <dl className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-              <Field label="Display name" value={item.target.vendorDraft.displayName} />
+              <Field
+                label="Display name"
+                value={
+                  item.target.vendorDraft.displayName === 'Unknown vendor' ? (
+                    <span>
+                      <span className="text-[var(--muted-foreground)]">—</span>
+                      <span className="ml-2 text-xs text-[var(--muted-foreground)]">
+                        (fallback: el extractor no infirió el nombre)
+                      </span>
+                    </span>
+                  ) : (
+                    item.target.vendorDraft.displayName
+                  )
+                }
+              />
               <Field label="External id" value={item.target.vendorDraft.externalId ?? '—'} />
               <Field label="Draft id" value={item.target.vendorDraft.id} />
             </dl>
@@ -174,7 +201,7 @@ export default async function ReviewItemDetailPage({ params }: PageProps) {
         </CardHeader>
         <CardBody className="space-y-4">
           <Field
-            label="Rules fired"
+            label="Reglas disparadas"
             value={
               rulesFired.length ? (
                 <div className="flex flex-wrap gap-1">
@@ -184,86 +211,107 @@ export default async function ReviewItemDetailPage({ params }: PageProps) {
                     </Badge>
                   ))}
                 </div>
+              ) : item.target.kind === 'UNEXTRACTABLE_PRODUCT' ? (
+                <span className="text-xs text-[var(--muted-foreground)]">
+                  El extractor de reglas no se ejecuta cuando la clasificación es{' '}
+                  <span className="font-mono">
+                    {item.target.extraction.classification ?? 'PRODUCT_NO_PRICE'}
+                  </span>
+                  .
+                </span>
               ) : (
                 '—'
               )
             }
           />
-          {productPayload?.extractionMeta && (
-            <Field
-              label="Extraction meta"
-              value={
-                <ul className="space-y-1 text-xs">
-                  {Object.entries(productPayload.extractionMeta).map(([field, meta]) => (
-                    <li key={field}>
-                      <span className="font-mono text-[var(--muted-foreground)]">{field}</span>:{' '}
-                      <span className="font-mono">{meta.rule}</span>
-                      {meta.source && (
-                        <span className="ml-2 text-[var(--muted-foreground)]">
-                          (“{meta.source}”)
-                        </span>
+
+          <details className="group rounded border border-[var(--border)] p-3">
+            <summary className="cursor-pointer text-xs font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
+              Detalles técnicos
+            </summary>
+            <div className="mt-3 space-y-4">
+              {productPayload?.extractionMeta && (
+                <Field
+                  label="Origen de cada campo"
+                  value={
+                    <ul className="space-y-1 text-xs">
+                      {Object.entries(productPayload.extractionMeta).map(([field, meta]) => (
+                        <li key={field}>
+                          <span className="font-mono text-[var(--muted-foreground)]">{field}</span>:{' '}
+                          <span className="font-mono">{meta.rule}</span>
+                          {meta.source && (
+                            <span className="ml-2 text-[var(--muted-foreground)]">
+                              (“{meta.source}”)
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  }
+                />
+              )}
+              {productPayload?.confidenceModel && (
+                <Field
+                  label="Modelo de confianza"
+                  value={
+                    <div className="space-y-1 text-xs">
+                      <div>
+                        <span className="text-[var(--muted-foreground)]">método: </span>
+                        <span className="font-mono">{productPayload.confidenceModel.method}</span>
+                      </div>
+                      {productPayload.confidenceModel.weights && (
+                        <div>
+                          <span className="text-[var(--muted-foreground)]">pesos:</span>
+                          <ul className="ml-4 list-disc space-y-0.5">
+                            {Object.entries(productPayload.confidenceModel.weights)
+                              .sort(([, a], [, b]) => b - a)
+                              .map(([field, weight]) => (
+                                <li key={field}>
+                                  <span className="font-mono">{field}</span>
+                                  <span className="ml-2 text-[var(--muted-foreground)]">×{weight}</span>
+                                </li>
+                              ))}
+                          </ul>
+                        </div>
                       )}
-                    </li>
-                  ))}
-                </ul>
-              }
-            />
-          )}
-          {productPayload?.confidenceModel && (
-            <Field
-              label="Confidence model"
-              value={
-                <div className="space-y-1 text-xs">
-                  <div>
-                    <span className="text-[var(--muted-foreground)]">method: </span>
-                    <span className="font-mono">{productPayload.confidenceModel.method}</span>
-                  </div>
-                  {productPayload.confidenceModel.weights && (
-                    <div>
-                      <span className="text-[var(--muted-foreground)]">weights: </span>
-                      <span className="font-mono">
-                        {JSON.stringify(productPayload.confidenceModel.weights)}
-                      </span>
+                      {productPayload.confidenceModel.excludedFields?.length ? (
+                        <div>
+                          <span className="text-[var(--muted-foreground)]">excluidos: </span>
+                          <span className="font-mono">
+                            {productPayload.confidenceModel.excludedFields.join(', ')}
+                          </span>
+                        </div>
+                      ) : null}
+                      {productPayload.confidenceModel.bonus && (
+                        <div>
+                          <span className="text-[var(--muted-foreground)]">bonus: </span>
+                          <span className="font-mono">
+                            {productPayload.confidenceModel.bonus.rule} (+
+                            {productPayload.confidenceModel.bonus.amount})
+                          </span>
+                        </div>
+                      )}
                     </div>
-                  )}
-                  {productPayload.confidenceModel.excludedFields?.length ? (
-                    <div>
-                      <span className="text-[var(--muted-foreground)]">excluded: </span>
-                      <span className="font-mono">
-                        {productPayload.confidenceModel.excludedFields.join(', ')}
-                      </span>
-                    </div>
-                  ) : null}
-                  {productPayload.confidenceModel.bonus && (
-                    <div>
-                      <span className="text-[var(--muted-foreground)]">bonus: </span>
-                      <span className="font-mono">
-                        {productPayload.confidenceModel.bonus.rule} (+
-                        {productPayload.confidenceModel.bonus.amount})
-                      </span>
-                    </div>
-                  )}
-                </div>
-              }
-            />
-          )}
-          <Field
-            label="Correlation id"
-            value={
-              <span className="font-mono text-xs">
-                {item.target.kind === 'PRODUCT_DRAFT'
-                  ? item.target.extraction.correlationId
-                  : item.target.extraction.correlationId}
-              </span>
-            }
-          />
+                  }
+                />
+              )}
+              <Field
+                label="Correlation id"
+                value={
+                  <span className="font-mono text-xs">
+                    {item.target.extraction.correlationId}
+                  </span>
+                }
+              />
+            </div>
+          </details>
         </CardBody>
       </Card>
 
       {item.target.kind === 'UNEXTRACTABLE_PRODUCT' && item.target.dedupeCandidates.length > 0 && (
         <Card>
           <CardHeader>
-            <h2 className="text-sm font-semibold">Dedupe candidates</h2>
+            <h2 className="text-sm font-semibold">Posibles duplicados</h2>
           </CardHeader>
           <CardBody>
             <ul className="space-y-2 text-sm">
@@ -278,7 +326,7 @@ export default async function ReviewItemDetailPage({ params }: PageProps) {
                       <Badge variant={c.riskClass === 'LOW' ? 'green' : c.riskClass === 'MEDIUM' ? 'amber' : 'red'}>
                         riesgo {c.riskClass}
                       </Badge>
-                      {c.autoApplied && <Badge variant="blue">auto-merged</Badge>}
+                      {c.autoApplied && <Badge variant="blue">fusión automática</Badge>}
                     </div>
                     <p className="mt-1 truncate text-xs text-[var(--muted-foreground)]">
                       {c.otherMessageText ?? '(sin texto)'}

--- a/src/app/(admin)/admin/ingestion/page.tsx
+++ b/src/app/(admin)/admin/ingestion/page.tsx
@@ -5,12 +5,14 @@ import {
   listReviewQueue,
   REVIEW_QUEUE_PAGE_SIZE,
   type ReviewQueueListKind,
+  type ReviewQueueSortKey,
+  type ReviewQueueSortDir,
 } from '@/domains/ingestion'
 import { requireIngestionAdmin } from '@/domains/ingestion/authz'
 import { IngestionFeatureUnavailableError } from '@/domains/ingestion/authz'
 import { Card, CardBody, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { cn, formatDate } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 
 export const metadata: Metadata = { title: 'Ingestion · Review queue | Admin' }
 export const dynamic = 'force-dynamic'
@@ -20,12 +22,46 @@ interface PageProps {
     kind?: string
     state?: string
     page?: string
+    sort?: string
+    dir?: string
   }>
+}
+
+type SortKey = ReviewQueueSortKey
+type SortDir = ReviewQueueSortDir
+
+const SORT_KEYS: readonly SortKey[] = [
+  'fecha',
+  'tipo',
+  'confianza',
+  'precio',
+  'autor',
+  'estado',
+]
+
+function parseSort(v: string | undefined): SortKey {
+  return (SORT_KEYS as readonly string[]).includes(v ?? '') ? (v as SortKey) : 'fecha'
+}
+
+function parseDir(v: string | undefined): SortDir {
+  return v === 'asc' ? 'asc' : 'desc'
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('es-ES', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+})
+
+function formatShortDate(d: Date): string {
+  // "28 mar 26" — Intl gives "28 mar. 26" on some runtimes, strip the
+  // trailing dot off the month abbreviation for consistency.
+  return DATE_FORMATTER.format(d).replace('.', '')
 }
 
 const KIND_OPTIONS: Array<{ value: ReviewQueueListKind | 'ALL'; label: string }> = [
   { value: 'ALL', label: 'Todo' },
-  { value: 'PRODUCT_DRAFT', label: 'Product drafts' },
+  { value: 'PRODUCT_DRAFT', label: 'Drafts de producto' },
   { value: 'UNEXTRACTABLE_PRODUCT', label: 'Sin precio' },
 ]
 
@@ -45,11 +81,23 @@ function parseState(v: string | undefined): 'ENQUEUED' | 'AUTO_RESOLVED' | 'ALL'
   return 'ENQUEUED'
 }
 
-function buildHref(base: { kind: string; state: string }, overrides: { kind?: string; state?: string; page?: number } = {}) {
+interface HrefBase {
+  kind: string
+  state: string
+  sort: SortKey
+  dir: SortDir
+}
+
+function buildHref(
+  base: HrefBase,
+  overrides: Partial<HrefBase> & { page?: number } = {},
+) {
   const next = { ...base, ...overrides }
   const params = new URLSearchParams()
   if (next.kind && next.kind !== 'ALL') params.set('kind', next.kind)
   if (next.state && next.state !== 'ENQUEUED') params.set('state', next.state)
+  if (next.sort !== 'fecha') params.set('sort', next.sort)
+  if (next.dir !== 'desc') params.set('dir', next.dir)
   if (overrides.page && overrides.page > 1) params.set('page', String(overrides.page))
   const qs = params.toString()
   return qs ? `/admin/ingestion?${qs}` : '/admin/ingestion'
@@ -67,6 +115,21 @@ function formatPriceCents(cents: number | null, currency: string | null): string
   return `${(cents / 100).toFixed(2)} ${currency ?? 'EUR'}`
 }
 
+function humaniseReason(reason: string): string {
+  switch (reason) {
+    case 'adminApproved': return 'Aprobado por admin'
+    case 'adminDiscarded': return 'Descartado por admin'
+    case 'adminDiscardedUnextractable': return 'Descartado por admin'
+    case 'adminMarkedValid': return 'Marcado como válido por admin'
+    default:
+      // Auto-merges from dedupe arrive as e.g.
+      // "unextractableDedupe:sameAuthorSameNormalisedFirstLine".
+      if (reason.startsWith('unextractableDedupe:')) return 'Fusionado automático (dedupe)'
+      if (reason.startsWith('productDedupe:')) return 'Fusionado automático (dedupe)'
+      return reason
+  }
+}
+
 export default async function IngestionReviewQueuePage({ searchParams }: PageProps) {
   try {
     await requireIngestionAdmin()
@@ -79,19 +142,21 @@ export default async function IngestionReviewQueuePage({ searchParams }: PagePro
   const kind = parseKind(sp.kind)
   const state = parseState(sp.state)
   const page = Math.max(1, Number.parseInt(sp.page ?? '1', 10) || 1)
-  const result = await listReviewQueue({ kind, state, page, pageSize: REVIEW_QUEUE_PAGE_SIZE })
+  const sort = parseSort(sp.sort)
+  const dir = parseDir(sp.dir)
+  const result = await listReviewQueue({ kind, state, page, pageSize: REVIEW_QUEUE_PAGE_SIZE, sort, dir })
   const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize))
 
-  const baseParams = { kind, state }
+  const baseParams: HrefBase = { kind, state, sort, dir }
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-[var(--foreground)]">
-          Ingestion · Review queue
+          Ingesta · Cola de revisión
         </h1>
         <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-          Drafts and unextractable producer messages queued for human review. Nothing here touches the public catalog yet.
+          Drafts y mensajes de productor sin precio pendientes de revisión humana. Nada de lo que haya aquí toca todavía el catálogo público.
         </p>
       </div>
 
@@ -132,17 +197,26 @@ export default async function IngestionReviewQueuePage({ searchParams }: PagePro
         </CardHeader>
 
         <CardBody className="p-0">
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
+          <div>
+            <table className="w-full table-fixed text-sm">
+              <colgroup>
+                <col />
+                <col className="w-[7rem]" />
+                <col className="w-[8rem]" />
+                <col className="w-[7rem]" />
+                <col className="w-[7.5rem]" />
+                <col className="w-[6rem]" />
+                <col className="w-[8rem]" />
+              </colgroup>
               <thead className="bg-[var(--muted)]/40 text-left text-xs uppercase tracking-wider text-[var(--muted-foreground)]">
                 <tr>
                   <th className="px-4 py-3 font-medium">Texto</th>
-                  <th className="px-4 py-3 font-medium">Tipo</th>
-                  <th className="px-4 py-3 font-medium">Confianza</th>
-                  <th className="px-4 py-3 font-medium">Precio</th>
-                  <th className="px-4 py-3 font-medium">Autor</th>
-                  <th className="px-4 py-3 font-medium">Fecha</th>
-                  <th className="px-4 py-3 font-medium">Estado</th>
+                  <SortableTh label="Tipo" sortKey="tipo" current={sort} dir={dir} base={baseParams} />
+                  <SortableTh label="Confianza" sortKey="confianza" current={sort} dir={dir} base={baseParams} />
+                  <SortableTh label="Precio" sortKey="precio" current={sort} dir={dir} base={baseParams} />
+                  <SortableTh label="Autor" sortKey="autor" current={sort} dir={dir} base={baseParams} />
+                  <SortableTh label="Fecha" sortKey="fecha" current={sort} dir={dir} base={baseParams} />
+                  <SortableTh label="Estado" sortKey="estado" current={sort} dir={dir} base={baseParams} />
                 </tr>
               </thead>
               <tbody className="divide-y divide-[var(--border)]">
@@ -169,41 +243,45 @@ export default async function IngestionReviewQueuePage({ searchParams }: PagePro
                       <td className="px-4 py-3 align-top">
                         <Link
                           href={`/admin/ingestion/${row.itemId}`}
-                          className="block max-w-[32rem] truncate text-[var(--foreground)] hover:underline"
+                          className="block truncate text-[var(--foreground)] hover:underline"
                           title={row.messageText ?? ''}
                         >
                           {productName ?? row.messageText ?? '(sin texto)'}
                         </Link>
                         {productName && row.messageText && (
-                          <div className="mt-0.5 max-w-[32rem] truncate text-xs text-[var(--muted-foreground)]">
+                          <div className="mt-0.5 truncate text-xs text-[var(--muted-foreground)]">
                             {row.messageText}
                           </div>
                         )}
                       </td>
-                      <td className="px-4 py-3 align-top">
-                        <Badge variant={isProduct ? 'blue' : 'amber'}>
+                      <td className="whitespace-nowrap px-4 py-3 align-top">
+                        <Badge variant={isProduct ? 'blue' : 'amber'} className="whitespace-nowrap">
                           {isProduct ? 'PRODUCT' : 'SIN PRECIO'}
                         </Badge>
                       </td>
-                      <td className="px-4 py-3 align-top">
-                        <Badge variant={bandVariant(band)}>
-                          {band} · {confidenceOverall}
-                        </Badge>
+                      <td className="whitespace-nowrap px-4 py-3 align-top">
+                        {isProduct ? (
+                          <Badge variant={bandVariant(band)} className="whitespace-nowrap">
+                            {band} · {confidenceOverall}
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-[var(--muted-foreground)]">—</span>
+                        )}
                       </td>
-                      <td className="px-4 py-3 align-top text-[var(--muted-foreground)]">{priceLabel}</td>
-                      <td className="px-4 py-3 align-top text-[var(--muted-foreground)]">
+                      <td className="whitespace-nowrap px-4 py-3 align-top text-[var(--muted-foreground)]">{priceLabel}</td>
+                      <td className="whitespace-nowrap px-4 py-3 align-top text-[var(--muted-foreground)]">
                         {row.authorId ?? '—'}
                       </td>
-                      <td className="px-4 py-3 align-top text-[var(--muted-foreground)]">
-                        {row.messagePostedAt ? formatDate(row.messagePostedAt) : '—'}
+                      <td className="whitespace-nowrap px-4 py-3 align-top text-[var(--muted-foreground)]">
+                        {row.messagePostedAt ? formatShortDate(row.messagePostedAt) : '—'}
                       </td>
-                      <td className="px-4 py-3 align-top">
-                        <Badge variant={row.state === 'ENQUEUED' ? 'outline' : 'green'}>
+                      <td className="whitespace-nowrap px-4 py-3 align-top">
+                        <Badge variant={row.state === 'ENQUEUED' ? 'outline' : 'green'} className="whitespace-nowrap">
                           {row.state === 'ENQUEUED' ? 'Por revisar' : 'Resuelto'}
                         </Badge>
                         {row.autoResolvedReason && (
                           <div className="mt-1 text-xs text-[var(--muted-foreground)]">
-                            {row.autoResolvedReason}
+                            {humaniseReason(row.autoResolvedReason)}
                           </div>
                         )}
                       </td>
@@ -246,5 +324,33 @@ export default async function IngestionReviewQueuePage({ searchParams }: PagePro
         )}
       </Card>
     </div>
+  )
+}
+
+interface SortableThProps {
+  label: string
+  sortKey: SortKey
+  current: SortKey
+  dir: SortDir
+  base: HrefBase
+}
+
+function SortableTh({ label, sortKey, current, dir, base }: SortableThProps) {
+  const active = current === sortKey
+  const nextDir: SortDir = active && dir === 'desc' ? 'asc' : 'desc'
+  const arrow = active ? (dir === 'asc' ? '↑' : '↓') : '↕'
+  return (
+    <th className="whitespace-nowrap px-4 py-3 font-medium">
+      <Link
+        href={buildHref(base, { sort: sortKey, dir: nextDir, page: 1 })}
+        className={cn(
+          'inline-flex items-center gap-1 hover:text-[var(--foreground)]',
+          active && 'text-[var(--foreground)]',
+        )}
+      >
+        {label}
+        <span className={cn('text-[10px]', !active && 'opacity-40')}>{arrow}</span>
+      </Link>
+    </th>
   )
 }

--- a/src/domains/ingestion/processing/admin/index.ts
+++ b/src/domains/ingestion/processing/admin/index.ts
@@ -9,6 +9,8 @@ export {
   type ReviewQueueDetail,
   type ReviewQueueDetailProduct,
   type ReviewQueueDetailUnextractable,
+  type ReviewQueueSortKey,
+  type ReviewQueueSortDir,
 } from './queries'
 
 export {

--- a/src/domains/ingestion/processing/admin/queries.ts
+++ b/src/domains/ingestion/processing/admin/queries.ts
@@ -1,4 +1,5 @@
 import { db } from '@/lib/db'
+import { Prisma } from '@/generated/prisma/client'
 import type {
   IngestionDraftKind,
   IngestionReviewState,
@@ -25,11 +26,43 @@ export const REVIEW_QUEUE_PAGE_SIZE = 50
 export type ReviewQueueListKind =
   | Extract<IngestionDraftKind, 'PRODUCT_DRAFT' | 'UNEXTRACTABLE_PRODUCT'>
 
+export type ReviewQueueSortKey =
+  | 'fecha'
+  | 'tipo'
+  | 'confianza'
+  | 'precio'
+  | 'autor'
+  | 'estado'
+
+export type ReviewQueueSortDir = 'asc' | 'desc'
+
 export interface ListReviewQueueInput {
   kind?: ReviewQueueListKind | 'ALL'
   state?: IngestionReviewState | 'ALL'
   page?: number
   pageSize?: number
+  sort?: ReviewQueueSortKey
+  dir?: ReviewQueueSortDir
+}
+
+/**
+ * Column expressions for the raw ORDER BY. Only this map's keys are
+ * accepted as sort keys, so using `Prisma.raw` against these strings
+ * is safe (no caller-supplied SQL ever reaches the expression).
+ */
+const SORT_EXPR: Record<ReviewQueueSortKey, string> = {
+  // `m."postedAt"` is the real time of the message, which is what a
+  // human reviewer actually cares about. Fall back to q."createdAt"
+  // for items where the join didn't resolve (shouldn't happen in
+  // practice, but keeps the ordering total).
+  fecha: 'COALESCE(m."postedAt", q."createdAt")',
+  tipo: 'q."kind"',
+  // Confidence lives on the product draft; unextractable items are
+  // always NULL here and sort to the end regardless of direction.
+  confianza: 'd."confidenceOverall"',
+  precio: 'd."priceCents"',
+  autor: 'm."tgAuthorId"',
+  estado: 'q."state"',
 }
 
 export interface ReviewQueueListRowProduct {
@@ -94,24 +127,59 @@ export async function listReviewQueue(
       ? [input.kind]
       : ['PRODUCT_DRAFT', 'UNEXTRACTABLE_PRODUCT']
 
+  const sortKey: ReviewQueueSortKey = input.sort ?? 'fecha'
+  const dir: ReviewQueueSortDir = input.dir === 'asc' ? 'asc' : 'desc'
+  const stateFilter = input.state && input.state !== 'ALL' ? input.state : null
+  const orderExpr = SORT_EXPR[sortKey]
+  // NULLS sort stable and predictable: on asc they go last, on desc
+  // also last — reviewers want concrete data first either way.
+  const orderBy = Prisma.raw(
+    `${orderExpr} ${dir === 'asc' ? 'ASC' : 'DESC'} NULLS LAST, q."createdAt" DESC`,
+  )
+  const skip = (page - 1) * pageSize
+
+  // Raw id query — LEFT JOIN the polymorphic targets and the message
+  // row, then ORDER BY whichever field the caller asked for. The
+  // joins are 1:1 so there's no row-multiplication.
+  const kindsSql = Prisma.sql`(${Prisma.join(kindFilter.map((k) => Prisma.sql`${k}::"IngestionDraftKind"`))})`
+  const stateSql = stateFilter
+    ? Prisma.sql` AND q."state" = ${stateFilter}::"IngestionReviewState"`
+    : Prisma.empty
+
+  const idRows = await db.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    SELECT q."id"
+    FROM "IngestionReviewQueueItem" q
+    LEFT JOIN "IngestionProductDraft" d
+      ON q."kind" = 'PRODUCT_DRAFT'::"IngestionDraftKind" AND d."id" = q."targetId"
+    LEFT JOIN "IngestionExtractionResult" e
+      ON q."kind" = 'UNEXTRACTABLE_PRODUCT'::"IngestionDraftKind" AND e."id" = q."targetId"
+    LEFT JOIN "TelegramIngestionMessage" m
+      ON m."id" = COALESCE(d."sourceMessageId", e."messageId")
+    WHERE q."kind" IN ${kindsSql}${stateSql}
+    ORDER BY ${orderBy}
+    LIMIT ${pageSize} OFFSET ${skip}
+  `)
+  const orderedIds = idRows.map((r) => r.id)
+
   const where = {
     kind: { in: kindFilter },
-    ...(input.state && input.state !== 'ALL' ? { state: input.state } : {}),
+    ...(stateFilter ? { state: stateFilter } : {}),
   }
 
-  const [items, total] = await Promise.all([
-    db.ingestionReviewQueueItem.findMany({
-      where,
-      orderBy: [
-        { state: 'asc' },
-        { priority: 'desc' },
-        { createdAt: 'desc' },
-      ],
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-    }),
+  const [rawItems, total] = await Promise.all([
+    orderedIds.length
+      ? db.ingestionReviewQueueItem.findMany({ where: { id: { in: orderedIds } } })
+      : [],
     db.ingestionReviewQueueItem.count({ where }),
   ])
+
+  // Restore the raw-SQL ordering: findMany does not preserve the
+  // order of `in` arrays.
+  const itemById = new Map(rawItems.map((i) => [i.id, i]))
+  const items = orderedIds.flatMap((id) => {
+    const hit = itemById.get(id)
+    return hit ? [hit] : []
+  })
 
   const draftIds: string[] = []
   const extractionIds: string[] = []


### PR DESCRIPTION
## Summary

Follow-up iteration on #698 after a real human review pass against 47 replayed dry-run messages. Addresses friction observed when actually using the surface — not speculation.

## List view

- Headers + filter labels switched to consistent Spanish (\"Ingesta · Cola de revisión\", \"Drafts de producto\", \"Sin precio\"). Previously mixed English.
- Confidence cell on UNEXTRACTABLE renders \`—\` instead of the structurally-always-zero \`LOW · 0\` badge.
- Dates show \"28 mar 26\" (2-digit year, short month, no trailing dot) — the long form was wrapping to two lines.
- Auto-resolved reasons humanised (\"Aprobado por admin\", \"Fusionado automático (dedupe)\", etc.) instead of raw tag strings (\`adminApproved\`, \`unextractableDedupe:...\`).
- Cells pinned \`whitespace-nowrap\` so badges + dates no longer wrap.
- Table switched to \`table-fixed\` + \`<colgroup>\` with fixed widths on the 6 side columns. Texto column absorbs whatever space is freed when the sidebar collapses. No more horizontal scroll.

## Detail view

- Title in Spanish (\"Draft de producto\").
- Empty \"Reglas disparadas\" on UNEXTRACTABLE is contextualised with the actual reason (\"El extractor de reglas no se ejecuta cuando la clasificación es PRODUCT_NO_PRICE\").
- Vendor \"Unknown vendor\" fallback is flagged as such (\"— (fallback: el extractor no infirió el nombre)\") so it can't be mistaken for a real name.
- Confidence-model weights rendered as a sorted list (\`productName ×2\`, \`priceCents ×2\`, …) instead of raw JSON.
- Extraction meta + confidence model + correlation id collapsed under a \"Detalles técnicos\" \`<details>\` disclosure. The technical trace stops competing with Aprobar / Editar / Descartar.

## Sortable columns — pushed down to the DB

- Tipo, Confianza, Precio, Autor, Fecha, Estado are now clickable with ↕ / ↑ / ↓ indicators.
- Sort is real, not page-local: \`listReviewQueue\` issues a raw-SQL query LEFT JOINing \`IngestionProductDraft\` / \`IngestionExtractionResult\` / \`TelegramIngestionMessage\` against the polymorphic \`targetId\`, then ORDERs globally. Pagination stays consistent with the chosen sort.
- Allowlisted sort keys are the only input to \`Prisma.raw\` — no path for caller-supplied SQL.
- \`NULLS LAST\` keeps UNEXTRACTABLE rows from polluting price / confidence sorts in either direction.

## Tests + validation

- Lint clean, \`tsc --noEmit\` clean.
- Existing \`test/integration/ingestion-admin-actions.test.ts\` (11 tests) still green; the sort refactor preserves the public \`listReviewQueue\` contract and adds two optional params.

## Guarantees before merge

- \`kill-ingestion-processing\` unchanged, default-engaged.
- \`feat-ingestion-admin\` unchanged, default-off.
- Zero writes to \`Product\` / \`Vendor\` / \`ProductImage\` anywhere.

## Test plan

- [ ] CI green.
- [ ] Post-merge: refresh the admin review page, confirm Spanish copy, verify sort works on every column and persists across pagination.