### PR TITLE
[codex] document auth and order-payment state decisions

### DIFF
--- a/docs/adr/001-nextauth-prismaadapter-jwt.md
+++ b/docs/adr/001-nextauth-prismaadapter-jwt.md
@@ -1,0 +1,56 @@
+# ADR 001: Keep NextAuth + PrismaAdapter + JWT
+
+- **Status:** Accepted
+- **Date:** 2026-04-23
+- **Issue:** #314
+
+## Context
+
+The current auth stack uses `PrismaAdapter(db)` with `session: { strategy: 'jwt' }`.
+That looks like extra moving parts at first glance, so this decision records why we are keeping it for now instead of simplifying it opportunistically.
+
+Relevant code:
+
+- [`src/lib/auth.ts`](../../src/lib/auth.ts)
+- [`src/lib/auth-config.ts`](../../src/lib/auth-config.ts)
+- [`docs/auth-proxy-contract.md`](../../auth-proxy-contract.md)
+- [`docs/admin-host.md`](../../admin-host.md)
+
+## Decision
+
+Keep the current setup:
+
+- NextAuth with the Prisma adapter
+- JWT sessions
+- DB-backed role refresh in the session callback
+
+## Why we are keeping it
+
+1. **Credential login already depends on the current shape.**
+   The project uses Prisma-backed credential verification through the auth stack. Removing the adapter now would not remove much complexity, but it would create migration risk for a working login path.
+
+2. **JWT fits the current request model.**
+   The app relies on stateless session reads in server components, route handlers, and the edge proxy. JWT keeps the hot path simple and avoids introducing server-session storage that would complicate middleware and role checks.
+
+3. **Role propagation is intentionally refreshed from the DB.**
+   The auth callback already refreshes the user role periodically so promotions like `CUSTOMER -> VENDOR` appear without a sign-out. That behavior is easier to preserve with JWT than with a server session store.
+
+4. **The adapter is not dead weight.**
+   It keeps the door open for future OAuth/account linking/email-verification flows without re-architecting auth later. Today we do not need to pay the cost of ripping it out just to reduce theoretical complexity.
+
+5. **Existing security contracts already assume this shape.**
+   Host-only cookie behavior and proxy protection are documented separately. The current auth stack is part of that larger contract, not an isolated implementation detail.
+
+## Consequences
+
+- We keep the current login, role propagation, and route authorization behavior.
+- Auth tests remain part of the safety net.
+- If we ever want to remove the adapter, that should happen in its own migration issue with explicit auth coverage, not as a drive-by simplification.
+
+## Follow-up policy
+
+Revisit this decision only if one of the following becomes true:
+
+- we add a real session-store use case that JWT cannot support cleanly
+- we remove credential login and no longer need Prisma-backed auth state
+- auth complexity grows enough that a migration brings clear, tested value

--- a/docs/order-payment-state-machine.md
+++ b/docs/order-payment-state-machine.md
@@ -1,0 +1,79 @@
+# Order and payment state machine
+
+Canonical reference for the order/payment lifecycle used by checkout, the Stripe webhook, mock confirmation, and incident triage.
+
+The key principle is that `Order.status` and `Order.paymentStatus` are related but distinct:
+
+- order status describes fulfillment progress
+- payment status describes money movement / provider confirmation
+
+## Current lifecycle
+
+### Order statuses
+
+| Status | Meaning |
+|---|---|
+| `PLACED` | Order created, stock reserved, payment still pending. |
+| `PAYMENT_CONFIRMED` | Payment succeeded and the order is now financially confirmed. |
+| `PROCESSING` | Vendor or ops has moved the order into fulfillment work. |
+| `PARTIALLY_SHIPPED` | Some fulfillments shipped, others still pending. |
+| `SHIPPED` | All fulfillments shipped. |
+| `DELIVERED` | All fulfillments delivered. |
+| `CANCELLED` | Terminal cancellation state. |
+| `REFUNDED` | Terminal refund state. |
+
+### Payment statuses
+
+| Status | Meaning |
+|---|---|
+| `PENDING` | Payment exists but Stripe has not confirmed success or failure yet. |
+| `SUCCEEDED` | Stripe has confirmed the charge. |
+| `FAILED` | Payment provider failed or the payment intent creation path failed. |
+| `REFUNDED` | Payment was fully refunded. |
+| `PARTIALLY_REFUNDED` | Payment was partially refunded. |
+
+## Canonical transitions
+
+### Checkout creation
+
+- `createOrder()` creates:
+  - `Order.status = PLACED`
+  - `Order.paymentStatus = PENDING`
+- The payment row is created in parallel and later linked to the provider reference.
+
+### Stripe webhook: `payment_intent.succeeded`
+
+- The payment row transitions to `SUCCEEDED`.
+- The order transitions from `PLACED` to `PAYMENT_CONFIRMED`.
+- A `PAYMENT_CONFIRMED` order event is written exactly once for the successful transition.
+
+### Stripe webhook: `payment_intent.payment_failed`
+
+- The payment row transitions to `FAILED`.
+- The order remains in its current fulfillment state, typically `PLACED`.
+- A `PAYMENT_FAILED` order event is written when the transition is applied.
+
+### Mock confirmation
+
+- `confirmOrder()` in mock mode mirrors the same successful-payment transition as the Stripe webhook.
+- This path exists for local and test flows only.
+
+## Invalid transitions and guardrails
+
+- `CANCELLED` and `REFUNDED` orders must not transition back to `PAYMENT_CONFIRMED`.
+- Already confirmed payments must not be reconfirmed.
+- Already failed payments must not be failed again.
+- Duplicate Stripe webhooks are a no-op after idempotency checks.
+- Amount mismatches must not confirm the order.
+
+## Code references
+
+- [`src/app/api/webhooks/stripe/route.ts`](../src/app/api/webhooks/stripe/route.ts)
+- [`src/domains/payments/webhook.ts`](../src/domains/payments/webhook.ts)
+- [`src/domains/orders/use-cases/confirm-order.ts`](../src/domains/orders/use-cases/confirm-order.ts)
+- [`src/domains/orders/payment-persistence.ts`](../src/domains/orders/payment-persistence.ts)
+
+## Notes
+
+- This document describes the current implementation, not an aspirational future workflow.
+- If refunds or additional fulfillment states expand the lifecycle, update this document and the tests together.

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -161,6 +161,8 @@ export async function POST(req: NextRequest) {
 
   try {
     switch (event.type) {
+      // Canonical lifecycle reference:
+      // docs/order-payment-state-machine.md
       case 'payment_intent.succeeded': {
         const pi = parseWebhookPaymentIntent(event.data.object)
         if (!pi) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,8 @@ const ROLE_REFRESH_INTERVAL_MS = 60_000
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
+  // See docs/adr/001-nextauth-prismaadapter-jwt.md for the rationale behind
+  // keeping the Prisma adapter with JWT sessions for the current product stage.
   adapter: PrismaAdapter(db) as Adapter,
   trustHost: true,
   session: { strategy: 'jwt' },

--- a/test/features/auth-architecture-decision.test.ts
+++ b/test/features/auth-architecture-decision.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function readSource(path: string) {
+  return readFileSync(new URL(path, import.meta.url), 'utf8')
+}
+
+test('auth architecture decision documents why PrismaAdapter + JWT stays in place', () => {
+  const adr = readSource('../../docs/adr/001-nextauth-prismaadapter-jwt.md')
+  const auth = readSource('../../src/lib/auth.ts')
+  const authConfig = readSource('../../src/lib/auth-config.ts')
+
+  assert.match(adr, /\*\*Status:\*\*\s+Accepted/)
+  assert.match(adr, /PrismaAdapter\(db\)/)
+  assert.match(adr, /session:\s*\{\s*strategy:\s*'jwt'\s*\}/i)
+  assert.match(adr, /credential login/i)
+  assert.match(adr, /JWT/)
+  assert.match(adr, /role propagation/i)
+  assert.match(adr, /host-only cookie/i)
+  assert.match(auth, /docs\/adr\/001-nextauth-prismaadapter-jwt\.md/)
+  assert.match(auth, /PrismaAdapter\(db\)/)
+  assert.match(auth, /session:\s+\{ strategy: 'jwt' \}/)
+  assert.match(authConfig, /authorized\(/)
+  assert.match(authConfig, /isAdminRoute/)
+  assert.match(authConfig, /isVendorRoute/)
+})

--- a/test/features/order-payment-state-machine.test.ts
+++ b/test/features/order-payment-state-machine.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function readSource(path: string) {
+  return readFileSync(new URL(path, import.meta.url), 'utf8')
+}
+
+test('order/payment state machine is documented and referenced from the Stripe webhook', () => {
+  const doc = readSource('../../docs/order-payment-state-machine.md')
+  const route = readSource('../../src/app/api/webhooks/stripe/route.ts')
+  const confirmOrder = readSource('../../src/domains/orders/use-cases/confirm-order.ts')
+  const webhookDomain = readSource('../../src/domains/payments/webhook.ts')
+
+  assert.match(doc, /Order and payment state machine/)
+  assert.match(doc, /Order\.status/)
+  assert.match(doc, /Order\.paymentStatus/)
+  assert.match(doc, /PLACED/)
+  assert.match(doc, /PAYMENT_CONFIRMED/)
+  assert.match(doc, /CANCELLED/)
+  assert.match(doc, /REFUNDED/)
+  assert.match(doc, /payment_intent\.succeeded/)
+  assert.match(doc, /payment_intent\.payment_failed/)
+  assert.match(doc, /Invalid transitions/)
+  assert.match(route, /docs\/order-payment-state-machine\.md/)
+  assert.match(confirmOrder, /shouldApplyPaymentSucceeded/)
+  assert.match(webhookDomain, /shouldApplyPaymentSucceeded/)
+  assert.match(webhookDomain, /shouldApplyPaymentFailed/)
+})


### PR DESCRIPTION
## What changed
- Added a canonical order/payment lifecycle document.
- Added a short auth ADR explaining why we keep NextAuth + PrismaAdapter + JWT.
- Linked the Stripe webhook and auth code to those references.
- Added source-contract tests so the docs and code references do not drift.

## Why
These two decisions were implicit in code. Making them explicit reduces review ambiguity and gives future changes a stable reference point without changing behavior.

## Validation
- `npx eslint 'src/app/api/webhooks/stripe/route.ts' 'src/lib/auth.ts' 'src/lib/auth-config.ts' 'test/features/auth-architecture-decision.test.ts' 'test/features/order-payment-state-machine.test.ts'`
- `node --import tsx --test test/features/auth-architecture-decision.test.ts test/features/order-payment-state-machine.test.ts test/integration/api-route-auth-audit.test.ts`

Closes #312
Closes #314
