### PR TITLE
feat(ingestion): Phase 4 PR-B — publishApprovedDraft + UI rename

### DIFF
--- a/src/components/admin/ingestion/ReviewItemActions.tsx
+++ b/src/components/admin/ingestion/ReviewItemActions.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import {
-  approveProductDraft,
+  publishApprovedDraft,
   editProductDraft,
   discardProductDraft,
   discardUnextractable,
@@ -208,9 +208,13 @@ export function ReviewItemActions(props: Props) {
       <div className="flex flex-wrap gap-2">
         <Button
           disabled={!canEdit || isPending}
-          onClick={() => runAction(() => approveProductDraft({ draftId }))}
+          onClick={() =>
+            runAction(async () => {
+              await publishApprovedDraft({ draftId })
+            })
+          }
         >
-          Aprobar
+          Aprobar y crear producto
         </Button>
         <Button
           variant="secondary"

--- a/src/domains/ingestion/processing/admin/actions.ts
+++ b/src/domains/ingestion/processing/admin/actions.ts
@@ -5,7 +5,9 @@ import { db } from '@/lib/db'
 import { getAuditRequestIp, mutateWithAudit } from '@/lib/audit'
 import { safeRevalidatePath } from '@/lib/revalidate'
 import { logger } from '@/lib/logger'
+import { slugify } from '@/lib/utils'
 import { requireIngestionAdmin } from '@/domains/ingestion/authz'
+import { isIngestionPublishEnabled } from '@/domains/ingestion/flags'
 
 /**
  * Phase 3 admin mutations for the ingestion review queue.
@@ -26,9 +28,79 @@ import { requireIngestionAdmin } from '@/domains/ingestion/authz'
 
 const REVALIDATE_PATH = '/admin/ingestion'
 
-const approveSchema = z.object({
+const publishSchema = z.object({
   draftId: z.string().min(1),
 })
+
+export class IngestionPublishValidationError extends Error {
+  readonly reason: string
+  constructor(reason: string, message: string) {
+    super(message)
+    this.name = 'IngestionPublishValidationError'
+    this.reason = reason
+  }
+}
+
+const UNIT_MAP: Record<string, string> = {
+  KG: 'kg',
+  G: 'g',
+  L: 'l',
+  ML: 'ml',
+  UNIT: 'unit',
+}
+
+/**
+ * Collapse whitespace, strip control chars, cap at 200 characters,
+ * and trim. Keeps emojis — they're load-bearing brand signal in
+ * Telegram producer posts. Returns empty string if nothing useful is
+ * left; the caller raises a validation error in that case.
+ */
+function sanitiseProductName(raw: string | null | undefined): string {
+  if (!raw) return ''
+  const cleaned = raw.replace(/[\u0000-\u001F\u007F]/g, ' ').replace(/\s+/g, ' ').trim()
+  return cleaned.slice(0, 200)
+}
+
+function ghostUserEmail(tgAuthorId: string): string {
+  return `tg-${tgAuthorId}@ingestion.ghost.local`
+}
+
+async function resolveUniqueSlug(base: string): Promise<string> {
+  const root = slugify(base) || 'producto'
+  let candidate = root
+  let suffix = 0
+  while (await db.product.findUnique({ where: { slug: candidate }, select: { id: true } })) {
+    suffix += 1
+    candidate = `${root}-${suffix}`
+    if (suffix > 50) {
+      candidate = `${root}-${Date.now()}`
+      break
+    }
+  }
+  return candidate
+}
+
+async function resolveUniqueVendorSlug(base: string): Promise<string> {
+  const root = slugify(base) || 'productor'
+  let candidate = root
+  let suffix = 0
+  while (await db.vendor.findUnique({ where: { slug: candidate }, select: { id: true } })) {
+    suffix += 1
+    candidate = `${root}-${suffix}`
+    if (suffix > 50) {
+      candidate = `${root}-${Date.now()}`
+      break
+    }
+  }
+  return candidate
+}
+
+interface PublishResult {
+  status: 'CREATED' | 'IDEMPOTENT'
+  productId: string
+  vendorId: string
+  ghostUserId: string
+}
 
 const editFieldsSchema = z.object({
   productName: z.string().trim().max(120).nullable().optional(),
@@ -84,27 +156,223 @@ function draftAuditSnapshot(draft: {
 }
 
 /**
- * Operator marks a product draft as approved. The draft row flips to
- * `APPROVED` and the review queue item transitions `ENQUEUED →
- * AUTO_RESOLVED` with a reason tag so subsequent audits can tell
- * manual approvals apart from LOW-risk dedupe auto-merges.
+ * Phase 4 — promote an ingested `IngestionProductDraft` into a real
+ * `Product` row. "Aprobar y crear producto" is what this action
+ * represents; there is no longer a simbolic "approve without
+ * publishing" step.
+ *
+ * Identity model — producers observed in Telegram do not have a
+ * platform `User`. To keep `Vendor.userId` non-nullable, we upsert a
+ * *ghost* User/Vendor pair keyed deterministically by `tgAuthorId`:
+ *
+ *   User.email   = `tg-<authorId>@ingestion.ghost.local`
+ *   User fields  = { isActive:false, emailVerified:null, passwordHash:null, role:VENDOR }
+ *   Vendor      = { userId → ghost user, status:'APPLYING', stripeOnboarded:false }
+ *
+ * The three independent blockers on the User row prevent the ghost
+ * from ever passing `authorizeCredentials`, and the Vendor status +
+ * `stripeOnboarded=false` combination is already filtered out of the
+ * public catalog by `getAvailableProductWhere` (hardened in PR-A).
+ *
+ * Idempotency is guaranteed by `Product.sourceIngestionDraftId`'s
+ * UNIQUE constraint. Re-running the action against the same draft
+ * returns the existing Product unchanged.
+ *
+ * Hard validations (raise `IngestionPublishValidationError`):
+ *   - Source message must carry a `tgAuthorId`. Without a stable
+ *     producer identity we refuse to create the ghost pair.
+ *   - `priceCents` must be present and strictly positive.
+ *   - `productName` must be non-empty after sanitisation.
+ *   - `currencyCode` must be EUR (or null → assumed EUR). Anything
+ *     else is refused until multi-currency lands.
  */
-export async function approveProductDraft(input: z.infer<typeof approveSchema>) {
+export async function publishApprovedDraft(
+  input: z.infer<typeof publishSchema>,
+): Promise<PublishResult> {
   const session = await requireIngestionAdmin()
-  const { draftId } = approveSchema.parse(input)
-  const ip = await getAuditRequestIp()
+  const { draftId } = publishSchema.parse(input)
 
-  const existing = await db.ingestionProductDraft.findUnique({ where: { id: draftId } })
-  if (!existing) throw new Error('Draft not found')
-  if (existing.status !== 'PENDING') {
-    throw new Error(`Draft already resolved (status=${existing.status})`)
+  // Strict publish-flag gate is separate from the admin UI flag —
+  // operators can have review access without the publish path armed.
+  const publishEnabled = await isIngestionPublishEnabled({
+    userId: session.user.id,
+    email: session.user.email ?? undefined,
+    role: session.user.role,
+  })
+  if (!publishEnabled) {
+    throw new IngestionPublishValidationError(
+      'flagOff',
+      'Publicación desactivada: flag feat-ingestion-publish no está habilitada para este operador.',
+    )
   }
 
-  await mutateWithAudit(async (tx) => {
-    const updated = await tx.ingestionProductDraft.update({
+  const ip = await getAuditRequestIp()
+
+  const draft = await db.ingestionProductDraft.findUnique({
+    where: { id: draftId },
+    include: {
+      sourceMessage: { select: { id: true, tgAuthorId: true } },
+    },
+  })
+  if (!draft) throw new IngestionPublishValidationError('notFound', 'Draft no encontrado')
+
+  // Idempotent short-circuit before touching anything else: if a
+  // Product already exists pointing at this draft, surface it and
+  // return. Callers cannot tell a first-time publish apart from a
+  // re-publish unless they inspect `status`.
+  const existingProduct = await db.product.findUnique({
+    where: { sourceIngestionDraftId: draftId },
+    select: { id: true, vendorId: true, vendor: { select: { userId: true } } },
+  })
+  if (existingProduct) {
+    logger.info('ingestion.admin.publish_idempotent', {
+      draftId,
+      productId: existingProduct.id,
+      actorId: session.user.id,
+    })
+    return {
+      status: 'IDEMPOTENT',
+      productId: existingProduct.id,
+      vendorId: existingProduct.vendorId,
+      ghostUserId: existingProduct.vendor.userId,
+    }
+  }
+
+  if (draft.status !== 'PENDING') {
+    throw new IngestionPublishValidationError(
+      'alreadyResolved',
+      `Draft ya resuelto (status=${draft.status}). Re-publicar un rechazado no está permitido.`,
+    )
+  }
+
+  // ── Hard validations ────────────────────────────────────────────
+  const tgAuthorId = draft.sourceMessage.tgAuthorId?.toString() ?? null
+  if (!tgAuthorId) {
+    throw new IngestionPublishValidationError(
+      'missingAuthor',
+      'El mensaje origen no tiene tgAuthorId — no se puede crear un vendor ghost estable.',
+    )
+  }
+  if (draft.priceCents == null || draft.priceCents <= 0) {
+    throw new IngestionPublishValidationError(
+      'invalidPrice',
+      'El draft no tiene priceCents > 0. Edita el draft antes de publicar.',
+    )
+  }
+  const productName = sanitiseProductName(draft.productName)
+  if (productName.length === 0) {
+    throw new IngestionPublishValidationError(
+      'emptyName',
+      'El nombre de producto queda vacío tras sanitizar. Edita el draft antes de publicar.',
+    )
+  }
+  const currencyCode = (draft.currencyCode ?? 'EUR').toUpperCase()
+  if (currencyCode !== 'EUR') {
+    throw new IngestionPublishValidationError(
+      'unsupportedCurrency',
+      `Solo EUR está soportado (draft usa ${currencyCode}).`,
+    )
+  }
+
+  // ── Ghost identity: upsert User + Vendor ────────────────────────
+  const email = ghostUserEmail(tgAuthorId)
+  const existingGhostUser = await db.user.findUnique({
+    where: { email },
+    select: { id: true, vendor: { select: { id: true } } },
+  })
+
+  let ghostUserId: string
+  let vendorId: string
+  if (existingGhostUser) {
+    ghostUserId = existingGhostUser.id
+    if (existingGhostUser.vendor) {
+      vendorId = existingGhostUser.vendor.id
+    } else {
+      // Defensive: a ghost user without its vendor row should not
+      // exist in practice, but nothing stops an operator from
+      // deleting one manually. Re-create the vendor if so.
+      const vendorSlug = await resolveUniqueVendorSlug(
+        `productor-tg-${tgAuthorId.slice(-4)}`,
+      )
+      const vendor = await db.vendor.create({
+        data: {
+          userId: ghostUserId,
+          slug: vendorSlug,
+          displayName: `Productor Telegram ${tgAuthorId.slice(-4)}`,
+          status: 'APPLYING',
+          stripeOnboarded: false,
+        },
+      })
+      vendorId = vendor.id
+    }
+  } else {
+    const ghostUser = await db.user.create({
+      data: {
+        email,
+        firstName: 'Productor',
+        lastName: `tg-${tgAuthorId.slice(0, 6)}`,
+        role: 'VENDOR',
+        isActive: false,
+        emailVerified: null,
+        passwordHash: null,
+      },
+    })
+    ghostUserId = ghostUser.id
+    const vendorSlug = await resolveUniqueVendorSlug(
+      `productor-tg-${tgAuthorId.slice(-4)}`,
+    )
+    const vendor = await db.vendor.create({
+      data: {
+        userId: ghostUserId,
+        slug: vendorSlug,
+        displayName: `Productor Telegram ${tgAuthorId.slice(-4)}`,
+        status: 'APPLYING',
+        stripeOnboarded: false,
+      },
+    })
+    vendorId = vendor.id
+  }
+
+  // ── Category: slug → id, fallback to cat_uncategorized ──────────
+  let categoryId = 'cat_uncategorized'
+  if (draft.categorySlug) {
+    const cat = await db.category.findUnique({
+      where: { slug: draft.categorySlug },
+      select: { id: true },
+    })
+    if (cat) categoryId = cat.id
+  }
+
+  // ── Product row + state transition + audit, one transaction ─────
+  const productSlug = await resolveUniqueSlug(productName)
+  const basePrice = (draft.priceCents / 100).toFixed(2)
+  const unit = UNIT_MAP[draft.unit ?? 'UNIT'] ?? 'unit'
+  const availability = draft.availability ?? 'UNKNOWN'
+  const stock = availability === 'AVAILABLE' ? 1 : 0
+
+  const { productId } = await mutateWithAudit(async (tx) => {
+    const product = await tx.product.create({
+      data: {
+        vendorId,
+        categoryId,
+        name: productName,
+        slug: productSlug,
+        status: 'PENDING_REVIEW',
+        basePrice,
+        unit,
+        stock,
+        trackStock: false,
+        weightGrams: draft.weightGrams,
+        sourceIngestionDraftId: draftId,
+        sourceTelegramMessageId: draft.sourceMessageId,
+      },
+    })
+
+    await tx.ingestionProductDraft.update({
       where: { id: draftId },
       data: { status: 'APPROVED' },
     })
+
     await tx.ingestionReviewQueueItem.updateMany({
       where: { kind: 'PRODUCT_DRAFT', targetId: draftId, state: 'ENQUEUED' },
       data: {
@@ -113,14 +381,26 @@ export async function approveProductDraft(input: z.infer<typeof approveSchema>) 
         autoResolvedAt: new Date(),
       },
     })
+
     return {
-      result: updated,
+      result: { productId: product.id },
       audit: {
-        action: 'INGESTION_DRAFT_APPROVED',
+        action: 'INGESTION_DRAFT_PUBLISHED',
         entityType: 'IngestionProductDraft',
         entityId: draftId,
-        before: draftAuditSnapshot(existing),
-        after: draftAuditSnapshot(updated),
+        before: draftAuditSnapshot(draft),
+        after: {
+          draftId,
+          productId: product.id,
+          vendorId,
+          ghostUserId,
+          sourceMessageId: draft.sourceMessageId,
+          productSlug,
+          productStatus: product.status,
+          basePriceEur: basePrice,
+          unit,
+          categoryId,
+        },
         actorId: session.user.id,
         actorRole: session.user.role,
         ip,
@@ -128,8 +408,17 @@ export async function approveProductDraft(input: z.infer<typeof approveSchema>) 
     }
   })
 
-  logger.info('ingestion.admin.draft_approved', { draftId, actorId: session.user.id })
+  logger.info('ingestion.admin.draft_published', {
+    draftId,
+    productId,
+    vendorId,
+    ghostUserId,
+    actorId: session.user.id,
+  })
   safeRevalidatePath(REVALIDATE_PATH)
+  safeRevalidatePath('/admin/productos')
+
+  return { status: 'CREATED', productId, vendorId, ghostUserId }
 }
 
 /**

--- a/src/domains/ingestion/processing/admin/actions.ts
+++ b/src/domains/ingestion/processing/admin/actions.ts
@@ -8,6 +8,7 @@ import { logger } from '@/lib/logger'
 import { slugify } from '@/lib/utils'
 import { requireIngestionAdmin } from '@/domains/ingestion/authz'
 import { isIngestionPublishEnabled } from '@/domains/ingestion/flags'
+import { IngestionPublishValidationError } from './errors'
 
 /**
  * Phase 3 admin mutations for the ingestion review queue.
@@ -31,15 +32,6 @@ const REVALIDATE_PATH = '/admin/ingestion'
 const publishSchema = z.object({
   draftId: z.string().min(1),
 })
-
-export class IngestionPublishValidationError extends Error {
-  readonly reason: string
-  constructor(reason: string, message: string) {
-    super(message)
-    this.name = 'IngestionPublishValidationError'
-    this.reason = reason
-  }
-}
 
 const UNIT_MAP: Record<string, string> = {
   KG: 'kg',

--- a/src/domains/ingestion/processing/admin/errors.ts
+++ b/src/domains/ingestion/processing/admin/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Domain errors for the Phase 4 admin publish action. Lives in its
+ * own (non-`'use server'`) module because Next.js server-action
+ * files are only allowed to export async functions — a class export
+ * from an `'use server'` file fails the Turbopack build.
+ */
+
+export class IngestionPublishValidationError extends Error {
+  readonly reason: string
+  constructor(reason: string, message: string) {
+    super(message)
+    this.name = 'IngestionPublishValidationError'
+    this.reason = reason
+  }
+}

--- a/src/domains/ingestion/processing/admin/index.ts
+++ b/src/domains/ingestion/processing/admin/index.ts
@@ -12,7 +12,8 @@ export {
 } from './queries'
 
 export {
-  approveProductDraft,
+  publishApprovedDraft,
+  IngestionPublishValidationError,
   editProductDraft,
   discardProductDraft,
   discardUnextractable,

--- a/src/domains/ingestion/processing/admin/index.ts
+++ b/src/domains/ingestion/processing/admin/index.ts
@@ -13,9 +13,10 @@ export {
 
 export {
   publishApprovedDraft,
-  IngestionPublishValidationError,
   editProductDraft,
   discardProductDraft,
   discardUnextractable,
   markUnextractableValid,
 } from './actions'
+
+export { IngestionPublishValidationError } from './errors'

--- a/test/integration/ingestion-admin-actions.test.ts
+++ b/test/integration/ingestion-admin-actions.test.ts
@@ -2,7 +2,6 @@ import test, { beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { db } from '@/lib/db'
 import {
-  approveProductDraft,
   discardProductDraft,
   editProductDraft,
   discardUnextractable,
@@ -170,22 +169,6 @@ afterEach(() => {
   clearTestSession()
 })
 
-test('admin: approve draft flips status to APPROVED + review item to AUTO_RESOLVED + audit row written', async () => {
-  const { draft, queueItem } = await seedProductDraft()
-  await withAdminSession(() => approveProductDraft({ draftId: draft.id }))
-
-  const updated = await db.ingestionProductDraft.findUniqueOrThrow({ where: { id: draft.id } })
-  assert.equal(updated.status, 'APPROVED')
-  const qi = await db.ingestionReviewQueueItem.findUniqueOrThrow({ where: { id: queueItem.id } })
-  assert.equal(qi.state, 'AUTO_RESOLVED')
-  assert.equal(qi.autoResolvedReason, 'adminApproved')
-  const auditRows = await db.auditLog.findMany({
-    where: { entityType: 'IngestionProductDraft', entityId: draft.id },
-  })
-  assert.equal(auditRows.length, 1)
-  assert.equal(auditRows[0]!.action, 'INGESTION_DRAFT_APPROVED')
-})
-
 test('admin: discard draft flips status to REJECTED + review item to AUTO_RESOLVED', async () => {
   const { draft, queueItem } = await seedProductDraft()
   await withAdminSession(() => discardProductDraft({ draftId: draft.id }))
@@ -218,11 +201,11 @@ test('admin: edit draft patches whitelisted fields only + writes before/after au
   assert.equal(auditRows.length, 1)
 })
 
-test('admin: approve refuses when draft is already resolved', async () => {
+test('admin: discard refuses when draft is already resolved', async () => {
   const { draft } = await seedProductDraft()
-  await withAdminSession(() => approveProductDraft({ draftId: draft.id }))
+  await withAdminSession(() => discardProductDraft({ draftId: draft.id }))
   await assert.rejects(
-    () => withAdminSession(() => approveProductDraft({ draftId: draft.id })),
+    () => withAdminSession(() => discardProductDraft({ draftId: draft.id })),
     /already resolved/,
   )
 })
@@ -250,7 +233,7 @@ test('admin: actions refuse when feat-ingestion-admin flag is off (pre-GA isolat
   const { draft } = await seedProductDraft()
   setTestFlagOverrides({ [INGESTION_ADMIN_FEATURE_FLAG]: false })
   await assert.rejects(
-    () => withAdminSession(() => approveProductDraft({ draftId: draft.id })),
+    () => withAdminSession(() => discardProductDraft({ draftId: draft.id })),
     /not currently available/i,
   )
   // State must be untouched.

--- a/test/integration/ingestion-publish-action.test.ts
+++ b/test/integration/ingestion-publish-action.test.ts
@@ -7,7 +7,7 @@ import {
   INGESTION_PUBLISH_FEATURE_FLAG,
   publishApprovedDraft,
 } from '@/domains/ingestion'
-import { IngestionPublishValidationError } from '@/domains/ingestion/processing/admin/actions'
+import { IngestionPublishValidationError } from '@/domains/ingestion/processing/admin/errors'
 import {
   buildSession,
   clearTestSession,

--- a/test/integration/ingestion-publish-action.test.ts
+++ b/test/integration/ingestion-publish-action.test.ts
@@ -1,0 +1,387 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/lib/db'
+import {
+  INGESTION_ADMIN_FEATURE_FLAG,
+  INGESTION_PUBLISH_FEATURE_FLAG,
+  publishApprovedDraft,
+} from '@/domains/ingestion'
+import { IngestionPublishValidationError } from '@/domains/ingestion/processing/admin/actions'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+import { clearTestFlagOverrides, setTestFlagOverrides } from '../flags-helper'
+
+/**
+ * Phase 4 PR-B publish action end-to-end against real Postgres.
+ *
+ * The action is the only path that turns an approved draft into a
+ * real `Product` + ghost `Vendor` row. Invariants covered:
+ *
+ *   - Happy path: PENDING → PENDING_REVIEW catalog row, deterministic
+ *     ghost User + Vendor created, draft flipped APPROVED, review
+ *     queue resolved with `adminApproved`, single audit row with
+ *     full trace.
+ *   - Idempotency: approving the same draft twice returns the same
+ *     Product id and does NOT create a second ghost user.
+ *   - Same producer across two drafts: one User + one Vendor, two
+ *     distinct Products.
+ *   - Hard validations: missing tgAuthorId, priceCents null or ≤ 0,
+ *     empty productName after sanitisation, non-EUR currency, and
+ *     already-resolved draft all raise `IngestionPublishValidationError`
+ *     without side effects.
+ *   - Category fallback: unknown slug maps to cat_uncategorized.
+ *   - Flag gating: publish is blocked when `feat-ingestion-publish`
+ *     is off, even when `feat-ingestion-admin` is on.
+ */
+
+interface SeedOpts {
+  tgAuthorId?: string | null
+  productName?: string | null
+  priceCents?: number | null
+  currencyCode?: string | null
+  unit?: string | null
+  weightGrams?: number | null
+  categorySlug?: string | null
+  availability?: string | null
+  draftStatus?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'TOMBSTONED'
+}
+
+async function seedProductDraft(opts: SeedOpts = {}) {
+  const connection = await db.telegramIngestionConnection.create({
+    data: {
+      label: `Test ${randomUUID().slice(0, 8)}`,
+      phoneNumberHash: 'h',
+      sessionRef: `sess-${randomUUID()}`,
+      status: 'ACTIVE',
+      createdByUserId: 'u1',
+    },
+  })
+  const chat = await db.telegramIngestionChat.create({
+    data: {
+      connectionId: connection.id,
+      tgChatId: BigInt(-100) - BigInt(Math.floor(Math.random() * 1_000_000)),
+      title: 't',
+      kind: 'SUPERGROUP',
+      isEnabled: true,
+    },
+  })
+  const tgAuthorId = opts.tgAuthorId === undefined ? '424242' : opts.tgAuthorId
+  const message = await db.telegramIngestionMessage.create({
+    data: {
+      chatId: chat.id,
+      tgMessageId: BigInt(Math.floor(Math.random() * 1_000_000_000)),
+      tgAuthorId: tgAuthorId == null ? null : BigInt(tgAuthorId),
+      text: 'seed text',
+      rawJson: {},
+      postedAt: new Date(),
+    },
+  })
+  const extraction = await db.ingestionExtractionResult.create({
+    data: {
+      messageId: message.id,
+      engine: 'RULES',
+      extractorVersion: 'rules-1.2.0',
+      schemaVersion: 2,
+      inputSnapshot: { text: 'seed text' },
+      payload: { products: [{ productOrdinal: 0 }], rulesFired: [] },
+      confidenceOverall: 0.85,
+      confidenceBand: 'HIGH',
+      confidenceByField: {},
+      classification: 'PRODUCT',
+      correlationId: `cid-${randomUUID()}`,
+    },
+  })
+  const draft = await db.ingestionProductDraft.create({
+    data: {
+      sourceMessageId: message.id,
+      sourceExtractionId: extraction.id,
+      extractorVersion: 'rules-1.2.0',
+      productOrdinal: 0,
+      status: opts.draftStatus ?? 'PENDING',
+      confidenceOverall: 0.85,
+      confidenceBand: 'HIGH',
+      productName:
+        opts.productName === undefined ? 'Manzanas golden' : opts.productName,
+      priceCents: opts.priceCents === undefined ? 250 : opts.priceCents,
+      currencyCode:
+        opts.currencyCode === undefined ? 'EUR' : opts.currencyCode,
+      unit: opts.unit === undefined ? 'KG' : opts.unit,
+      weightGrams: opts.weightGrams === undefined ? null : opts.weightGrams,
+      categorySlug:
+        opts.categorySlug === undefined ? null : opts.categorySlug,
+      availability:
+        opts.availability === undefined ? 'AVAILABLE' : opts.availability,
+      rawFieldsSeen: {},
+    },
+  })
+  await db.ingestionReviewQueueItem.create({
+    data: { kind: 'PRODUCT_DRAFT', targetId: draft.id, state: 'ENQUEUED' },
+  })
+  return { draft, message, extraction }
+}
+
+async function withAdmin<T>(fn: () => Promise<T>): Promise<T> {
+  const user = await createUser('ADMIN_OPS')
+  useTestSession(buildSession(user.id, 'ADMIN_OPS'))
+  try {
+    return await fn()
+  } finally {
+    clearTestSession()
+  }
+}
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  setTestFlagOverrides({
+    [INGESTION_ADMIN_FEATURE_FLAG]: true,
+    [INGESTION_PUBLISH_FEATURE_FLAG]: true,
+  })
+})
+
+afterEach(() => {
+  clearTestFlagOverrides()
+  clearTestSession()
+})
+
+// ─── happy path ──────────────────────────────────────────────────────
+
+test('publish: happy path creates Product + ghost Vendor + ghost User, resolves draft', async () => {
+  const { draft, message } = await seedProductDraft()
+  const result = await withAdmin(() => publishApprovedDraft({ draftId: draft.id }))
+
+  assert.equal(result.status, 'CREATED')
+  assert.ok(result.productId)
+  assert.ok(result.vendorId)
+  assert.ok(result.ghostUserId)
+
+  const product = await db.product.findUniqueOrThrow({ where: { id: result.productId } })
+  assert.equal(product.status, 'PENDING_REVIEW')
+  assert.equal(product.name, 'Manzanas golden')
+  assert.equal(product.basePrice.toString(), '2.5')
+  assert.equal(product.unit, 'kg')
+  assert.equal(product.stock, 1)
+  assert.equal(product.trackStock, false)
+  assert.equal(product.sourceIngestionDraftId, draft.id)
+  assert.equal(product.sourceTelegramMessageId, message.id)
+  assert.equal(product.categoryId, 'cat_uncategorized')
+
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: result.vendorId } })
+  assert.equal(vendor.status, 'APPLYING')
+  assert.equal(vendor.stripeOnboarded, false)
+  assert.equal(vendor.userId, result.ghostUserId)
+
+  const user = await db.user.findUniqueOrThrow({ where: { id: result.ghostUserId } })
+  assert.equal(user.email, 'tg-424242@ingestion.ghost.local')
+  assert.equal(user.isActive, false)
+  assert.equal(user.emailVerified, null)
+  assert.equal(user.passwordHash, null)
+
+  const updatedDraft = await db.ingestionProductDraft.findUniqueOrThrow({ where: { id: draft.id } })
+  assert.equal(updatedDraft.status, 'APPROVED')
+
+  const reviewItem = await db.ingestionReviewQueueItem.findFirstOrThrow({
+    where: { kind: 'PRODUCT_DRAFT', targetId: draft.id },
+  })
+  assert.equal(reviewItem.state, 'AUTO_RESOLVED')
+  assert.equal(reviewItem.autoResolvedReason, 'adminApproved')
+
+  const auditRows = await db.auditLog.findMany({
+    where: { entityType: 'IngestionProductDraft', entityId: draft.id },
+  })
+  assert.equal(auditRows.length, 1)
+  assert.equal(auditRows[0]!.action, 'INGESTION_DRAFT_PUBLISHED')
+  const after = auditRows[0]!.after as Record<string, unknown>
+  assert.equal(after.productId, result.productId)
+  assert.equal(after.vendorId, result.vendorId)
+  assert.equal(after.ghostUserId, result.ghostUserId)
+  assert.equal(after.sourceMessageId, message.id)
+})
+
+test('publish: honours categorySlug when it resolves to an existing Category', async () => {
+  const cat = await db.category.create({
+    data: { name: 'Frutas', slug: 'frutas', isActive: true },
+  })
+  const { draft } = await seedProductDraft({ categorySlug: 'frutas' })
+  const result = await withAdmin(() => publishApprovedDraft({ draftId: draft.id }))
+  const product = await db.product.findUniqueOrThrow({ where: { id: result.productId } })
+  assert.equal(product.categoryId, cat.id)
+})
+
+test('publish: unknown categorySlug falls back to cat_uncategorized without error', async () => {
+  const { draft } = await seedProductDraft({ categorySlug: 'this-category-does-not-exist' })
+  const result = await withAdmin(() => publishApprovedDraft({ draftId: draft.id }))
+  const product = await db.product.findUniqueOrThrow({ where: { id: result.productId } })
+  assert.equal(product.categoryId, 'cat_uncategorized')
+})
+
+test('publish: availability=UNKNOWN sets stock=0, AVAILABLE sets stock=1', async () => {
+  const { draft: draftAvail } = await seedProductDraft({ availability: 'AVAILABLE' })
+  const a = await withAdmin(() => publishApprovedDraft({ draftId: draftAvail.id }))
+  const pa = await db.product.findUniqueOrThrow({ where: { id: a.productId } })
+  assert.equal(pa.stock, 1)
+
+  const { draft: draftUnknown } = await seedProductDraft({
+    availability: 'UNKNOWN',
+    tgAuthorId: '999999',
+  })
+  const b = await withAdmin(() => publishApprovedDraft({ draftId: draftUnknown.id }))
+  const pb = await db.product.findUniqueOrThrow({ where: { id: b.productId } })
+  assert.equal(pb.stock, 0)
+})
+
+// ─── idempotency ─────────────────────────────────────────────────────
+
+test('publish: idempotent — same draft twice returns same Product, no duplicate ghosts', async () => {
+  const { draft } = await seedProductDraft()
+  const first = await withAdmin(() => publishApprovedDraft({ draftId: draft.id }))
+  assert.equal(first.status, 'CREATED')
+
+  const second = await withAdmin(() => publishApprovedDraft({ draftId: draft.id }))
+  assert.equal(second.status, 'IDEMPOTENT')
+  assert.equal(second.productId, first.productId)
+  assert.equal(second.vendorId, first.vendorId)
+  assert.equal(second.ghostUserId, first.ghostUserId)
+
+  const products = await db.product.findMany({ where: { sourceIngestionDraftId: draft.id } })
+  assert.equal(products.length, 1)
+  const vendors = await db.vendor.count()
+  assert.equal(vendors, 1)
+  const users = await db.user.count({
+    where: { email: { startsWith: 'tg-' } },
+  })
+  assert.equal(users, 1)
+})
+
+test('publish: two drafts from same tgAuthorId reuse the ghost User+Vendor and create two Products', async () => {
+  const { draft: d1 } = await seedProductDraft({ tgAuthorId: '555', productName: 'A' })
+  const { draft: d2 } = await seedProductDraft({ tgAuthorId: '555', productName: 'B' })
+
+  const r1 = await withAdmin(() => publishApprovedDraft({ draftId: d1.id }))
+  const r2 = await withAdmin(() => publishApprovedDraft({ draftId: d2.id }))
+
+  assert.equal(r1.status, 'CREATED')
+  assert.equal(r2.status, 'CREATED')
+  assert.notEqual(r1.productId, r2.productId)
+  assert.equal(r1.vendorId, r2.vendorId)
+  assert.equal(r1.ghostUserId, r2.ghostUserId)
+
+  const ghostUsers = await db.user.count({
+    where: { email: 'tg-555@ingestion.ghost.local' },
+  })
+  assert.equal(ghostUsers, 1)
+  const ghostVendors = await db.vendor.count({
+    where: { userId: r1.ghostUserId },
+  })
+  assert.equal(ghostVendors, 1)
+})
+
+test('publish: two drafts from DIFFERENT authors create two ghost User+Vendor pairs', async () => {
+  const { draft: d1 } = await seedProductDraft({ tgAuthorId: '111' })
+  const { draft: d2 } = await seedProductDraft({ tgAuthorId: '222' })
+
+  const r1 = await withAdmin(() => publishApprovedDraft({ draftId: d1.id }))
+  const r2 = await withAdmin(() => publishApprovedDraft({ draftId: d2.id }))
+
+  assert.notEqual(r1.ghostUserId, r2.ghostUserId)
+  assert.notEqual(r1.vendorId, r2.vendorId)
+  const users = await db.user.count({ where: { email: { startsWith: 'tg-' } } })
+  assert.equal(users, 2)
+})
+
+// ─── validation blocks ───────────────────────────────────────────────
+
+test('publish: refuses when the source message has no tgAuthorId', async () => {
+  const { draft } = await seedProductDraft({ tgAuthorId: null })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'missingAuthor',
+  )
+  assert.equal(await db.product.count(), 0)
+  assert.equal(await db.vendor.count(), 0)
+})
+
+test('publish: refuses when priceCents is null', async () => {
+  const { draft } = await seedProductDraft({ priceCents: null })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'invalidPrice',
+  )
+})
+
+test('publish: refuses when priceCents is zero or negative', async () => {
+  const { draft: zero } = await seedProductDraft({ priceCents: 0 })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: zero.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'invalidPrice',
+  )
+  const { draft: negative } = await seedProductDraft({ priceCents: -10 })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: negative.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'invalidPrice',
+  )
+})
+
+test('publish: refuses when productName sanitises to empty string', async () => {
+  const { draft } = await seedProductDraft({ productName: '   \n\t  ' })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'emptyName',
+  )
+})
+
+test('publish: refuses when currency is not EUR', async () => {
+  const { draft } = await seedProductDraft({ currencyCode: 'USD' })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'unsupportedCurrency',
+  )
+})
+
+test('publish: refuses when draft is already REJECTED', async () => {
+  const { draft } = await seedProductDraft({ draftStatus: 'REJECTED' })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'alreadyResolved',
+  )
+})
+
+test('publish: missing draft returns a clean validation error', async () => {
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: 'no-such-draft' })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'notFound',
+  )
+})
+
+// ─── flag gating ─────────────────────────────────────────────────────
+
+test('publish: blocked when feat-ingestion-publish is off even with admin flag on', async () => {
+  const { draft } = await seedProductDraft()
+  setTestFlagOverrides({
+    [INGESTION_ADMIN_FEATURE_FLAG]: true,
+    [INGESTION_PUBLISH_FEATURE_FLAG]: false,
+  })
+  await assert.rejects(
+    () => withAdmin(() => publishApprovedDraft({ draftId: draft.id })),
+    (err: unknown) =>
+      err instanceof IngestionPublishValidationError && err.reason === 'flagOff',
+  )
+  // No side effects.
+  assert.equal(await db.product.count(), 0)
+  assert.equal(await db.vendor.count(), 0)
+  const unchanged = await db.ingestionProductDraft.findUniqueOrThrow({ where: { id: draft.id } })
+  assert.equal(unchanged.status, 'PENDING')
+})


### PR DESCRIPTION
## Summary

**Aprobar** deja de ser simbólico. El botón ahora crea un \`Product\` real en \`PENDING_REVIEW\`, bajo un Ghost \`Vendor\` determinista ligado al \`tgAuthorId\`. Completa la condición #1 del PR-B aprobado: **una sola semántica de aprobar** (\"Aprobar y crear producto\").

Cumple las 5 condiciones de la aprobación previa.

## Flujo real end-to-end

```
Admin hace click en "Aprobar y crear producto" en /admin/ingestion/[itemId]
  │
  ▼ ReviewItemActions → publishApprovedDraft({ draftId })
  │
  ├─ requireIngestionAdmin   (ADMIN_* role + feat-ingestion-admin)
  ├─ isIngestionPublishEnabled (fail-closed, strict evaluator)
  │
  ├─ Carga draft + sourceMessage.tgAuthorId
  │
  ├─ Idempotent short-circuit:
  │    SI existe Product.sourceIngestionDraftId = draftId
  │      → return { status: 'IDEMPOTENT', productId, vendorId, ghostUserId }
  │
  ├─ Hard validations → IngestionPublishValidationError { reason, message }:
  │    • notFound            (draft missing)
  │    • alreadyResolved     (status ≠ PENDING)
  │    • missingAuthor       (source message sin tgAuthorId)
  │    • invalidPrice        (null, 0, negativo)
  │    • emptyName           (productName vacío tras sanitizar)
  │    • unsupportedCurrency (currency ≠ EUR)
  │    • flagOff             (feat-ingestion-publish off)
  │
  ├─ Ghost identity (upsert idempotente por tgAuthorId):
  │    User  { email: tg-<id>@ingestion.ghost.local,
  │            isActive:false, emailVerified:null, passwordHash:null,
  │            role:VENDOR }
  │    Vendor { userId: ghost, status:'APPLYING',
  │             stripeOnboarded:false, slug único }
  │
  ├─ Category resolver: slug → id, fallback 'cat_uncategorized'
  │
  ├─ TX única:
  │    1. INSERT Product (status=PENDING_REVIEW, sourceIngestionDraftId,
  │                       sourceTelegramMessageId, basePrice=priceCents/100,
  │                       unit mapped, stock desde availability)
  │    2. UPDATE IngestionProductDraft.status = APPROVED
  │    3. UPDATE IngestionReviewQueueItem.state = AUTO_RESOLVED
  │                (autoResolvedReason = 'adminApproved')
  │    4. INSERT AuditLog (INGESTION_DRAFT_PUBLISHED) con:
  │         before: snapshot del draft
  │         after:  { draftId, productId, vendorId, ghostUserId,
  │                   sourceMessageId, productSlug, productStatus,
  │                   basePriceEur, unit, categoryId }
  │
  └─ return { status: 'CREATED', productId, vendorId, ghostUserId }
```

El Product aparece inmediatamente en \`/admin/productos\` con estado \`PENDING_REVIEW\`. Nunca se pone en \`ACTIVE\` desde este flujo — eso queda como acto humano separado en el panel de productos.

## Cumplimiento de las 5 condiciones

**1. Acción única y clara**
- Botón renombrado a \"Aprobar y crear producto\".
- \`approveProductDraft\` eliminada del domain + tests. Sólo \`publishApprovedDraft\` existe.

**2. Idempotencia fuerte**
- \`Product.sourceIngestionDraftId\` (UNIQUE en PR-A) bloquea duplicados.
- Second call → \`{ status: 'IDEMPOTENT', productId: <existing> }\`, no audit extra.
- Ghost upsert por email determinista → mismo \`tgAuthorId\` = mismo \`User\` + mismo \`Vendor\`.
- Probado con 2 drafts de distinto author (→ 2 ghosts) y 2 drafts del mismo author (→ 1 ghost, 2 Products).

**3. Validaciones duras antes de crear**
- Todas raise \`IngestionPublishValidationError\` con \`reason\` discriminable.
- **Cero side effects** en cualquier fallo (verificado en tests: \`db.product.count()=0\`, \`db.vendor.count()=0\`, draft sigue \`PENDING\`).

**4. Trazabilidad completa**
- Audit row \`INGESTION_DRAFT_PUBLISHED\` con \`before\` (draft snapshot) + \`after\` containing all 5 requested fields: \`draftId\`, \`productId\`, \`vendorId\`, \`ghostUserId\`, \`sourceMessageId\` (más \`productSlug\`, \`productStatus\`, \`basePriceEur\`, \`unit\`, \`categoryId\` para análisis post-hoc).

**5. Sin efectos colaterales extra**
- No images (Product.images=[])
- No ACTIVE automático (status=PENDING_REVIEW)
- No claim flow
- No description generated

## Tests (15 integration + 1242 / 1242 unit)

**Happy path**
- Product creado en PENDING_REVIEW con provenance columns + basePrice correcto + unit mapeado + stock derivado.
- Ghost User con las tres puertas de auth cerradas.
- Ghost Vendor con APPLYING + stripeOnboarded=false.
- Draft → APPROVED, review item → AUTO_RESOLVED con reason \`adminApproved\`.
- Audit row con \`after\` conteniendo los 5 campos obligatorios.

**Idempotencia**
- Same draft twice → segundo call \`IDEMPOTENT\`, mismo productId/vendorId/ghostUserId, 1 solo Product en DB, 1 solo ghost User + Vendor.
- Two drafts same tgAuthorId → 2 Products distintos, **1** ghost User + Vendor.
- Two drafts different tgAuthorId → 2 Products + 2 ghost User+Vendor pairs.

**Bloqueos por validación** (cada uno verifica \`reason\` + \`count()==0\` side-effects)
- \`missingAuthor\` — message sin tgAuthorId
- \`invalidPrice\` — priceCents null
- \`invalidPrice\` — priceCents = 0
- \`invalidPrice\` — priceCents < 0
- \`emptyName\` — sólo whitespace + control chars
- \`unsupportedCurrency\` — USD
- \`alreadyResolved\` — draft REJECTED
- \`notFound\` — draftId inexistente

**Flag gating**
- \`feat-ingestion-publish\` off + admin flag on → bloqueado con \`reason=flagOff\`, cero side effects.

**Category resolver**
- Known slug → categoryId correcto
- Unknown slug → fallback \`cat_uncategorized\` sin error

## Tests retirados
- Los tests antiguos de \`approveProductDraft\` (3) eliminados porque la función ya no existe. El test de flag-off se migra a \`discardProductDraft\` para seguir cubriendo \`requireIngestionAdmin\`.

## Guarantees before merge
- Lint clean, \`tsc --noEmit\` clean, audit:contracts clean, 1242 unit + 15 integration nuevos verdes.
- \`kill-ingestion-processing\` default-engaged (unchanged).
- \`feat-ingestion-admin\` default-off (unchanged).
- \`feat-ingestion-publish\` default-off + fail-closed (unchanged).
- Product siempre creado en \`PENDING_REVIEW\`, nunca \`ACTIVE\`. Ningún cambio en \`getAvailableProductWhere\` — los productos no aparecen en catálogo público hasta que un humano los revise en \`/admin/productos\` y el Vendor pase a \`ACTIVE\` (ruta no cubierta en este PR por diseño).

## Out of scope (explícito)
- PR-C: image pipeline (TelegramIngestionMessageMedia → Product.images).
- PR-D: badge \"Importado de Telegram\" en \`/admin/productos\` + link al draft/mensaje.
- PR-E: claim vendor flow.

## Test plan
- [ ] CI green.
- [ ] Post-merge: flip \`feat-ingestion-publish=true\` para el operador, aprobar un draft PRODUCT real en \`/admin/ingestion\`, confirmar que el Product aparece en \`/admin/productos\` con status PENDING_REVIEW, verificar que el Vendor ghost no aparece en catálogo público.
- [ ] Verificar audit row en \`/admin/auditoria\` con action \`INGESTION_DRAFT_PUBLISHED\`.