### PR TITLE
fix(security): block mock webhook path outside dev/test

### DIFF
--- a/src/domains/payments/webhook.ts
+++ b/src/domains/payments/webhook.ts
@@ -81,11 +81,16 @@ function getWebhookErrorMessage(error: unknown) {
 
 /**
  * Returns true if the mock webhook path is safe to use.
- * In production, mock processing must be blocked to prevent spoofed events.
+ *
+ * Mock mode bypasses Stripe signature verification, so it must only be
+ * active in the dev/test harness. The previous `!== 'production'` check
+ * silently allowed any custom NODE_ENV (eg. 'staging', 'preview') to
+ * process unsigned webhook events. Switch to an explicit allowlist so
+ * an unfamiliar deploy environment fails closed.
  */
 export function isMockWebhookAllowed(paymentProvider: string, nodeEnv: string): boolean {
   if (paymentProvider !== 'mock') return false
-  return nodeEnv !== 'production'
+  return nodeEnv === 'development' || nodeEnv === 'test'
 }
 
 /**

--- a/test/features/webhook-security.test.ts
+++ b/test/features/webhook-security.test.ts
@@ -33,10 +33,12 @@ test('isMockWebhookAllowed: returns false when provider is stripe (not mock)', (
 })
 
 test('isMockWebhookAllowed: treats unknown environments as production-safe (deny)', () => {
-  // An unrecognised NODE_ENV should not accidentally allow mock processing
-  assert.equal(isMockWebhookAllowed('mock', 'staging'), true)
-  // staging is not 'production' so it is currently allowed — document this:
-  // if stricter control is needed, add 'staging' to the blocklist
+  // Any NODE_ENV outside the dev/test allowlist must fail closed. A
+  // custom 'staging' deploy was previously allowed (bypassed Stripe
+  // signature verification) — the allowlist shuts that path.
+  assert.equal(isMockWebhookAllowed('mock', 'staging'), false)
+  assert.equal(isMockWebhookAllowed('mock', 'preview'), false)
+  assert.equal(isMockWebhookAllowed('mock', ''), false)
 })
 
 // ─── getWebhookIdempotencyKey ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `isMockWebhookAllowed` previously gated on `nodeEnv !== 'production'`. Any custom NODE_ENV (staging, preview, unknown) silently took the mock branch, **bypassing Stripe signature verification**.
- Switch to an explicit dev/test allowlist so non-production deploys fail closed. Production remains guarded at boot via \`env.ts\` (#548) refusing \`PAYMENT_PROVIDER=mock\` — this tightens the second layer.
- Updates the existing test that documented staging as a known gap (now asserts it is blocked).

## Test plan
- [x] \`test/features/webhook-security.test.ts\` — 9/9 passing; \`staging\`, \`preview\`, \`\'\'\` now return \`false\`.
- [ ] Grep confirms \`isMockWebhookAllowed\` only used in \`/api/webhooks/stripe/route.ts\` (single call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)