### PR TITLE
feat(ingestion): PR-D — visible Telegram ingestion origin in admin catalog

### DIFF
--- a/src/app/(admin)/admin/productos/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/productos/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { requireCatalogAdmin } from '@/lib/auth-guard'
 import { getCategories } from '@/domains/catalog/queries'
 import { AdminProductEditForm } from '@/components/admin/AdminProductEditForm'
+import { ProductIngestionOriginCard } from '@/components/admin/ProductIngestionOriginCard'
 
 export const metadata: Metadata = { title: 'Editar producto | Admin' }
 export const dynamic = 'force-dynamic'
@@ -25,6 +26,23 @@ export default async function AdminProductEditPage({ params }: Props) {
 
   if (!product) notFound()
 
+  // Resolve the reviewItemId so the origin card can deep-link to the
+  // admin ingestion detail. One targeted lookup by the
+  // (kind, targetId) unique — no join on Product needed.
+  let reviewItemId: string | null = null
+  if (product.sourceIngestionDraftId) {
+    const item = await db.ingestionReviewQueueItem.findUnique({
+      where: {
+        kind_targetId: {
+          kind: 'PRODUCT_DRAFT',
+          targetId: product.sourceIngestionDraftId,
+        },
+      },
+      select: { id: true },
+    })
+    reviewItemId = item?.id ?? null
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -37,6 +55,14 @@ export default async function AdminProductEditPage({ params }: Props) {
           Productor: <span className="font-medium text-[var(--foreground)]">{product.vendor.displayName}</span>
         </p>
       </div>
+
+      {product.sourceIngestionDraftId && (
+        <ProductIngestionOriginCard
+          draftId={product.sourceIngestionDraftId}
+          sourceMessageId={product.sourceTelegramMessageId}
+          reviewItemId={reviewItemId}
+        />
+      )}
 
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
         <AdminProductEditForm

--- a/src/app/(admin)/admin/productos/page.tsx
+++ b/src/app/(admin)/admin/productos/page.tsx
@@ -274,7 +274,17 @@ export default async function AdminProductsPage({ searchParams }: Props) {
                   {product.trackStock ? product.stock : 'Sin control'}
                 </td>
                 <td className="px-5 py-4 align-middle">
-                  <AdminStatusBadge label={PRODUCT_STATUS_LABELS[product.status]} tone={getProductStatusTone(product.status)} />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <AdminStatusBadge label={PRODUCT_STATUS_LABELS[product.status]} tone={getProductStatusTone(product.status)} />
+                    {product.sourceIngestionDraftId && (
+                      <span
+                        className="inline-flex items-center gap-1 rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-300"
+                        title={`Creado desde draft de ingestión ${product.sourceIngestionDraftId}`}
+                      >
+                        Importado de Telegram
+                      </span>
+                    )}
+                  </div>
                 </td>
                 <td className="px-5 py-4 align-middle">
                   <div className="flex items-center justify-end gap-3 whitespace-nowrap">

--- a/src/components/admin/ProductIngestionOriginCard.tsx
+++ b/src/components/admin/ProductIngestionOriginCard.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link'
+
+/**
+ * Admin-only origin card rendered on the product edit page when the
+ * Product was created by publishing an `IngestionProductDraft`. Gives
+ * the reviewer a one-click jump back to the draft + message in the
+ * admin ingestion queue. Never rendered on public catalog surfaces.
+ *
+ * The review item is resolved server-side by the caller via the
+ * (kind, targetId) unique on `IngestionReviewQueueItem`. When it
+ * cannot be resolved — e.g. the retention sweep trimmed it already —
+ * the card falls back to listing the raw ids so the trail stays
+ * visible without a dangling link.
+ */
+
+interface Props {
+  draftId: string
+  sourceMessageId: string | null
+  reviewItemId: string | null
+}
+
+export function ProductIngestionOriginCard({ draftId, sourceMessageId, reviewItemId }: Props) {
+  return (
+    <div className="rounded-2xl border border-sky-500/30 bg-sky-50/60 p-5 shadow-sm dark:border-sky-500/20 dark:bg-sky-950/20">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-400">
+            Origen
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-[var(--foreground)]">
+            Telegram ingestion
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted)]">
+            Este producto fue creado al aprobar un draft en la cola de ingestión.
+            Revisa el mensaje original para contexto antes de activarlo.
+          </p>
+        </div>
+        {reviewItemId ? (
+          <Link
+            href={`/admin/ingestion/${reviewItemId}`}
+            className="inline-flex items-center gap-1 rounded-lg bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-sky-700 dark:bg-sky-500 dark:text-sky-950 dark:hover:bg-sky-400"
+          >
+            Ver en ingestión →
+          </Link>
+        ) : (
+          <Link
+            href={`/admin/ingestion?search=${encodeURIComponent(draftId)}`}
+            className="inline-flex items-center gap-1 rounded-lg border border-sky-500/40 px-3 py-1.5 text-xs font-semibold text-sky-700 hover:bg-sky-100 dark:text-sky-300 dark:hover:bg-sky-900/40"
+          >
+            Abrir cola de ingestión →
+          </Link>
+        )}
+      </div>
+      <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-3">
+        <div>
+          <dt className="font-medium uppercase tracking-wide text-[var(--muted-light)]">Draft id</dt>
+          <dd className="mt-1 break-all font-mono text-[var(--foreground-soft)]">{draftId}</dd>
+        </div>
+        {sourceMessageId && (
+          <div>
+            <dt className="font-medium uppercase tracking-wide text-[var(--muted-light)]">Mensaje id</dt>
+            <dd className="mt-1 break-all font-mono text-[var(--foreground-soft)]">{sourceMessageId}</dd>
+          </div>
+        )}
+        {reviewItemId && (
+          <div>
+            <dt className="font-medium uppercase tracking-wide text-[var(--muted-light)]">Review item</dt>
+            <dd className="mt-1 break-all font-mono text-[var(--foreground-soft)]">{reviewItemId}</dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Close the trazabilidad loop in admin catalog. Products created by Phase 4 publish now carry a \"Importado de Telegram\" badge in \`/admin/productos\` and a dedicated **Origen** card in the product detail, with a deep link back to the review item in \`/admin/ingestion\`.

Minimal, reviewable, no schema change. Reuses \`Product.sourceIngestionDraftId\` (PR-A) and \`Product.sourceTelegramMessageId\`.

## Cumplimiento del scope

**1. Badge en listado** ✅
- \`/admin/productos\`: chip \"Importado de Telegram\" junto al status, sólo cuando \`product.sourceIngestionDraftId != null\`.
- Catálogo público intacto: el badge vive dentro del admin route; la columna era ya visible desde PR-A.
- El \`title\` del badge expone el draft id para inspección al pasar el ratón.

**2. Sección \"Origen\" en detalle** ✅
- Nuevo \`<ProductIngestionOriginCard>\` sobre el form de edición.
- Muestra: tipo de origen (\"Telegram ingestion\"), \`draftId\`, \`sourceMessageId\` (cuando existe), \`reviewItemId\` (cuando se resuelve).
- Cuando el producto **no** viene de ingestión, la card no se renderiza — \`null\` guard al principio del JSX.

**3. Navegación al origen** ✅
- Link primario: \`/admin/ingestion/[reviewItemId]\` (botón sólido).
- Fallback cuando \`reviewItemId\` no se resuelve (retention sweep lo eliminó): link suave a \`/admin/ingestion?search={draftId}\`. Trail nunca queda roto.

**4. Copys simples** ✅
- Badge: \`Importado de Telegram\`
- Card header: \`Origen\` + \`Telegram ingestion\`
- CTA: \`Ver en ingestión →\`

## Decisión técnica — cómo se resuelve el reviewItemId

Una única query targetizada al índice único que ya existe:

\`\`\`ts
db.ingestionReviewQueueItem.findUnique({
  where: { kind_targetId: { kind: 'PRODUCT_DRAFT', targetId: product.sourceIngestionDraftId } },
  select: { id: true },
})
\`\`\`

- **Cero schema change.** El \`@@unique([kind, targetId])\` en \`IngestionReviewQueueItem\` (desde Phase 2) es exactamente la clave que necesito.
- Se evalúa sólo cuando el producto es ingestado — los productos normales no pagan el coste.
- El resultado puede ser \`null\` (sweep retiró el item). El componente cae al link de fallback.

## Descripción visual

**Listado \`/admin/productos\`:**
\`\`\`
┌──────────────┬───────────┬───────────┬──────┬───────┬────────────────────────────────────────────┐
│ Producto     │ Productor │ Categoría │ €    │ Stock │ Estado                                     │
├──────────────┼───────────┼───────────┼──────┼───────┼────────────────────────────────────────────┤
│ Manzanas …   │ Prod Tg   │ Sin cat.  │ 2,50 │ 1     │ [Por revisar] [Importado de Telegram]     │← nuevo
│ Azafrán …    │ Pepe      │ Especies  │ 8,00 │ 10    │ [Activo]                                   │ (sin badge)
└──────────────┴───────────┴───────────┴──────┴───────┴────────────────────────────────────────────┘
\`\`\`

**Detalle \`/admin/productos/[id]/edit\` (producto ingestado):**
\`\`\`
┌──────────────────────────────────────────────────────────────────────────┐
│ Origen                                    [ Ver en ingestión → ]          │
│ Telegram ingestion                                                        │
│ Este producto fue creado al aprobar un draft en la cola de ingestión.     │
│ Revisa el mensaje original para contexto antes de activarlo.              │
│                                                                           │
│ Draft id        Mensaje id           Review item                          │
│ cmo8h7wsa…      cmo8h7ws5…           cmo8ir7…                             │
└──────────────────────────────────────────────────────────────────────────┘
┌── Formulario de edición (sin cambios) ───────────────────────────────────┐
\`\`\`

Producto NO ingestado: card no se renderiza — página idéntica a antes.

## Archivos tocados

- \`src/app/(admin)/admin/productos/page.tsx\` — badge en la columna de estado
- \`src/app/(admin)/admin/productos/[id]/edit/page.tsx\` — resolve \`reviewItemId\` + render Origen card condicional
- \`src/components/admin/ProductIngestionOriginCard.tsx\` — componente nuevo (self-contained, zero dependencies externas)

## Tests ejecutados

- \`npx tsc --noEmit\` — clean
- \`npm run lint\` — clean
- \`npm test\` — 1242 / 1242 green (incluye el test de i18n no-hardcoded-literals: \`/admin/productos\` ya estaba allowlisted desde antes, el nuevo componente está bajo \`src/components/admin/\` que también está allowlisted implícitamente por carpeta admin)

## Restricciones cumplidas

- ✅ No schema nuevo
- ✅ No pipeline de imágenes tocado
- ✅ Lógica de publicación intacta
- ✅ Catálogo público intacto
- ✅ Reutiliza \`sourceIngestionDraftId\` existente
- ✅ PR pequeño: +111 / -1

## Criterio de éxito

1. ✅ Producto importado muestra badge en \`/admin/productos\`
2. ✅ En el detalle del producto se ve que viene de ingestión
3. ✅ Existe link navegable al origen administrativo
4. ✅ Un producto no importado no muestra nada de esto
5. ✅ Sin regresiones en productos normales (tests unit + typecheck verdes)

## Test plan

- [ ] CI green.
- [ ] Post-merge: en el dev con \`feat-ingestion-admin=true\` + \`feat-ingestion-publish=true\`, aprobar un draft, abrir \`/admin/productos\`, confirmar el badge, entrar a editar, confirmar la card de Origen, click en \"Ver en ingestión →\" y confirmar que lleva al review item correcto.
- [ ] Confirmar que productos pre-existentes (creados por vendors self-serve) no renderizan badge ni card.