### PR TITLE
feat(ingestion): Phase 4 PR-E — ghost-vendor claim flow closes the path to ACTIVE

### DIFF
--- a/prisma/migrations/20260421110000_ingestion_vendor_claim/migration.sql
+++ b/prisma/migrations/20260421110000_ingestion_vendor_claim/migration.sql
@@ -1,0 +1,8 @@
+-- Phase 4 PR-E: ghost-vendor claim flow. Additive only.
+-- Columns are nullable so existing vendor-self-serve rows stay
+-- unaffected; only ingestion-created ghosts populate them.
+
+ALTER TABLE "Vendor" ADD COLUMN "claimCode" TEXT;
+ALTER TABLE "Vendor" ADD COLUMN "claimCodeExpiresAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "Vendor_claimCode_key" ON "Vendor"("claimCode");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -277,6 +277,16 @@ model Vendor {
   bankAccountName String?
   stripeAccountId String?         @unique
   stripeOnboarded Boolean         @default(false)
+
+  // Phase 4 PR-E — ghost-vendor claim. Populated only when this
+  // Vendor was created by Telegram ingestion (owned by a ghost
+  // User). A real producer enters this code to take ownership;
+  // once claimed, both columns are cleared and the Vendor looks
+  // like any other self-serve vendor. Null for all vendors that
+  // were created through `applyAsVendor`.
+  claimCode          String?   @unique
+  claimCodeExpiresAt DateTime?
+
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
 

--- a/src/app/(admin)/admin/productos/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/productos/[id]/edit/page.tsx
@@ -19,7 +19,18 @@ export default async function AdminProductEditPage({ params }: Props) {
   const [product, categories] = await Promise.all([
     db.product.findUnique({
       where: { id },
-      include: { vendor: { select: { id: true, displayName: true } } },
+      include: {
+        vendor: {
+          select: {
+            id: true,
+            displayName: true,
+            status: true,
+            stripeOnboarded: true,
+            claimCode: true,
+            claimCodeExpiresAt: true,
+          },
+        },
+      },
     }),
     getCategories(),
   ])
@@ -61,6 +72,12 @@ export default async function AdminProductEditPage({ params }: Props) {
           draftId={product.sourceIngestionDraftId}
           sourceMessageId={product.sourceTelegramMessageId}
           reviewItemId={reviewItemId}
+          vendor={{
+            status: product.vendor.status,
+            stripeOnboarded: product.vendor.stripeOnboarded,
+            claimCode: product.vendor.claimCode,
+            claimCodeExpiresAt: product.vendor.claimCodeExpiresAt,
+          }}
         />
       )}
 

--- a/src/app/(buyer)/cuenta/reclamar-productor/ClaimVendorForm.tsx
+++ b/src/app/(buyer)/cuenta/reclamar-productor/ClaimVendorForm.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { claimGhostVendor } from '@/domains/vendors/claim'
+
+export function ClaimVendorForm() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault()
+        setError(null)
+        startTransition(async () => {
+          try {
+            const result = await claimGhostVendor({ code })
+            // Send them straight to the vendor dashboard where they
+            // will complete profile + Stripe onboarding via the
+            // existing UI.
+            router.push(`/vendor/dashboard?reclamado=${result.vendorSlug}`)
+          } catch (err) {
+            setError(err instanceof Error ? err.message : 'Error desconocido')
+          }
+        })
+      }}
+    >
+      <label className="block">
+        <span className="block text-sm font-medium text-[var(--foreground)]">
+          Código de reclamación
+        </span>
+        <input
+          name="code"
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          maxLength={8}
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase())}
+          placeholder="AB2CD3EF"
+          className="mt-2 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 font-mono text-lg tracking-widest text-[var(--foreground)] shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/20"
+          required
+        />
+        <span className="mt-1 block text-xs text-[var(--muted-foreground)]">
+          8 caracteres, letras y números. Sin espacios. Distingue mayúsculas.
+        </span>
+      </label>
+
+      {error && (
+        <p className="rounded-lg border border-red-500/30 bg-red-50/60 px-3 py-2 text-sm text-red-800 dark:border-red-500/20 dark:bg-red-950/20 dark:text-red-300">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending || code.length !== 8}
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 disabled:opacity-50 dark:bg-emerald-500 dark:text-emerald-950 dark:hover:bg-emerald-400"
+      >
+        {isPending ? 'Validando…' : 'Reclamar'}
+      </button>
+    </form>
+  )
+}

--- a/src/app/(buyer)/cuenta/reclamar-productor/page.tsx
+++ b/src/app/(buyer)/cuenta/reclamar-productor/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { ClaimVendorForm } from './ClaimVendorForm'
+
+export const metadata: Metadata = { title: 'Reclamar productor' }
+export const dynamic = 'force-dynamic'
+
+/**
+ * Producer-facing entry point for the ghost-vendor claim flow. A
+ * code is handed to the producer out-of-band by the admin
+ * (Telegram DM, email, etc.); they paste it here, and if the code
+ * is valid the Vendor's ownership transfers to their account.
+ *
+ * The page short-circuits when the caller already owns a vendor —
+ * a User can only have one Vendor by the existing schema unique,
+ * so the claim attempt would fail later anyway.
+ */
+export default async function ClaimVendorPage() {
+  const session = await auth()
+  if (!session) redirect('/login?callbackUrl=/cuenta/reclamar-productor')
+
+  const vendor = await db.vendor.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true, slug: true, displayName: true, status: true },
+  })
+
+  if (vendor) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+        <Link href="/cuenta" className="mb-4 inline-block text-sm text-[var(--muted)] hover:underline">
+          ← Volver a mi cuenta
+        </Link>
+        <h1 className="mb-2 text-3xl font-bold text-[var(--foreground)]">
+          Ya tienes un productor
+        </h1>
+        <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+          Tu cuenta ya está vinculada al productor <strong>{vendor.displayName}</strong>.
+          Cada cuenta solo puede tener uno. Si el código que recibiste es para otro
+          productor, contacta con el admin: el código no se puede usar desde aquí.
+        </p>
+        <Link
+          href={vendor.status === 'ACTIVE' ? '/vendor/dashboard' : '/cuenta/hazte-vendedor'}
+          className="mt-6 inline-block rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
+        >
+          {vendor.status === 'ACTIVE' ? 'Ir a mi panel de productor' : 'Ver estado de mi solicitud'}
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+      <Link href="/cuenta" className="mb-4 inline-block text-sm text-[var(--muted)] hover:underline">
+        ← Volver a mi cuenta
+      </Link>
+      <h1 className="mb-2 text-3xl font-bold text-[var(--foreground)]">
+        Reclamar productor importado
+      </h1>
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+        Si un admin del marketplace te ha compartido un código, introdúcelo aquí
+        para tomar posesión de tu productor. Tus productos importados quedarán
+        ligados a tu cuenta. Necesitarás completar el alta de Stripe después
+        para poder vender.
+      </p>
+
+      <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm">
+        <ClaimVendorForm />
+      </div>
+
+      <div className="mt-6 rounded-xl border border-sky-500/30 bg-sky-50/60 p-5 text-sm text-sky-900 dark:border-sky-500/20 dark:bg-sky-950/20 dark:text-sky-200">
+        <p className="font-semibold">¿Cómo consigo un código?</p>
+        <p className="mt-1">
+          Los códigos los generan los admins cuando importan mensajes de productores
+          desde Telegram. Si crees que deberías tener uno, escribe al admin por el
+          canal habitual — no pidas el código públicamente.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ProductIngestionOriginCard.tsx
+++ b/src/components/admin/ProductIngestionOriginCard.tsx
@@ -4,22 +4,49 @@ import Link from 'next/link'
  * Admin-only origin card rendered on the product edit page when the
  * Product was created by publishing an `IngestionProductDraft`. Gives
  * the reviewer a one-click jump back to the draft + message in the
- * admin ingestion queue. Never rendered on public catalog surfaces.
+ * admin ingestion queue, and — when the owning Vendor is still a
+ * ghost — the single-use claim code to hand to the real producer.
  *
- * The review item is resolved server-side by the caller via the
- * (kind, targetId) unique on `IngestionReviewQueueItem`. When it
- * cannot be resolved — e.g. the retention sweep trimmed it already —
- * the card falls back to listing the raw ids so the trail stays
- * visible without a dangling link.
+ * Never rendered on public catalog surfaces. Claim codes leak nothing
+ * on their own (32^8 entropy per code + UNIQUE DB index + 365-day
+ * expiry), but the admin route is still the only surface that should
+ * show them.
  */
+
+interface VendorClaimInfo {
+  status: string
+  stripeOnboarded: boolean
+  claimCode: string | null
+  claimCodeExpiresAt: Date | null
+}
 
 interface Props {
   draftId: string
   sourceMessageId: string | null
   reviewItemId: string | null
+  vendor?: VendorClaimInfo
 }
 
-export function ProductIngestionOriginCard({ draftId, sourceMessageId, reviewItemId }: Props) {
+function formatExpiry(date: Date | null): string {
+  if (!date) return ''
+  const days = Math.round((date.getTime() - Date.now()) / (24 * 60 * 60 * 1000))
+  if (days < 0) return 'caducado'
+  if (days === 0) return 'caduca hoy'
+  if (days === 1) return 'caduca mañana'
+  return `caduca en ${days} días`
+}
+
+export function ProductIngestionOriginCard({ draftId, sourceMessageId, reviewItemId, vendor }: Props) {
+  // A ghost vendor is recognisable by `status=APPLYING` + an
+  // unexpired `claimCode`. Once claimed, both fields are cleared.
+  const isUnclaimedGhost =
+    !!vendor &&
+    vendor.status === 'APPLYING' &&
+    !vendor.stripeOnboarded &&
+    !!vendor.claimCode &&
+    !!vendor.claimCodeExpiresAt &&
+    vendor.claimCodeExpiresAt.getTime() > Date.now()
+
   return (
     <div className="rounded-2xl border border-sky-500/30 bg-sky-50/60 p-5 shadow-sm dark:border-sky-500/20 dark:bg-sky-950/20">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -51,6 +78,35 @@ export function ProductIngestionOriginCard({ draftId, sourceMessageId, reviewIte
           </Link>
         )}
       </div>
+
+      {isUnclaimedGhost && (
+        <div className="mt-4 rounded-xl border border-amber-500/30 bg-amber-50/60 p-4 dark:border-amber-500/20 dark:bg-amber-950/20">
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">
+            Productor no reclamado
+          </p>
+          <p className="mt-1 text-sm text-amber-900 dark:text-amber-200">
+            Este producto está ligado a un productor fantasma que todavía nadie ha
+            reclamado. No podrá activarse ni venderse hasta que el productor real
+            entre en <span className="font-mono">/cuenta/reclamar-productor</span> con el código y complete su alta de Stripe.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-amber-700 dark:text-amber-400">Código de reclamación</p>
+              <p className="mt-1 select-all font-mono text-lg font-bold tracking-[0.3em] text-amber-900 dark:text-amber-100">
+                {vendor!.claimCode}
+              </p>
+            </div>
+            <span className="text-xs text-amber-700 dark:text-amber-400">
+              {formatExpiry(vendor!.claimCodeExpiresAt)}
+            </span>
+          </div>
+          <p className="mt-3 text-xs text-amber-800/80 dark:text-amber-300/70">
+            Pásale este código al productor por el canal privado (Telegram DM, WhatsApp,
+            email). Es de un solo uso y caduca automáticamente.
+          </p>
+        </div>
+      )}
+
       <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-3">
         <div>
           <dt className="font-medium uppercase tracking-wide text-[var(--muted-light)]">Draft id</dt>

--- a/src/domains/ingestion/processing/admin/actions.ts
+++ b/src/domains/ingestion/processing/admin/actions.ts
@@ -72,6 +72,42 @@ async function resolveUniqueSlug(base: string): Promise<string> {
   return candidate
 }
 
+/**
+ * Alphanumeric code without ambiguous glyphs (0/O, 1/I/L) so the
+ * operator can dictate it over Telegram without the producer asking
+ * "is that a zero or an o". 8 chars = 32^8 ≈ 1.1 × 10¹² permutations
+ * which is plenty for the audit volumes we expect while keeping the
+ * code short enough to type by hand.
+ */
+const CLAIM_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
+const CLAIM_CODE_LENGTH = 8
+const CLAIM_CODE_TTL_MS = 365 * 24 * 60 * 60 * 1000
+
+function generateClaimCode(): string {
+  let out = ''
+  const { randomInt } = globalThis.crypto
+    ? { randomInt: (n: number) => {
+        const buf = new Uint32Array(1)
+        crypto.getRandomValues(buf)
+        return buf[0]! % n
+      } }
+    : { randomInt: (n: number) => Math.floor(Math.random() * n) }
+  for (let i = 0; i < CLAIM_CODE_LENGTH; i++) {
+    out += CLAIM_CODE_ALPHABET[randomInt(CLAIM_CODE_ALPHABET.length)]
+  }
+  return out
+}
+
+async function issueUniqueClaimCode(): Promise<string> {
+  // Retry on the ~0% chance of a collision against the UNIQUE index.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = generateClaimCode()
+    const hit = await db.vendor.findUnique({ where: { claimCode: code }, select: { id: true } })
+    if (!hit) return code
+  }
+  throw new Error('Failed to issue unique claim code after 5 attempts')
+}
+
 async function resolveUniqueVendorSlug(base: string): Promise<string> {
   const root = slugify(base) || 'productor'
   let candidate = root
@@ -293,6 +329,8 @@ export async function publishApprovedDraft(
           displayName: `Productor Telegram ${tgAuthorId.slice(-4)}`,
           status: 'APPLYING',
           stripeOnboarded: false,
+          claimCode: await issueUniqueClaimCode(),
+          claimCodeExpiresAt: new Date(Date.now() + CLAIM_CODE_TTL_MS),
         },
       })
       vendorId = vendor.id
@@ -320,6 +358,8 @@ export async function publishApprovedDraft(
         displayName: `Productor Telegram ${tgAuthorId.slice(-4)}`,
         status: 'APPLYING',
         stripeOnboarded: false,
+        claimCode: await issueUniqueClaimCode(),
+        claimCodeExpiresAt: new Date(Date.now() + CLAIM_CODE_TTL_MS),
       },
     })
     vendorId = vendor.id

--- a/src/domains/vendors/claim-errors.ts
+++ b/src/domains/vendors/claim-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Domain error for the ghost-vendor claim action. Lives in its own
+ * non-`'use server'` module because Next.js server-action files can
+ * only export async functions — a class export breaks the Turbopack
+ * build. Mirrors the `IngestionPublishValidationError` split landed
+ * for Phase 4 PR-B.
+ */
+export class VendorClaimError extends Error {
+  readonly reason: string
+  constructor(reason: string, message: string) {
+    super(message)
+    this.name = 'VendorClaimError'
+    this.reason = reason
+  }
+}

--- a/src/domains/vendors/claim.ts
+++ b/src/domains/vendors/claim.ts
@@ -1,0 +1,204 @@
+'use server'
+
+import { z } from 'zod'
+import { UserRole } from '@/generated/prisma/enums'
+import { db } from '@/lib/db'
+import { getActionSession } from '@/lib/action-session'
+import { createAuditLog, getAuditRequestIp } from '@/lib/audit'
+import { safeRevalidatePath } from '@/lib/revalidate'
+import { logger } from '@/lib/logger'
+
+/**
+ * Phase 4 PR-E — ghost vendor claim flow.
+ *
+ * When a draft is published from `/admin/ingestion`, a Ghost User +
+ * Ghost Vendor pair is created deterministically by Telegram
+ * authorId. The Vendor carries a one-time `claimCode` that the admin
+ * hands to the real producer out-of-band (Telegram DM, WhatsApp,
+ * email — the channel is outside the system on purpose).
+ *
+ * The real producer logs into their normal account and calls this
+ * action with the code. If everything checks out we transfer
+ * `Vendor.userId` from the ghost to the caller, promote the caller
+ * to `VENDOR` role, and delete the now-orphaned ghost User.
+ *
+ * From that moment on the vendor behaves exactly like a
+ * self-applied one: `vendor.status='APPLYING'`, `stripeOnboarded=false`.
+ * The producer lands at `/vendor/dashboard`, fills in profile +
+ * Stripe at `/vendor/perfil`, and admin approves → ACTIVE. That path
+ * is Phase 1/2 vendor lifecycle and untouched here.
+ */
+
+export class VendorClaimError extends Error {
+  readonly reason: string
+  constructor(reason: string, message: string) {
+    super(message)
+    this.name = 'VendorClaimError'
+    this.reason = reason
+  }
+}
+
+const claimSchema = z.object({
+  code: z
+    .string()
+    .trim()
+    .toUpperCase()
+    .min(8)
+    .max(8)
+    .regex(/^[A-Z0-9]+$/),
+})
+
+export interface ClaimResult {
+  vendorId: string
+  vendorSlug: string
+  vendorDisplayName: string
+}
+
+export async function claimGhostVendor(input: unknown): Promise<ClaimResult> {
+  const session = await getActionSession()
+  if (!session) {
+    throw new VendorClaimError('unauthenticated', 'Debes iniciar sesión para reclamar un productor.')
+  }
+
+  const parsed = claimSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new VendorClaimError(
+      'invalidCode',
+      'El código debe tener 8 caracteres (letras y números, sin espacios).',
+    )
+  }
+
+  const code = parsed.data.code
+  const ip = await getAuditRequestIp()
+
+  // Caller can only claim if they don't already own a vendor — we
+  // enforce 1:1 User↔Vendor as the existing schema unique requires.
+  const callerVendor = await db.vendor.findUnique({
+    where: { userId: session.user.id },
+    select: { id: true },
+  })
+  if (callerVendor) {
+    throw new VendorClaimError(
+      'alreadyVendor',
+      'Tu cuenta ya tiene un productor asociado. Cada usuario puede tener uno solo.',
+    )
+  }
+
+  const vendor = await db.vendor.findUnique({
+    where: { claimCode: code },
+    select: {
+      id: true,
+      slug: true,
+      displayName: true,
+      userId: true,
+      claimCodeExpiresAt: true,
+      status: true,
+    },
+  })
+
+  // Constant-timing is not a concern here — the code space is 32^8
+  // and the endpoint is rate-limited by the existing middleware on
+  // `/cuenta/*`. A "not found" vs "expired" distinction is useful
+  // for the producer to tell "I mistyped" from "ask admin for a
+  // fresh one".
+  if (!vendor) {
+    throw new VendorClaimError('notFound', 'Código no encontrado. Revisa que lo hayas escrito igual que te lo pasaron.')
+  }
+  if (!vendor.claimCodeExpiresAt || vendor.claimCodeExpiresAt.getTime() < Date.now()) {
+    throw new VendorClaimError(
+      'expired',
+      'El código ha caducado. Pide al admin que te genere uno nuevo.',
+    )
+  }
+
+  const ghostUserId = vendor.userId
+
+  // Transfer in a single transaction. Order matters:
+  //   1. Move Vendor.userId to the caller (the UNIQUE on userId
+  //      would reject this if the caller already had a vendor; we
+  //      pre-checked above).
+  //   2. Bump caller's role to VENDOR.
+  //   3. Clear claimCode + claimCodeExpiresAt (single-use).
+  //   4. Delete the now-orphaned ghost User. Its FK children are
+  //      either empty (no orders/reviews on a user that never
+  //      logged in) or auth-side (tokens, 2FA) which cascade
+  //      harmlessly.
+  await db.$transaction(async (tx) => {
+    await tx.vendor.update({
+      where: { id: vendor.id },
+      data: {
+        userId: session.user.id,
+        claimCode: null,
+        claimCodeExpiresAt: null,
+      },
+    })
+    await tx.user.update({
+      where: { id: session.user.id },
+      data: { role: UserRole.VENDOR },
+    })
+    await tx.user.delete({ where: { id: ghostUserId } })
+  })
+
+  await createAuditLog({
+    action: 'VENDOR_CLAIMED',
+    entityType: 'Vendor',
+    entityId: vendor.id,
+    actorId: session.user.id,
+    actorRole: UserRole.VENDOR,
+    before: { ownerUserId: ghostUserId, role: 'ghost' },
+    after: {
+      ownerUserId: session.user.id,
+      vendorSlug: vendor.slug,
+      vendorStatus: vendor.status,
+    },
+    ip,
+  })
+
+  logger.info('vendors.claim_succeeded', {
+    vendorId: vendor.id,
+    ghostUserId,
+    newOwnerUserId: session.user.id,
+  })
+
+  safeRevalidatePath('/cuenta')
+  safeRevalidatePath('/vendor/dashboard')
+  safeRevalidatePath('/admin/productores')
+  safeRevalidatePath('/admin/ingestion')
+
+  return {
+    vendorId: vendor.id,
+    vendorSlug: vendor.slug,
+    vendorDisplayName: vendor.displayName,
+  }
+}
+
+/**
+ * Read-only helper for the admin surface: look up a vendor by claim
+ * code to preview what the producer will take ownership of before
+ * they enter it. Returns `null` when the code is invalid or expired
+ * so the admin UI can render a consistent "not available" message.
+ */
+export async function peekClaimCode(code: string) {
+  const parsed = claimSchema.safeParse({ code })
+  if (!parsed.success) return null
+  const vendor = await db.vendor.findUnique({
+    where: { claimCode: parsed.data.code },
+    select: {
+      id: true,
+      slug: true,
+      displayName: true,
+      claimCodeExpiresAt: true,
+      _count: { select: { products: true } },
+    },
+  })
+  if (!vendor) return null
+  if (!vendor.claimCodeExpiresAt || vendor.claimCodeExpiresAt.getTime() < Date.now()) {
+    return null
+  }
+  return {
+    vendorId: vendor.id,
+    displayName: vendor.displayName,
+    productsCount: vendor._count.products,
+    expiresAt: vendor.claimCodeExpiresAt,
+  }
+}

--- a/src/domains/vendors/claim.ts
+++ b/src/domains/vendors/claim.ts
@@ -7,6 +7,7 @@ import { getActionSession } from '@/lib/action-session'
 import { createAuditLog, getAuditRequestIp } from '@/lib/audit'
 import { safeRevalidatePath } from '@/lib/revalidate'
 import { logger } from '@/lib/logger'
+import { VendorClaimError } from './claim-errors'
 
 /**
  * Phase 4 PR-E — ghost vendor claim flow.
@@ -28,15 +29,6 @@ import { logger } from '@/lib/logger'
  * Stripe at `/vendor/perfil`, and admin approves → ACTIVE. That path
  * is Phase 1/2 vendor lifecycle and untouched here.
  */
-
-export class VendorClaimError extends Error {
-  readonly reason: string
-  constructor(reason: string, message: string) {
-    super(message)
-    this.name = 'VendorClaimError'
-    this.reason = reason
-  }
-}
 
 const claimSchema = z.object({
   code: z

--- a/test/contracts/i18n-no-hardcoded-literals.test.ts
+++ b/test/contracts/i18n-no-hardcoded-literals.test.ts
@@ -70,6 +70,8 @@ const ALLOWLIST_FILES: ReadonlySet<string> = new Set([
   'src/app/(admin)/admin/ingestion/page.tsx', // Phase 3 ingestion review queue — feat-ingestion-admin gated, not localized yet.
   'src/app/(admin)/admin/ingestion/[itemId]/page.tsx', // Phase 3 ingestion review item detail — feat-ingestion-admin gated, not localized yet.
   'src/components/admin/ingestion/ReviewItemActions.tsx', // Phase 3 ingestion review actions — feat-ingestion-admin gated, not localized yet.
+  'src/app/(buyer)/cuenta/reclamar-productor/page.tsx', // Phase 4 PR-E ghost-vendor claim — operator-facing via out-of-band code, not localized yet.
+  'src/app/(buyer)/cuenta/reclamar-productor/ClaimVendorForm.tsx', // Phase 4 PR-E claim form — operator-facing, not localized yet.
   // Auth flows — pending dedicated i18n PR.
   'src/app/(auth)/forgot-password/page.tsx',
   'src/app/(auth)/recuperar-contrasena/nueva/ResetForm.tsx',

--- a/test/integration/ingestion-vendor-claim.test.ts
+++ b/test/integration/ingestion-vendor-claim.test.ts
@@ -1,0 +1,289 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { db } from '@/lib/db'
+import {
+  INGESTION_ADMIN_FEATURE_FLAG,
+  INGESTION_PUBLISH_FEATURE_FLAG,
+  publishApprovedDraft,
+} from '@/domains/ingestion'
+import { claimGhostVendor, VendorClaimError } from '@/domains/vendors/claim'
+import {
+  buildSession,
+  clearTestSession,
+  createUser,
+  resetIntegrationDatabase,
+  useTestSession,
+} from './helpers'
+import { clearTestFlagOverrides, setTestFlagOverrides } from '../flags-helper'
+
+/**
+ * Phase 4 PR-E — ghost vendor claim flow end-to-end against real
+ * Postgres.
+ *
+ * Covered:
+ *   - Publish auto-generates a `claimCode` with expiry.
+ *   - A real user can claim the vendor: ownership transfers, role
+ *     bumps to VENDOR, claim fields clear, ghost User is deleted.
+ *   - Second claim of the same code returns `notFound` (single-use).
+ *   - An expired code returns `expired`.
+ *   - A user that already owns a vendor cannot claim another one.
+ *   - The claim preserves Products (they stay attached to the same
+ *     vendor row whose userId just moved).
+ */
+
+async function seedPendingDraft(tgAuthorId: string) {
+  const connection = await db.telegramIngestionConnection.create({
+    data: {
+      label: `Claim test ${randomUUID().slice(0, 6)}`,
+      phoneNumberHash: 'h',
+      sessionRef: `sess-${randomUUID()}`,
+      status: 'ACTIVE',
+      createdByUserId: 'u1',
+    },
+  })
+  const chat = await db.telegramIngestionChat.create({
+    data: {
+      connectionId: connection.id,
+      tgChatId: BigInt(-100) - BigInt(Math.floor(Math.random() * 1_000_000)),
+      title: 't',
+      kind: 'SUPERGROUP',
+      isEnabled: true,
+    },
+  })
+  const message = await db.telegramIngestionMessage.create({
+    data: {
+      chatId: chat.id,
+      tgMessageId: BigInt(Math.floor(Math.random() * 1_000_000_000)),
+      tgAuthorId: BigInt(tgAuthorId),
+      text: 'seed',
+      rawJson: {},
+      postedAt: new Date(),
+    },
+  })
+  const extraction = await db.ingestionExtractionResult.create({
+    data: {
+      messageId: message.id,
+      engine: 'RULES',
+      extractorVersion: 'rules-1.2.0',
+      schemaVersion: 2,
+      inputSnapshot: { text: 'seed' },
+      payload: { products: [{ productOrdinal: 0 }], rulesFired: [] },
+      confidenceOverall: 0.85,
+      confidenceBand: 'HIGH',
+      confidenceByField: {},
+      classification: 'PRODUCT',
+      correlationId: `cid-${randomUUID()}`,
+    },
+  })
+  const draft = await db.ingestionProductDraft.create({
+    data: {
+      sourceMessageId: message.id,
+      sourceExtractionId: extraction.id,
+      extractorVersion: 'rules-1.2.0',
+      productOrdinal: 0,
+      status: 'PENDING',
+      confidenceOverall: 0.85,
+      confidenceBand: 'HIGH',
+      productName: 'Manzanas claim test',
+      priceCents: 250,
+      currencyCode: 'EUR',
+      unit: 'KG',
+      availability: 'AVAILABLE',
+      rawFieldsSeen: {},
+    },
+  })
+  await db.ingestionReviewQueueItem.create({
+    data: { kind: 'PRODUCT_DRAFT', targetId: draft.id, state: 'ENQUEUED' },
+  })
+  return draft
+}
+
+async function publishAsAdmin(draftId: string) {
+  const adminUser = await createUser('ADMIN_OPS')
+  useTestSession(buildSession(adminUser.id, 'ADMIN_OPS'))
+  try {
+    return await publishApprovedDraft({ draftId })
+  } finally {
+    clearTestSession()
+  }
+}
+
+beforeEach(async () => {
+  await resetIntegrationDatabase()
+  setTestFlagOverrides({
+    [INGESTION_ADMIN_FEATURE_FLAG]: true,
+    [INGESTION_PUBLISH_FEATURE_FLAG]: true,
+  })
+})
+
+afterEach(() => {
+  clearTestFlagOverrides()
+  clearTestSession()
+})
+
+// ─── happy path ───────────────────────────────────────────────────────
+
+test('claim: publish issues a claimCode + expiry on the ghost vendor', async () => {
+  const draft = await seedPendingDraft('501501501')
+  const result = await publishAsAdmin(draft.id)
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: result.vendorId } })
+  assert.ok(vendor.claimCode, 'claimCode should be issued at publish time')
+  assert.equal(vendor.claimCode?.length, 8)
+  assert.match(vendor.claimCode!, /^[A-HJKMNP-Z2-9]+$/, 'only unambiguous alphabet')
+  assert.ok(vendor.claimCodeExpiresAt)
+  const daysOut = (vendor.claimCodeExpiresAt!.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
+  assert.ok(daysOut > 364 && daysOut < 366, 'TTL ~= 365 days')
+})
+
+test('claim: real user redeems the code, ownership transfers, ghost user is deleted', async () => {
+  const draft = await seedPendingDraft('600600600')
+  const published = await publishAsAdmin(draft.id)
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: published.vendorId } })
+
+  const realUser = await createUser('CUSTOMER')
+  useTestSession(buildSession(realUser.id, 'CUSTOMER'))
+  const claimed = await claimGhostVendor({ code: vendor.claimCode! })
+
+  assert.equal(claimed.vendorId, vendor.id)
+  assert.equal(claimed.vendorSlug, vendor.slug)
+
+  // Vendor now owned by the real user, claim fields cleared.
+  const after = await db.vendor.findUniqueOrThrow({ where: { id: vendor.id } })
+  assert.equal(after.userId, realUser.id)
+  assert.equal(after.claimCode, null)
+  assert.equal(after.claimCodeExpiresAt, null)
+
+  // Real user promoted to VENDOR.
+  const userAfter = await db.user.findUniqueOrThrow({ where: { id: realUser.id } })
+  assert.equal(userAfter.role, 'VENDOR')
+
+  // Ghost user deleted.
+  const ghost = await db.user.findUnique({ where: { id: published.ghostUserId } })
+  assert.equal(ghost, null)
+
+  // Product still attached to the same vendor (nothing about its
+  // row changed — only Vendor.userId moved).
+  const product = await db.product.findUniqueOrThrow({ where: { id: published.productId } })
+  assert.equal(product.vendorId, vendor.id)
+
+  // Audit row written.
+  const audit = await db.auditLog.findFirstOrThrow({
+    where: { action: 'VENDOR_CLAIMED', entityId: vendor.id },
+  })
+  const after_ = audit.after as Record<string, unknown>
+  assert.equal(after_.ownerUserId, realUser.id)
+})
+
+test('claim: second redemption of the same code returns notFound (single-use)', async () => {
+  const draft = await seedPendingDraft('700700700')
+  const published = await publishAsAdmin(draft.id)
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: published.vendorId } })
+  const code = vendor.claimCode!
+
+  const firstUser = await createUser('CUSTOMER')
+  useTestSession(buildSession(firstUser.id, 'CUSTOMER'))
+  await claimGhostVendor({ code })
+  clearTestSession()
+
+  const secondUser = await createUser('CUSTOMER')
+  useTestSession(buildSession(secondUser.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => claimGhostVendor({ code }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'notFound',
+  )
+})
+
+// ─── validation / failure modes ───────────────────────────────────────
+
+test('claim: unauthenticated caller is rejected', async () => {
+  // `clearTestSession()` sets the override to `undefined`, which
+  // makes getActionSession fall through to real auth. We need an
+  // explicit `null` override to simulate "no session" in tests.
+  useTestSession(null)
+  await assert.rejects(
+    () => claimGhostVendor({ code: 'AAAAAAAA' }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'unauthenticated',
+  )
+})
+
+test('claim: invalid code shape returns invalidCode', async () => {
+  const user = await createUser('CUSTOMER')
+  useTestSession(buildSession(user.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => claimGhostVendor({ code: 'short' }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'invalidCode',
+  )
+  await assert.rejects(
+    () => claimGhostVendor({ code: 'with spa' }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'invalidCode',
+  )
+})
+
+test('claim: unknown code returns notFound', async () => {
+  const user = await createUser('CUSTOMER')
+  useTestSession(buildSession(user.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => claimGhostVendor({ code: 'ZZZZZZZZ' }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'notFound',
+  )
+})
+
+test('claim: expired code returns expired without transferring ownership', async () => {
+  const draft = await seedPendingDraft('800800800')
+  const published = await publishAsAdmin(draft.id)
+  // Backdate the expiry.
+  await db.vendor.update({
+    where: { id: published.vendorId },
+    data: { claimCodeExpiresAt: new Date(Date.now() - 60 * 1000) },
+  })
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: published.vendorId } })
+
+  const user = await createUser('CUSTOMER')
+  useTestSession(buildSession(user.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => claimGhostVendor({ code: vendor.claimCode! }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'expired',
+  )
+  const unchanged = await db.vendor.findUniqueOrThrow({ where: { id: vendor.id } })
+  assert.equal(unchanged.userId, published.ghostUserId, 'ownership untouched on expired claim')
+})
+
+test('claim: caller who already owns a vendor cannot claim another', async () => {
+  // Arrange: caller has their own vendor already
+  const draftA = await seedPendingDraft('910')
+  await publishAsAdmin(draftA.id)
+
+  const realUser = await createUser('CUSTOMER')
+  await db.vendor.create({
+    data: {
+      userId: realUser.id,
+      slug: `user-${realUser.id.slice(0, 6)}`,
+      displayName: 'My own vendor',
+      status: 'APPLYING',
+    },
+  })
+
+  // And there is another ghost vendor out there to try claiming.
+  const draftB = await seedPendingDraft('920')
+  const other = await publishAsAdmin(draftB.id)
+  const otherVendor = await db.vendor.findUniqueOrThrow({ where: { id: other.vendorId } })
+
+  useTestSession(buildSession(realUser.id, 'CUSTOMER'))
+  await assert.rejects(
+    () => claimGhostVendor({ code: otherVendor.claimCode! }),
+    (err: unknown) => err instanceof VendorClaimError && err.reason === 'alreadyVendor',
+  )
+})
+
+test('claim: code is case-insensitive and tolerates surrounding whitespace', async () => {
+  const draft = await seedPendingDraft('1010101010')
+  const published = await publishAsAdmin(draft.id)
+  const vendor = await db.vendor.findUniqueOrThrow({ where: { id: published.vendorId } })
+
+  const user = await createUser('CUSTOMER')
+  useTestSession(buildSession(user.id, 'CUSTOMER'))
+  const lowerWithSpaces = `  ${vendor.claimCode!.toLowerCase()}  `
+  const claimed = await claimGhostVendor({ code: lowerWithSpaces })
+  assert.equal(claimed.vendorId, vendor.id)
+})

--- a/test/integration/ingestion-vendor-claim.test.ts
+++ b/test/integration/ingestion-vendor-claim.test.ts
@@ -7,7 +7,8 @@ import {
   INGESTION_PUBLISH_FEATURE_FLAG,
   publishApprovedDraft,
 } from '@/domains/ingestion'
-import { claimGhostVendor, VendorClaimError } from '@/domains/vendors/claim'
+import { claimGhostVendor } from '@/domains/vendors/claim'
+import { VendorClaimError } from '@/domains/vendors/claim-errors'
 import {
   buildSession,
   clearTestSession,


### PR DESCRIPTION
## Summary

Cierra Phase 4. Sin este PR el modelo ghost-vendor estaba a medias: los productos publicados desde ingestión quedaban atascados en PENDING_REVIEW porque el moderation action existente exige \`vendor.stripeOnboarded=true\`, y los ghosts no pueden onboardear por diseño (no tienen usuario real). Ese es el gap que el usuario encontró en uso real.

Este PR añade la otra mitad: cada ghost Vendor lleva un **código de reclamación único** (8 chars alfanuméricos sin glyphs ambiguos, TTL 365 días). El admin se lo pasa al productor real por un canal privado. El productor lo introduce en \`/cuenta/reclamar-productor\` y **toma posesión del Vendor**: ownership transfiere, role bumpea a VENDOR, ghost User se borra. A partir de ahí el flujo es idéntico al del vendor self-serve: completa \`/vendor/perfil\` + Stripe, admin aprueba → ACTIVE, productos activables.

## Arquitectura elegida vs alternativas descartadas

| Opción | Por qué sí/no |
|---|---|
| **A — DB hack: flip stripeOnboarded=true en ghosts** | NO. Miente en DB. Checkout y payouts leerían datos falsos. Deuda técnica pura. |
| **B — Bypass del Stripe gate para ghosts** | NO. Producto aparece ACTIVE pero el checkout real bloquea. UX mentira. |
| **C1 — House Vendor** | NO. Reversa una decisión de diseño ya aprobada (ghost vendor por tgAuthorId) y cambia quién es legalmente el seller. Scope mayor. |
| **✓ C2 — Claim flow** | SÍ. Completa el modelo ghost aprobado. Usa el `Vendor.userId @unique` existente. Cero mentiras en DB. Stripe onboarding ocurre con un usuario real responsable legalmente. |

## Cambios

### Schema (aditivo, migración `20260421110000_ingestion_vendor_claim`)
- \`Vendor.claimCode String? @unique\`
- \`Vendor.claimCodeExpiresAt DateTime?\`
- Ambas nullable: vendors self-serve quedan con \`NULL\` y todo lo existente sigue igual.

### Publish genera el código
\`publishApprovedDraft\` ahora emite un código cuando crea un ghost. Alfabeto \`A-HJKMNP-Z2-9\` (sin \`0/O\`, \`1/I/L\`) para que el admin lo pueda dictar por voz/DM sin ambigüedad. 8 chars → 32⁸ ≈ 10¹² combinaciones. TTL: 365 días. El helper \`issueUniqueClaimCode\` reintenta hasta 5 veces ante colisión contra el UNIQUE.

### Acción \`claimGhostVendor\` — \`src/domains/vendors/claim.ts\`
Cualquier usuario autenticado puede llamarla. Flujo:

1. Zod valida shape (8 alfanuméricos, case-insensitive, trimmed).
2. Rechaza si el caller ya tiene un Vendor (schema unique de \`Vendor.userId\`).
3. Lookup del ghost por claimCode, comprueba expiry.
4. **En una sola transacción:**
   - \`Vendor.userId\` → caller
   - \`claimCode\` + \`claimCodeExpiresAt\` → \`NULL\` (single-use)
   - \`User.role\` del caller → \`VENDOR\`
   - \`DELETE\` del ghost User (huérfano, cascades solo tocan tokens/2FA del ghost)
5. Audit row \`VENDOR_CLAIMED\` con ownerUserId transition.

**Validation errors tipados** (\`VendorClaimError.reason\`): \`unauthenticated\`, \`invalidCode\`, \`notFound\`, \`expired\`, \`alreadyVendor\`. Cero side effects en cualquier fallo.

### UI productor — \`/cuenta/reclamar-productor\`
Form minimalista. Input de 8 chars monospace. Tras success redirige a \`/vendor/dashboard?reclamado=<slug>\` donde el checklist de onboarding existente guía el resto. Short-circuit si el caller ya tiene vendor.

### UI admin — \`ProductIngestionOriginCard\`
Cuando el Product pertenece a un ghost (\`status=APPLYING\` + \`stripeOnboarded=false\` + \`claimCode\` válido), la card renderiza un panel ámbar con:
- Código en monospace grande, seleccionable
- Countdown de expiry (\"caduca en X días\")
- Nota recordando que hay que pasarlo **por canal privado** (Telegram DM, WhatsApp, email)

Una vez consumido o caducado, el panel desaparece automáticamente.

## Tests (9 integration tests contra Postgres real, 1242/1242 unit green)

- ✓ Publish emite claimCode + TTL 365 días, alfabeto correcto
- ✓ Real user redime → ownership transfiere, role → VENDOR, fields clear, ghost deleted, Product intact, audit escrito
- ✓ Segunda llamada con mismo código → \`notFound\` (single-use)
- ✓ Caller no autenticado → \`unauthenticated\`
- ✓ Código malformado → \`invalidCode\`
- ✓ Código inexistente → \`notFound\`
- ✓ Código expirado → \`expired\`, ownership intacto
- ✓ Caller con Vendor propio → \`alreadyVendor\`
- ✓ Case-insensitive + tolerante a whitespace

## Guarantees

- Migration aditiva, sin backfill, sin locks largos (índice único sobre columna nueva + nullable).
- Kill switch + \`feat-ingestion-admin\` + \`feat-ingestion-publish\` intocados. Este PR no toca flags.
- Claim action es auth-only. No hay surface pública que exponga códigos.
- Lint clean, \`tsc --noEmit\` clean (app + tsconfig.test.json), \`audit:contracts\` clean.
- Zero new public-catalog behaviour. Productos ghost siguen invisibles al público hasta que el productor reclame + onboardee + admin apruebe vendor + admin apruebe product. Cuatro puertas, todas ya existentes o explícitas.

## Test plan

- [ ] CI green.
- [ ] Post-merge dev smoke:
  1. Publicar un draft → verificar que la card Origen muestra el código.
  2. Crear un usuario \`producer@test.local\`, logueo, ir a \`/cuenta/reclamar-productor\`, introducir el código.
  3. Verificar redirección a \`/vendor/dashboard\`, User.role = VENDOR, Vendor.userId = nuevo user, ghost User borrado.
  4. Ir a \`/vendor/perfil\` → completar Stripe (en dev, mock).
  5. Admin flipa el vendor a ACTIVE desde \`/admin/productores\`.
  6. Admin aprueba el producto desde \`/admin/productos\` → ya no debería fallar con \"Debes configurar Stripe\".
  7. Verificar que el producto aparece ACTIVE en catálogo público.

## Phase 4 cerrado end-to-end

Con PR-A foundation + PR-B publish + PR-D admin trace + PR-E claim flow, el loop ingestión → catálogo público está completo:

1. Admin revisa mensaje en \`/admin/ingestion\`.
2. \"Aprobar y crear producto\" → Product en PENDING_REVIEW + ghost Vendor con código.
3. Admin pasa código al productor real (Telegram DM).
4. Productor se registra, entra en \`/cuenta/reclamar-productor\`, reclama.
5. Productor completa Stripe en \`/vendor/perfil\`.
6. Admin aprueba Vendor en \`/admin/productores\` (existente).
7. Admin aprueba Product en \`/admin/productos\` (existente, ya no bloquea).
8. Producto visible en catálogo público.

Cada paso 2–7 tiene trace + audit log. Cada puerta es humana o explícita. Sin atajos.