### PR TITLE
fix(checkout): reject replay of checkoutAttemptId with a different cart

### DIFF
--- a/src/domains/orders/cart-dedupe.ts
+++ b/src/domains/orders/cart-dedupe.ts
@@ -1,0 +1,40 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * Deterministic fingerprint of a cart payload used by the
+ * checkoutAttemptId dedupe path in `createOrder`.
+ *
+ * Two calls with the same logical cart (same products + variants +
+ * quantities, regardless of input order or duplicate-row shape) must
+ * hash to the same value. Any change to items, quantities, or variants
+ * must produce a different hash.
+ *
+ * Server-only: lives outside `actions.ts` so it can be unit-tested
+ * without the 'use server' barrier, and outside `checkout.ts` so the
+ * browser bundle never pulls in `node:crypto`.
+ */
+export type DedupeCartItem = {
+  productId: string
+  variantId?: string | null
+  quantity: number
+}
+
+export function hashCartForDedupe(items: ReadonlyArray<DedupeCartItem>): string {
+  if (items.length === 0) return 'empty'
+
+  // Group by (productId, variantId) in case the same line appears
+  // multiple times with the same variant. Summing quantities matches
+  // the downstream order-line semantics (one row per variant).
+  const normalised = items.reduce<Map<string, number>>((acc, item) => {
+    const key = `${item.productId}|${item.variantId ?? ''}`
+    acc.set(key, (acc.get(key) ?? 0) + item.quantity)
+    return acc
+  }, new Map())
+
+  const serialised = Array.from(normalised.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, quantity]) => `${key}:${quantity}`)
+    .join(',')
+
+  return createHash('sha256').update(serialised).digest('hex')
+}

--- a/src/domains/orders/use-cases/create-order.ts
+++ b/src/domains/orders/use-cases/create-order.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { db } from '@/lib/db'
+import { hashCartForDedupe } from '@/domains/orders/cart-dedupe'
 import { redirect } from 'next/navigation'
 import { generateOrderNumber } from '@/lib/utils'
 import { createPaymentIntent } from '@/domains/payments'
@@ -103,10 +104,12 @@ async function replayCheckoutAttempt({
   sessionUserId,
   correlationId,
   checkoutAttemptId,
+  items,
 }: {
   sessionUserId: string
   correlationId: string
   checkoutAttemptId: string
+  items: CartItemInput[]
 }): Promise<CreateOrderResult | null> {
   const existing = await db.order.findUnique({
     where: { checkoutAttemptId },
@@ -114,6 +117,9 @@ async function replayCheckoutAttempt({
       id: true,
       orderNumber: true,
       customerId: true,
+      lines: {
+        select: { productId: true, variantId: true, quantity: true },
+      },
     },
   })
   if (!existing) return null
@@ -126,6 +132,30 @@ async function replayCheckoutAttempt({
       existingOrderOwner: existing.customerId,
     })
     throw new CheckoutAttemptCrossUserError()
+  }
+
+  // Cart-shape check: a replay must carry the same cart. If the hash
+  // diverges, the buyer has edited their cart but is presenting a
+  // stale attempt id (back button, cached HTML, page restore). Refuse
+  // to replay — returning the old Order would redirect them to a
+  // confirmation page for a purchase that no longer reflects what
+  // they intended to buy. The client must regenerate a fresh id.
+  const cartHash = hashCartForDedupe(items)
+  const existingCartHash = hashCartForDedupe(
+    existing.lines.map(line => ({
+      productId: line.productId,
+      variantId: line.variantId ?? undefined,
+      quantity: line.quantity,
+    }))
+  )
+  if (existingCartHash !== cartHash) {
+    logger.error('checkout.attempt_id_cart_mismatch', {
+      correlationId,
+      checkoutAttemptId,
+      userId: sessionUserId,
+      orderId: existing.id,
+    })
+    throw new Error('Sesión de checkout inválida. Recarga la página.')
   }
 
   logger.info('checkout.replayed', {
@@ -374,6 +404,7 @@ export async function createOrder(
       sessionUserId,
       correlationId,
       checkoutAttemptId,
+      items,
     })
     if (replay) {
       return replay

--- a/test/features/cart-dedupe-hash.test.ts
+++ b/test/features/cart-dedupe-hash.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { hashCartForDedupe } from '@/domains/orders/cart-dedupe'
+
+test('hashCartForDedupe is stable for identical carts', () => {
+  const items = [
+    { productId: 'p1', variantId: 'v1', quantity: 2 },
+    { productId: 'p2', quantity: 1 },
+  ]
+  assert.equal(hashCartForDedupe(items), hashCartForDedupe(items))
+})
+
+test('hashCartForDedupe is order-independent', () => {
+  const a = [
+    { productId: 'p1', variantId: 'v1', quantity: 2 },
+    { productId: 'p2', quantity: 1 },
+  ]
+  const b = [
+    { productId: 'p2', quantity: 1 },
+    { productId: 'p1', variantId: 'v1', quantity: 2 },
+  ]
+  assert.equal(hashCartForDedupe(a), hashCartForDedupe(b))
+})
+
+test('hashCartForDedupe changes when quantity changes', () => {
+  const base = [{ productId: 'p1', quantity: 1 }]
+  const more = [{ productId: 'p1', quantity: 2 }]
+  assert.notEqual(hashCartForDedupe(base), hashCartForDedupe(more))
+})
+
+test('hashCartForDedupe changes when a product is added', () => {
+  const base = [{ productId: 'p1', quantity: 1 }]
+  const extended = [
+    { productId: 'p1', quantity: 1 },
+    { productId: 'p2', quantity: 1 },
+  ]
+  assert.notEqual(hashCartForDedupe(base), hashCartForDedupe(extended))
+})
+
+test('hashCartForDedupe distinguishes variants of the same product', () => {
+  const a = [{ productId: 'p1', variantId: 'v1', quantity: 1 }]
+  const b = [{ productId: 'p1', variantId: 'v2', quantity: 1 }]
+  assert.notEqual(hashCartForDedupe(a), hashCartForDedupe(b))
+})
+
+test('hashCartForDedupe collapses duplicate rows with matching variant', () => {
+  // Some UI flows can end up shipping two rows for the same variant; the
+  // server groups them downstream, so the fingerprint must too.
+  const split = [
+    { productId: 'p1', variantId: 'v1', quantity: 1 },
+    { productId: 'p1', variantId: 'v1', quantity: 2 },
+  ]
+  const merged = [{ productId: 'p1', variantId: 'v1', quantity: 3 }]
+  assert.equal(hashCartForDedupe(split), hashCartForDedupe(merged))
+})
+
+test('hashCartForDedupe treats undefined and null variantId the same way', () => {
+  const undef = [{ productId: 'p1', variantId: undefined, quantity: 1 }]
+  const nul = [{ productId: 'p1', variantId: null, quantity: 1 }]
+  assert.equal(hashCartForDedupe(undef), hashCartForDedupe(nul))
+})
+
+test('hashCartForDedupe returns a fixed marker for empty carts', () => {
+  // Empty is allowed for symmetry (an order with no lines can never exist
+  // in practice but the helper should be total). The exact string does
+  // not matter, but it must differ from any non-empty fingerprint.
+  const empty = hashCartForDedupe([])
+  const nonEmpty = hashCartForDedupe([{ productId: 'p1', quantity: 1 }])
+  assert.notEqual(empty, nonEmpty)
+})


### PR DESCRIPTION
## Summary
- Compute a deterministic SHA-256 fingerprint of the submitted cart (\`productId\`, \`variantId\`, \`quantity\`) and compare it against the fingerprint of the existing order's lines before replaying.
- On mismatch, throw the existing \"Sesión de checkout inválida. Recarga la página.\" error so the client regenerates a fresh attempt id.
- Move the helper to a new server-only module \`src/domains/orders/cart-dedupe.ts\` (keeps \`node:crypto\` out of the browser bundle, enables unit testing outside 'use server' files).
- Add 8 unit tests covering stability, order-independence, variant sensitivity, duplicate-row collapsing, and null/undefined variantId equivalence.

## Why
\`docs/checkout-dedupe.md\` declares the attempt id reusable (no structural expiry). Today's dedupe returns the previous Order whenever the owner matches — regardless of whether the **cart** matches. A stale HTML page (bfcache restore, back button, extension refresh, CDN cache) replaying the same id with a different cart got \`replayed: true\` back, the client followed the UX matrix and redirected to the old confirmation page, and the new cart silently evaporated: stock not decremented, payment not charged for the intended items. This is the buyer-visible, money-adjacent tail of the 2026-04-21 audit.

## Test plan
- [x] 8 new unit tests in \`test/features/cart-dedupe-hash.test.ts\` — all pass.
- [x] Existing \`checkout-persist-first.test.ts\` + \`order-create.test.ts\` unaffected (same-cart replay path is unchanged).
- [ ] CI green.
- [ ] Manual: double-submit with identical cart still returns \`replayed: true\`; edit cart then re-submit with same id now returns a \`checkout.attempt_id_cart_mismatch\` log line and the generic error the frontend expects.

## Related
- #712 — synthetic eventId fallback (parallel idempotency hardening on webhook side)
- #716 — confirmOrder predecessor guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)