### PR TITLE
fix(webhook): guard against resurrecting terminal orders on late webhooks

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -341,14 +341,13 @@ async function handlePaymentSucceeded(providerRef: string, amount?: number, curr
           data: { status: 'SUCCEEDED' },
         })
 
+        // Only PLACED is a legal predecessor for PAYMENT_CONFIRMED. The
+        // previous `OR { not: ... }` filter would happily resurrect a
+        // CANCELLED or REFUNDED order when a late/retried webhook arrived,
+        // leaving the buyer charged with no fulfillment intent. Being
+        // explicit makes the transition a single allowed edge.
         const orderUpdate = await tx.order.updateMany({
-          where: {
-            id: payment.orderId,
-            OR: [
-              { paymentStatus: { not: 'SUCCEEDED' } },
-              { status: { not: 'PAYMENT_CONFIRMED' } },
-            ],
-          },
+          where: { id: payment.orderId, status: 'PLACED' },
           data: { status: 'PAYMENT_CONFIRMED', paymentStatus: 'SUCCEEDED' },
         })
 

--- a/src/domains/payments/webhook.ts
+++ b/src/domains/payments/webhook.ts
@@ -97,6 +97,16 @@ export function getWebhookIdempotencyKey(eventId: string | undefined): string | 
 }
 
 export function shouldApplyPaymentSucceeded(snapshot: PaymentSnapshot) {
+  // Terminal orders must never transition back to PAYMENT_CONFIRMED. A late
+  // or retried webhook arriving after a vendor-initiated cancellation or a
+  // refund would otherwise silently resurrect the order — charging the buyer
+  // with no fulfillment intent, no stock decrement, and a stale cancellation
+  // notification already delivered. Fail closed here and let the DB-level
+  // `where: status: 'PLACED'` guard be the second line of defence.
+  if (snapshot.orderStatus === 'CANCELLED' || snapshot.orderStatus === 'REFUNDED') {
+    return false
+  }
+
   return !(
     snapshot.paymentStatus === 'SUCCEEDED' &&
     snapshot.orderPaymentStatus === 'SUCCEEDED' &&

--- a/test/features/webhook-state.test.ts
+++ b/test/features/webhook-state.test.ts
@@ -34,3 +34,25 @@ test('shouldApplyPaymentFailed returns true for a fresh pending snapshot', () =>
     true
   )
 })
+
+test('shouldApplyPaymentSucceeded refuses to resurrect a CANCELLED order', () => {
+  assert.equal(
+    shouldApplyPaymentSucceeded({
+      paymentStatus: 'PENDING',
+      orderPaymentStatus: 'PENDING',
+      orderStatus: 'CANCELLED',
+    }),
+    false
+  )
+})
+
+test('shouldApplyPaymentSucceeded refuses to resurrect a REFUNDED order', () => {
+  assert.equal(
+    shouldApplyPaymentSucceeded({
+      paymentStatus: 'SUCCEEDED',
+      orderPaymentStatus: 'REFUNDED',
+      orderStatus: 'REFUNDED',
+    }),
+    false
+  )
+})


### PR DESCRIPTION
## Summary
- Block Order state resurrection when a late/retried Stripe webhook arrives for a CANCELLED or REFUNDED order.
- Two-layer guard: strengthen \`shouldApplyPaymentSucceeded\` predicate + replace the DB \`OR { not: ... }\` filter with the explicit legal predecessor \`status: 'PLACED'\`.

## Why
\`handlePaymentSucceeded\` previously used \`OR: [{ paymentStatus: { not: 'SUCCEEDED' } }, { status: { not: 'PAYMENT_CONFIRMED' } }]\` as the \`updateMany\` \`where\`. That clause matches CANCELLED and REFUNDED orders — so a late Stripe retry after a vendor cancellation would flip the order back to PAYMENT_CONFIRMED, charging the buyer with no fulfillment intent, no stock restoration, and a stale cancellation notification already out the door.

This is a payment-incident-class bug: visible to the buyer, money-moving, and easily masked by the existing log scopes. Flagged during the 2026-04-21 production-risk audit.

## Test plan
- [x] New unit tests: \`shouldApplyPaymentSucceeded\` rejects CANCELLED / REFUNDED snapshots.
- [x] Existing idempotency tests (PAYMENT_CONFIRMED + SUCCEEDED) still pass.
- [ ] CI green (\`webhook-state.test.ts\`, \`payments-webhook.test.ts\`).

## Risk notes
- DB filter is strictly narrower than before: PLACED → PAYMENT_CONFIRMED is the only allowed edge for this path. Any earlier intermediate state machine additions must revisit this \`where\`.
- Webhook becomes a silent no-op for non-PLACED orders; the orphan event is already covered by the existing dead-letter path on prior branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)