### PR TITLE
feat(ingestion): Phase 4 PR-A — publish-to-catalog foundation

### DIFF
--- a/prisma/migrations/20260421080000_ingestion_publish_foundation/migration.sql
+++ b/prisma/migrations/20260421080000_ingestion_publish_foundation/migration.sql
@@ -1,0 +1,23 @@
+-- Phase 4 PR-A: foundation for publishing approved ingestion drafts
+-- as real Products. Additive only — no existing rows are mutated.
+
+-- Provenance columns on Product. Both nullable because the vast
+-- majority of existing products were created by vendor self-serve
+-- and have no ingestion origin. `sourceIngestionDraftId` is UNIQUE
+-- so the publish action is idempotent: approving the same draft
+-- twice returns the existing Product rather than creating a duplicate.
+ALTER TABLE "Product" ADD COLUMN     "sourceIngestionDraftId" TEXT;
+ALTER TABLE "Product" ADD COLUMN     "sourceTelegramMessageId" TEXT;
+
+CREATE UNIQUE INDEX "Product_sourceIngestionDraftId_key" ON "Product"("sourceIngestionDraftId");
+CREATE INDEX "Product_sourceTelegramMessageId_idx" ON "Product"("sourceTelegramMessageId");
+
+-- Fallback Category for ingestion publishes whose extracted
+-- `categorySlug` does not match any existing Category row. The
+-- admin-side catalog reviewer is expected to reassign these before
+-- flipping the product to ACTIVE. The ID is hard-coded so the row
+-- is deterministic across environments and safe to reference from
+-- tests.
+INSERT INTO "Category" ("id", "name", "slug", "isActive", "sortOrder", "createdAt", "updatedAt")
+VALUES ('cat_uncategorized', 'Sin categoría', 'uncategorized', true, 999, NOW(), NOW())
+ON CONFLICT ("slug") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -366,6 +366,18 @@ model Product {
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 
+  // Phase 4 — ingestion provenance. Set when this Product was created
+  // by publishing an approved IngestionProductDraft. The UNIQUE
+  // constraint on `sourceIngestionDraftId` is the sole mechanism that
+  // prevents the "approve the same draft twice" race from inserting
+  // duplicate products. `sourceTelegramMessageId` is kept as a
+  // convenience for cross-references from Product back to the raw
+  // Telegram message; it is a secondary handle and NOT unique (a
+  // single message can theoretically yield several product drafts
+  // when the extractor detects multiple products in one post).
+  sourceIngestionDraftId  String? @unique
+  sourceTelegramMessageId String?
+
   vendor            Vendor             @relation(fields: [vendorId], references: [id])
   category          Category?          @relation(fields: [categoryId], references: [id])
   variants          ProductVariant[]
@@ -387,6 +399,7 @@ model Product {
   // filtered by status. Composite index keeps page N constant-time
   // regardless of N. See #89.
   @@index([status, createdAt(sort: Desc), id(sort: Desc)])
+  @@index([sourceTelegramMessageId])
 }
 
 model ProductVariant {

--- a/src/domains/catalog/availability.ts
+++ b/src/domains/catalog/availability.ts
@@ -7,6 +7,14 @@ export function getAvailableProductWhere(now = new Date()): Prisma.ProductWhereI
   return {
     status: 'ACTIVE',
     deletedAt: null,
+    // Phase 4 defence: even if a `Product` is flipped to ACTIVE, it
+    // must not leak into the public catalog while its owning Vendor
+    // is still in any non-public state (APPLYING, PENDING_DOCS,
+    // REJECTED, SUSPENDED_*). This matters for ingestion-created
+    // products whose Vendor is a ghost row keyed to a Telegram
+    // author, but it also plugs a latent gap for any suspended
+    // vendor whose products weren't individually taken down.
+    vendor: { status: 'ACTIVE' },
     OR: [
       { expiresAt: null },
       { expiresAt: { gt: now } },

--- a/src/domains/ingestion/flags.ts
+++ b/src/domains/ingestion/flags.ts
@@ -1,4 +1,4 @@
-import { isFeatureEnabled, type FlagContext } from '@/lib/flags'
+import { isFeatureEnabled, isFeatureEnabledStrict, type FlagContext } from '@/lib/flags'
 import { logger } from '@/lib/logger'
 
 /**
@@ -22,6 +22,7 @@ import { logger } from '@/lib/logger'
 
 export const INGESTION_KILL_FLAG = 'kill-ingestion-telegram'
 export const INGESTION_ADMIN_FEATURE_FLAG = 'feat-ingestion-admin'
+export const INGESTION_PUBLISH_FEATURE_FLAG = 'feat-ingestion-publish'
 
 export interface KillSwitchLogFields {
   correlationId?: string
@@ -63,4 +64,22 @@ export async function isIngestionAdminEnabled(
   ctx?: FlagContext,
 ): Promise<boolean> {
   return isFeatureEnabled(INGESTION_ADMIN_FEATURE_FLAG, ctx)
+}
+
+/**
+ * Phase 4 — returns `true` when the publish-to-catalog action is
+ * enabled for the given caller. Orthogonal to the admin UI flag:
+ * operators may want to preview the review queue without arming the
+ * publish path. Default off until Phase 4 PR-B lands the action.
+ *
+ * Unlike `isIngestionAdminEnabled`, this gate uses the **strict**
+ * evaluator: a PostHog outage, a missing key, or an `undefined` flag
+ * value all resolve to `false`. Spinning up Product + Vendor rows
+ * during an ops incident would be harder to roll back than simply
+ * waiting, so fail-closed is the right default for this path.
+ */
+export async function isIngestionPublishEnabled(
+  ctx?: FlagContext,
+): Promise<boolean> {
+  return isFeatureEnabledStrict(INGESTION_PUBLISH_FEATURE_FLAG, ctx)
 }

--- a/src/domains/ingestion/index.ts
+++ b/src/domains/ingestion/index.ts
@@ -21,8 +21,10 @@ export {
 export {
   INGESTION_KILL_FLAG,
   INGESTION_ADMIN_FEATURE_FLAG,
+  INGESTION_PUBLISH_FEATURE_FLAG,
   isIngestionKilled,
   isIngestionAdminEnabled,
+  isIngestionPublishEnabled,
 } from './flags'
 
 export {

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -105,6 +105,41 @@ export async function isFeatureEnabled(
   }
 }
 
+/**
+ * Fail-closed variant of `isFeatureEnabled` for feature gates whose
+ * "unknown" state MUST resolve to off — publish paths, destructive
+ * actions, anything that cannot safely run during a PostHog outage.
+ *
+ * Returns `true` only when:
+ *   - an explicit `true` override is present, OR
+ *   - PostHog is configured AND returns a strict `true` for the key.
+ *
+ * A PostHog outage, a missing key, an exception, or an `undefined`
+ * flag value all resolve to `false`. Use this INSTEAD OF
+ * `isFeatureEnabled` for anything whose default-on behaviour during
+ * an outage would be unacceptable.
+ */
+export async function isFeatureEnabledStrict(
+  key: string,
+  ctx?: FlagContext
+): Promise<boolean> {
+  const overrides = getOverrides()
+  const override = overrides[key]
+  if (typeof override === 'boolean') return override
+
+  try {
+    const client = await getClient()
+    if (!client) return false
+    const result = await client.isFeatureEnabled(key, distinctId(ctx), {
+      personProperties: personProperties(ctx),
+    })
+    return result === true
+  } catch (err) {
+    logger.warn('flags.eval_failed_strict', { key, err })
+    return false
+  }
+}
+
 export function resetFlagsForTests(): void {
   clientPromise = null
   overrideCache = null

--- a/test/features/catalog-availability.test.ts
+++ b/test/features/catalog-availability.test.ts
@@ -16,6 +16,10 @@ test('getAvailableProductWhere excludes expired products from storefront queries
   assert.deepEqual(where, {
     status: 'ACTIVE',
     deletedAt: null,
+    // Phase 4 hardening: a Product only counts as "available" when
+    // its owning Vendor is ACTIVE too. Prevents suspended vendors and
+    // ingestion ghost vendors from leaking into the public catalog.
+    vendor: { status: 'ACTIVE' },
     OR: [
       { expiresAt: null },
       { expiresAt: { gt: now } },

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -15,6 +15,19 @@ export async function resetIntegrationDatabase() {
     .join(', ')
 
   await db.$executeRawUnsafe(`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`)
+
+  // Re-seed the fallback Category the Phase 4 publish migration
+  // creates. The shared-isolation cohort registers every file's
+  // `beforeEach(resetIntegrationDatabase)` globally in the same
+  // process, so a later file's reset can wipe a row that an earlier
+  // file's beforeEach seeded. Re-seeding here keeps the invariant
+  // "after any reset, cat_uncategorized exists" true regardless of
+  // hook ordering across files.
+  await db.$executeRawUnsafe(`
+    INSERT INTO "Category" ("id", "name", "slug", "isActive", "sortOrder", "createdAt", "updatedAt")
+    VALUES ('cat_uncategorized', 'Sin categoría', 'uncategorized', true, 999, NOW(), NOW())
+    ON CONFLICT ("slug") DO NOTHING
+  `)
 }
 
 export function useTestSession(session: ActionSession | null) {

--- a/test/integration/ingestion-cycle-end-to-end.test.ts
+++ b/test/integration/ingestion-cycle-end-to-end.test.ts
@@ -124,8 +124,15 @@ test('integration: end-to-end cycle produces coherent aggregates across stages',
   // PRODUCT with no extractable price — expected skip (bias).
   await ingest(chat.id, 6, 'Hoy tengo manzanas disponibles', '42')
 
-  const from = new Date('2026-04-19T00:00:00Z')
-  const to = new Date('2026-04-21T00:00:00Z')
+  // The aggregator filters by the `createdAt` of Ingestion* rows
+  // (not `postedAt`), so the window has to cover whatever wall-clock
+  // moment these writes happen. Anchoring to `new Date()` ± a day
+  // lets this test keep working after the calendar ticks past the
+  // fixture date — the previous hard-coded 2026-04-21 ceiling
+  // silently dropped every row once the runner passed that moment.
+  const now = new Date()
+  const from = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+  const to = new Date(now.getTime() + 24 * 60 * 60 * 1000)
   const aggregates = await computeProcessingAggregates(
     db as unknown as ObservabilityDb,
     { from, to },

--- a/test/integration/ingestion-publish-foundation.test.ts
+++ b/test/integration/ingestion-publish-foundation.test.ts
@@ -45,22 +45,6 @@ import { clearTestFlagOverrides, setTestFlagOverrides } from '../flags-helper'
  * unique constraint + seeded category) landed.
  */
 
-async function insertActiveCategoryIfMissing() {
-  // `uncategorized` is seeded by migration but tests that truncate
-  // the DB lose it; re-insert defensively.
-  await db.category.upsert({
-    where: { slug: 'uncategorized' },
-    create: {
-      id: 'cat_uncategorized',
-      name: 'Sin categoría',
-      slug: 'uncategorized',
-      isActive: true,
-      sortOrder: 999,
-    },
-    update: {},
-  })
-}
-
 async function createGhostUserVendor(tgAuthorId: string) {
   const email = `tg-${tgAuthorId}@ingestion.ghost.local`
   const user = await db.user.create({
@@ -126,7 +110,6 @@ async function createActiveProduct(vendorId: string, name: string) {
 
 beforeEach(async () => {
   await resetIntegrationDatabase()
-  await insertActiveCategoryIfMissing()
 })
 
 afterEach(() => {
@@ -186,8 +169,9 @@ test('migration: Product.sourceIngestionDraftId UNIQUE is enforced (idempotent p
 })
 
 test('migration: uncategorized Category row is present with stable id', async () => {
-  // The migration seeds this; resetIntegrationDatabase truncates; the
-  // beforeEach re-inserts via upsert to keep tests independent.
+  // The migration seeds this once per environment; the shared test
+  // helper re-seeds after every TRUNCATE so the invariant holds
+  // across cross-file beforeEach hook ordering.
   const row = await db.category.findUnique({ where: { slug: 'uncategorized' } })
   assert.ok(row)
   assert.equal(row!.id, 'cat_uncategorized')

--- a/test/integration/ingestion-publish-foundation.test.ts
+++ b/test/integration/ingestion-publish-foundation.test.ts
@@ -1,0 +1,341 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/lib/db'
+import {
+  getFeaturedProducts,
+  getHomeSnapshot,
+  getProductBySlug,
+  getProducts,
+  getVendorBySlug,
+  getVendors,
+} from '@/domains/catalog/queries'
+import { getAvailableProductWhere } from '@/domains/catalog/availability'
+import { authorizeCredentials } from '@/domains/auth/credentials'
+import {
+  INGESTION_PUBLISH_FEATURE_FLAG,
+  isIngestionPublishEnabled,
+} from '@/domains/ingestion'
+import { resetIntegrationDatabase } from './helpers'
+import { clearTestFlagOverrides, setTestFlagOverrides } from '../flags-helper'
+
+/**
+ * Phase 4 PR-A foundation tests against real Postgres.
+ *
+ * Three invariants the schema foundation commits to, all proven here
+ * rather than assumed:
+ *
+ *   1. A ghost Vendor (status=APPLYING, stripeOnboarded=false) and
+ *      every Product owned by it are invisible on every public
+ *      catalog surface, regardless of Product.status. This is the
+ *      load-bearing guarantee that lets Phase 4 create Ghost vendors
+ *      without leaking them into the shopfront.
+ *
+ *   2. A ghost User (isActive=false, emailVerified=null,
+ *      passwordHash=null) cannot reach a session via the credentials
+ *      provider. Three independent gates must all hold; each is
+ *      exercised independently.
+ *
+ *   3. `isIngestionPublishEnabled` is fail-closed: without an explicit
+ *      override and without PostHog, it resolves to `false`. This is
+ *      the critical difference from `isIngestionAdminEnabled`, which
+ *      is fail-open.
+ *
+ * Additionally: sanity-check the schema migration (new columns +
+ * unique constraint + seeded category) landed.
+ */
+
+async function insertActiveCategoryIfMissing() {
+  // `uncategorized` is seeded by migration but tests that truncate
+  // the DB lose it; re-insert defensively.
+  await db.category.upsert({
+    where: { slug: 'uncategorized' },
+    create: {
+      id: 'cat_uncategorized',
+      name: 'Sin categoría',
+      slug: 'uncategorized',
+      isActive: true,
+      sortOrder: 999,
+    },
+    update: {},
+  })
+}
+
+async function createGhostUserVendor(tgAuthorId: string) {
+  const email = `tg-${tgAuthorId}@ingestion.ghost.local`
+  const user = await db.user.create({
+    data: {
+      email,
+      firstName: 'Productor',
+      lastName: `tg-${tgAuthorId.slice(0, 6)}`,
+      role: 'VENDOR',
+      isActive: false,
+      emailVerified: null,
+      passwordHash: null,
+    },
+  })
+  const vendor = await db.vendor.create({
+    data: {
+      userId: user.id,
+      slug: `ghost-tg-${tgAuthorId}-${randomUUID().slice(0, 6)}`,
+      displayName: `Productor Telegram ${tgAuthorId.slice(-4)}`,
+      status: 'APPLYING',
+      stripeOnboarded: false,
+      commissionRate: 0.12,
+    },
+  })
+  return { user, vendor, email }
+}
+
+async function createActiveUserVendor() {
+  const user = await db.user.create({
+    data: {
+      email: `real-${randomUUID()}@example.com`,
+      firstName: 'Real',
+      lastName: 'Vendor',
+      role: 'VENDOR',
+      isActive: true,
+      emailVerified: new Date(),
+    },
+  })
+  const vendor = await db.vendor.create({
+    data: {
+      userId: user.id,
+      slug: `real-${randomUUID().slice(0, 8)}`,
+      displayName: 'Real Vendor',
+      status: 'ACTIVE',
+      stripeOnboarded: true,
+    },
+  })
+  return { user, vendor }
+}
+
+async function createActiveProduct(vendorId: string, name: string) {
+  return db.product.create({
+    data: {
+      vendorId,
+      name,
+      slug: `${name.toLowerCase().replace(/\s+/g, '-')}-${randomUUID().slice(0, 6)}`,
+      status: 'ACTIVE',
+      basePrice: 10,
+      stock: 5,
+      categoryId: 'cat_uncategorized',
+    },
+  })
+}
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  await insertActiveCategoryIfMissing()
+})
+
+afterEach(() => {
+  clearTestFlagOverrides()
+})
+
+// ─── schema migration sanity ─────────────────────────────────────────
+
+test('migration: Product carries sourceIngestionDraftId and sourceTelegramMessageId columns', async () => {
+  const { vendor } = await createActiveUserVendor()
+  const product = await db.product.create({
+    data: {
+      vendorId: vendor.id,
+      name: 'With provenance',
+      slug: `prov-${randomUUID().slice(0, 8)}`,
+      status: 'DRAFT',
+      basePrice: 1,
+      stock: 0,
+      sourceIngestionDraftId: `draft-${randomUUID()}`,
+      sourceTelegramMessageId: `msg-${randomUUID()}`,
+    },
+  })
+  const roundTrip = await db.product.findUniqueOrThrow({ where: { id: product.id } })
+  assert.ok(roundTrip.sourceIngestionDraftId)
+  assert.ok(roundTrip.sourceTelegramMessageId)
+})
+
+test('migration: Product.sourceIngestionDraftId UNIQUE is enforced (idempotent publish relies on this)', async () => {
+  const { vendor } = await createActiveUserVendor()
+  const draftId = `draft-${randomUUID()}`
+  await db.product.create({
+    data: {
+      vendorId: vendor.id,
+      name: 'First',
+      slug: `first-${randomUUID().slice(0, 8)}`,
+      status: 'DRAFT',
+      basePrice: 1,
+      stock: 0,
+      sourceIngestionDraftId: draftId,
+    },
+  })
+  await assert.rejects(
+    () =>
+      db.product.create({
+        data: {
+          vendorId: vendor.id,
+          name: 'Second attempt, same draft',
+          slug: `second-${randomUUID().slice(0, 8)}`,
+          status: 'DRAFT',
+          basePrice: 1,
+          stock: 0,
+          sourceIngestionDraftId: draftId,
+        },
+      }),
+    /Unique constraint/i,
+  )
+})
+
+test('migration: uncategorized Category row is present with stable id', async () => {
+  // The migration seeds this; resetIntegrationDatabase truncates; the
+  // beforeEach re-inserts via upsert to keep tests independent.
+  const row = await db.category.findUnique({ where: { slug: 'uncategorized' } })
+  assert.ok(row)
+  assert.equal(row!.id, 'cat_uncategorized')
+  assert.equal(row!.isActive, true)
+})
+
+// ─── public catalog exclusion ────────────────────────────────────────
+
+test('catalog: Product owned by ghost Vendor (APPLYING) is excluded by getAvailableProductWhere even when ACTIVE', async () => {
+  const { vendor } = await createGhostUserVendor('4242')
+  await createActiveProduct(vendor.id, 'Ghost Product')
+
+  const visible = await db.product.findMany({ where: getAvailableProductWhere() })
+  assert.equal(visible.length, 0, 'Ghost vendor products must never appear via the public WHERE filter')
+})
+
+test('catalog: ghost-owned Product does not surface in getProducts / getFeaturedProducts / home snapshot', async () => {
+  const { vendor: ghostVendor } = await createGhostUserVendor('9999')
+  await createActiveProduct(ghostVendor.id, 'Ghost Leak')
+
+  const { user: realUser, vendor: realVendor } = await createActiveUserVendor()
+  void realUser
+  await createActiveProduct(realVendor.id, 'Real Product')
+
+  const products = await getProducts()
+  assert.equal(products.products.length, 1)
+  assert.equal(products.products[0]!.name, 'Real Product')
+
+  const featured = await getFeaturedProducts(10)
+  assert.equal(featured.length, 1)
+  assert.equal(featured[0]!.name, 'Real Product')
+
+  const home = await getHomeSnapshot()
+  assert.equal(home.stats.activeProducts, 1)
+  assert.equal(home.featured.length, 1)
+})
+
+test('catalog: getVendors and getVendorBySlug never surface a Vendor in APPLYING status', async () => {
+  const { vendor: ghostVendor } = await createGhostUserVendor('7777')
+  const { vendor: realVendor } = await createActiveUserVendor()
+
+  const vendors = await getVendors(50)
+  assert.equal(vendors.length, 1)
+  assert.equal(vendors[0]!.id, realVendor.id)
+
+  const ghostBySlug = await getVendorBySlug(ghostVendor.slug)
+  assert.equal(ghostBySlug, null, 'Ghost vendor page must 404 even by direct slug')
+
+  const realBySlug = await getVendorBySlug(realVendor.slug)
+  assert.ok(realBySlug, 'Sanity: real vendor page resolves')
+})
+
+test('catalog: getProductBySlug returns null for a ghost-owned Product', async () => {
+  const { vendor } = await createGhostUserVendor('1234')
+  const product = await createActiveProduct(vendor.id, 'Should Not Resolve')
+  const hit = await getProductBySlug(product.slug)
+  assert.equal(hit, null)
+})
+
+test('catalog: a later SUSPENDED vendor is also excluded (hardening is not ingestion-specific)', async () => {
+  const { vendor } = await createActiveUserVendor()
+  const product = await createActiveProduct(vendor.id, 'Real And Active')
+
+  // Sanity before suspension.
+  const beforeVisible = await db.product.findMany({ where: getAvailableProductWhere() })
+  assert.equal(beforeVisible.length, 1)
+
+  await db.vendor.update({ where: { id: vendor.id }, data: { status: 'SUSPENDED_TEMP' } })
+  const afterVisible = await db.product.findMany({ where: getAvailableProductWhere() })
+  assert.equal(afterVisible.length, 0)
+  // Product row still exists — we just stopped serving it to the public.
+  const stillThere = await db.product.findUnique({ where: { id: product.id } })
+  assert.ok(stillThere)
+})
+
+// ─── ghost user cannot authenticate ──────────────────────────────────
+
+test('auth: ghost user with isActive=false is rejected by authorizeCredentials', async () => {
+  const { email } = await createGhostUserVendor('auth-1')
+  const result = await authorizeCredentials({
+    email,
+    password: 'does-not-matter-but-meets-min-length',
+  })
+  assert.equal(result, null)
+})
+
+test('auth: even with a password hash, an inactive ghost user cannot log in', async () => {
+  const { user } = await createGhostUserVendor('auth-2')
+  // Defensive probe: an operator who accidentally set a password on a
+  // ghost row still shouldn't be able to authenticate while isActive
+  // remains false.
+  await db.user.update({
+    where: { id: user.id },
+    data: {
+      // A valid bcrypt hash of 'Password123!' so we prove the
+      // isActive gate (not just the missing-hash short-circuit) is
+      // what blocks authentication.
+      passwordHash: '$2a$10$CwTycUXWue0Thq9StjUM0uJ8aQEYxjyxkqVcG1G3r/IL8RVXUmcJ6',
+      emailVerified: new Date(),
+    },
+  })
+  await db.user.update({
+    where: { id: user.id },
+    data: { isActive: false },
+  })
+  const result = await authorizeCredentials({
+    email: user.email,
+    password: 'Password123!',
+  })
+  assert.equal(result, null)
+})
+
+test('auth: a ghost user reactivated but with emailVerified=null stays blocked', async () => {
+  const { user } = await createGhostUserVendor('auth-3')
+  await db.user.update({
+    where: { id: user.id },
+    data: {
+      isActive: true,
+      emailVerified: null,
+      passwordHash: '$2a$10$CwTycUXWue0Thq9StjUM0uJ8aQEYxjyxkqVcG1G3r/IL8RVXUmcJ6',
+    },
+  })
+  const result = await authorizeCredentials({
+    email: user.email,
+    password: 'Password123!',
+  })
+  assert.equal(result, null)
+})
+
+// ─── publish flag fail-closed ────────────────────────────────────────
+
+test('flag: isIngestionPublishEnabled is FAIL-CLOSED — resolves false without override and without PostHog', async () => {
+  // `flags-helper`'s setTestFlagOverrides is where we normally pin a
+  // value; here we explicitly do NOT set one. With no PostHog key in
+  // the test env, the strict evaluator must return false.
+  clearTestFlagOverrides()
+  const enabled = await isIngestionPublishEnabled({ userId: 'probe', role: 'ADMIN_OPS' })
+  assert.equal(enabled, false)
+})
+
+test('flag: isIngestionPublishEnabled honours an explicit override=true', async () => {
+  setTestFlagOverrides({ [INGESTION_PUBLISH_FEATURE_FLAG]: true })
+  const enabled = await isIngestionPublishEnabled({ userId: 'probe', role: 'ADMIN_OPS' })
+  assert.equal(enabled, true)
+})
+
+test('flag: isIngestionPublishEnabled honours an explicit override=false', async () => {
+  setTestFlagOverrides({ [INGESTION_PUBLISH_FEATURE_FLAG]: false })
+  const enabled = await isIngestionPublishEnabled({ userId: 'probe', role: 'ADMIN_OPS' })
+  assert.equal(enabled, false)
+})


### PR DESCRIPTION
## Summary

Groundwork for **Phase 4** — turning approved `IngestionProductDraft` rows into real `Product` + `Vendor` rows so \"Aprobar\" stops being symbolic. This PR-A ships the **schema, flag, and defensive guarantees only**. No new user-facing behaviour. The publish action and the UI rename (\"Aprobar y crear producto\") land in PR-B.

Design validated beforehand — see the previous chat turn where the flow, field mapping, ghost-vendor strategy, risks, and phased plan were all signed off.

## What's in this PR

### Schema (additive migration, zero rows mutated)
- `Product.sourceIngestionDraftId` — nullable, **`UNIQUE`**. This is the sole defence against \"approve same draft twice creates two products\"; PR-B's publish action relies on it for idempotency.
- `Product.sourceTelegramMessageId` — nullable, indexed. Direct handle from `Product` back to the raw Telegram message so catalog admins can trace provenance without walking the draft + extraction chain.
- Seeded `Category { slug: 'uncategorized', id: 'cat_uncategorized' }`. Deterministic fallback when an ingested `categorySlug` doesn't match any existing row. Admin reassigns before flipping to `ACTIVE`.

### Flag (default off)
- `feat-ingestion-publish` via a **new** `isFeatureEnabledStrict` evaluator in `src/lib/flags.ts`. Unlike the existing `isFeatureEnabled` (fail-open), the strict variant fails **closed** — PostHog outage, missing key, exception, or `undefined` result all resolve to `false`. Spinning up Product + Vendor rows during an ops incident would be harder to roll back than waiting, so fail-closed is the correct default for this path.

### Public catalog hardening
`getAvailableProductWhere` now requires `vendor.status='ACTIVE'` alongside `product.status='ACTIVE'`. Closes a latent gap that would have let a suspended vendor's products stay visible, and — critically — is the load-bearing guarantee that a ghost Vendor (status `APPLYING`) cannot leak into the shopfront even if an operator flips one of its Products to `ACTIVE` by mistake.

The feature test pinning the WHERE shape was updated to match.

## Tests (14 integration tests, real Postgres, 1242 / 1242 green)

**Schema sanity**
- New columns round-trip.
- `UNIQUE` on `sourceIngestionDraftId` is enforced.
- Seeded `uncategorized` Category row resolves with stable id.

**Catalog exclusion — the user-required defensive battery**
- Ghost Vendor (`APPLYING`, `stripeOnboarded=false`) + `Product.status='ACTIVE'` is invisible in: `getProducts`, `getFeaturedProducts`, `getHomeSnapshot`, `getVendors`, `getVendorBySlug`, `getProductBySlug`, and via the raw `getAvailableProductWhere` filter.
- Same guard catches a real vendor later flipped to `SUSPENDED_TEMP` — proving the hardening is not ingestion-specific.

**Ghost user cannot authenticate — the three gates**
- `authorizeCredentials` rejects a ghost with `isActive=false`.
- Rejects an inactive ghost **even when someone sets a valid bcrypt hash + emailVerified** — proves the `isActive` gate (not just the missing-hash short-circuit) is what blocks auth.
- Rejects a reactivated ghost whose `emailVerified` is still `null`.

**Flag fail-closed**
- `isIngestionPublishEnabled` resolves `false` without override and without PostHog.
- Honours explicit `true` / `false` overrides.

## Explicitly **not** in this PR
- No `publishApprovedDraft` server action — PR-B.
- No UI changes — PR-B renames \"Aprobar\" → \"Aprobar y crear producto\".
- No image pipeline — PR-C.
- No claim-vendor flow — deferred as discussed.

## Guarantees before merge
- `kill-ingestion-processing` unchanged, default-engaged.
- `feat-ingestion-admin` unchanged, default-off.
- `feat-ingestion-publish` **default off** and **fail-closed** — a PostHog outage cannot accidentally enable the still-unimplemented publish path.
- Zero Product / Vendor / ProductImage mutations from ingestion code in this PR. Only schema + flag + catalog-filter tightening.
- Lint clean, `tsc --noEmit` clean (app + tsconfig.test.json), `audit:contracts` clean, unit suite 1242 / 1242.

## Test plan
- [ ] CI green.
- [ ] Post-merge: verify migration applies cleanly to all envs; `cat_uncategorized` row appears in Categories admin list with name \"Sin categoría\".
- [ ] Confirm existing public catalog still renders after the `vendor.status='ACTIVE'` filter lands (smoke the home page + a vendor page).
- [ ] Once validated, proceed to PR-B (publish action + UI wire).