### PR TITLE
ci(flags): enforce feat-* cleanup ticket metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           mkdir -p .ci-logs
           npm run lint             > .ci-logs/lint.log             2>&1 & PID_LINT=$!
           npm run audit:contracts  > .ci-logs/audit-contracts.log  2>&1 & PID_AUDIT=$!
+          npm run audit:flags-cleanup > .ci-logs/audit-flags.log   2>&1 & PID_AUDIT_FLAGS=$!
           npm run typecheck:app    > .ci-logs/typecheck-app.log    2>&1 & PID_TC_APP=$!
           npm run typecheck:test   > .ci-logs/typecheck-test.log   2>&1 & PID_TC_TEST=$!
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -57,6 +58,7 @@ jobs:
           STATUS=0
           wait $PID_LINT    || { echo "::group::lint FAILED";             cat .ci-logs/lint.log;             echo "::endgroup::"; STATUS=1; }
           wait $PID_AUDIT   || { echo "::group::audit:contracts FAILED";  cat .ci-logs/audit-contracts.log;  echo "::endgroup::"; STATUS=1; }
+          wait $PID_AUDIT_FLAGS || { echo "::group::audit:flags-cleanup FAILED"; cat .ci-logs/audit-flags.log; echo "::endgroup::"; STATUS=1; }
           wait $PID_TC_APP  || { echo "::group::typecheck:app FAILED";    cat .ci-logs/typecheck-app.log;    echo "::endgroup::"; STATUS=1; }
           wait $PID_TC_TEST || { echo "::group::typecheck:test FAILED";   cat .ci-logs/typecheck-test.log;   echo "::endgroup::"; STATUS=1; }
           wait $PID_TESTS   || { echo "::group::tests FAILED";            cat .ci-logs/tests.log;            echo "::endgroup::"; STATUS=1; }
@@ -64,6 +66,7 @@ jobs:
           if [ $STATUS -eq 0 ]; then
             echo "::group::lint";            cat .ci-logs/lint.log;             echo "::endgroup::"
             echo "::group::audit:contracts"; cat .ci-logs/audit-contracts.log;  echo "::endgroup::"
+            echo "::group::audit:flags-cleanup"; cat .ci-logs/audit-flags.log;   echo "::endgroup::"
             echo "::group::typecheck:app";   cat .ci-logs/typecheck-app.log;    echo "::endgroup::"
             echo "::group::typecheck:test";  cat .ci-logs/typecheck-test.log;   echo "::endgroup::"
             echo "::group::tests";           cat .ci-logs/tests.log;            echo "::endgroup::"

--- a/config/feature-flag-cleanup.json
+++ b/config/feature-flag-cleanup.json
@@ -1,0 +1,32 @@
+{
+  "feat-buyer-subscriptions": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  },
+  "feat-ingestion-admin": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  },
+  "feat-ingestion-classifier": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  },
+  "feat-ingestion-dedupe": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  },
+  "feat-ingestion-publish": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  },
+  "feat-ingestion-rules-extractor": {
+    "issue": 753,
+    "owner": "@juanmixto",
+    "dueDate": "2026-05-23"
+  }
+}

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -373,6 +373,7 @@ Both evaluators return `true` if PostHog is unreachable, the SDK throws, or the 
 2. Wrap the call site with `await isFeatureEnabled('kill-foo', { userId, email, role })` (pass the richest context you have — PostHog targeting depends on it).
 3. Log a `<scope>.kill_switch_active` event when the switch fires so oncall can trace which flag rejected traffic. Follow the `scope.action` pattern already used in [`docs/runbooks/payment-incidents.md`](./runbooks/payment-incidents.md).
 4. **Every `feat-*` flag needs a cleanup ticket** filed when you ship it. Flags are debt; 30 days post-GA is the soft cap.
+5. Add or update the flag metadata in `config/feature-flag-cleanup.json` (`issue`, `owner`, `dueDate`). `npm run audit:flags-cleanup` is enforced by CI and fails if any active `feat-*` is missing metadata.
 
 ### Local eval
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint . --max-warnings=0",
     "audit:contracts": "node ./scripts/audit-domain-contracts.mjs",
     "audit:authz": "node ./scripts/audit-authz-coverage.mjs",
+    "audit:flags-cleanup": "node ./scripts/audit-flag-cleanup-tickets.mjs",
     "audit:deps": "npm audit --omit=dev --audit-level=high",
     "prisma:generate": "prisma generate",
     "db:migrate": "node --env-file=.env --env-file-if-exists=.env.local ./node_modules/prisma/build/index.js migrate dev",

--- a/scripts/audit-flag-cleanup-tickets.mjs
+++ b/scripts/audit-flag-cleanup-tickets.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(new URL('..', import.meta.url).pathname)
+const srcRoot = path.join(repoRoot, 'src')
+const registryPath = path.join(repoRoot, 'config', 'feature-flag-cleanup.json')
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+    const absolute = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(absolute, out)
+      continue
+    }
+    if (entry.isFile() && (absolute.endsWith('.ts') || absolute.endsWith('.tsx'))) {
+      out.push(absolute)
+    }
+  }
+  return out
+}
+
+function collectFeatFlags() {
+  const files = walk(srcRoot)
+  const flags = new Set()
+  const pattern = /['"`](feat-[a-z0-9-]+)['"`]/g
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8')
+    for (const match of source.matchAll(pattern)) {
+      flags.add(match[1])
+    }
+  }
+
+  return [...flags].sort()
+}
+
+function isValidDate(value) {
+  if (typeof value !== 'string') return false
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
+
+function main() {
+  if (!fs.existsSync(registryPath)) {
+    console.error('Missing cleanup registry:', path.relative(repoRoot, registryPath))
+    process.exit(1)
+  }
+
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+  const activeFlags = collectFeatFlags()
+
+  const errors = []
+
+  for (const flag of activeFlags) {
+    const row = registry[flag]
+    if (!row) {
+      errors.push(`${flag}: missing entry in config/feature-flag-cleanup.json`)
+      continue
+    }
+
+    if (!Number.isInteger(row.issue) || row.issue <= 0) {
+      errors.push(`${flag}: issue must be a positive integer`)
+    }
+
+    if (typeof row.owner !== 'string' || row.owner.trim().length === 0) {
+      errors.push(`${flag}: owner must be a non-empty string`)
+    }
+
+    if (!isValidDate(row.dueDate)) {
+      errors.push(`${flag}: dueDate must use YYYY-MM-DD`)
+    }
+  }
+
+  const staleRegistryEntries = Object.keys(registry)
+    .filter((flag) => flag.startsWith('feat-'))
+    .filter((flag) => !activeFlags.includes(flag))
+
+  console.log('Feature flag cleanup audit')
+  console.log('- active feat-* flags:', activeFlags.length)
+  console.log('- registry entries:', Object.keys(registry).length)
+
+  if (staleRegistryEntries.length > 0) {
+    console.log('- stale registry entries:', staleRegistryEntries.join(', '))
+  }
+
+  if (errors.length > 0) {
+    console.error('\nAudit failed:')
+    for (const error of errors) console.error(`- ${error}`)
+    process.exit(1)
+  }
+
+  console.log('\nAudit passed.')
+}
+
+main()


### PR DESCRIPTION
## Summary

Implements issue #753 by adding an explicit registry + CI guard for `feat-*` cleanup ownership.

## What Changed

- Added `config/feature-flag-cleanup.json` with metadata for each active `feat-*` flag:
  - `issue`
  - `owner`
  - `dueDate` (`YYYY-MM-DD`)
- Added `scripts/audit-flag-cleanup-tickets.mjs`.
  - Scans `src/**/*.{ts,tsx}` for active `feat-*` flags.
  - Fails if any active flag is missing registry metadata.
  - Validates metadata shape (`issue` positive integer, non-empty `owner`, `dueDate` format).
- Added npm script in `package.json`:
  - `audit:flags-cleanup`
- Wired the check into CI `Verify` job (`.github/workflows/ci.yml`) in parallel with other audits.
- Updated `docs/conventions.md` to make the registry step mandatory when adding new `feat-*` flags.

## Why

Current policy says every `feat-*` needs a cleanup ticket, but this was manual and easy to forget. This PR makes it enforceable and visible in CI.

## Validation

- `node scripts/audit-flag-cleanup-tickets.mjs` ✅
- `npm run -s audit:flags-cleanup` ✅

## Related

- Closes #753