### PR TITLE
fix(e2e): stabilize auth smoke and checkout redirect

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -15,10 +15,10 @@ test.describe('auth @smoke', () => {
 
   test('login with wrong credentials surfaces an error', async ({ page }) => {
     await page.goto('/login')
-    await page.locator('input[name="email"]').pressSequentially('cliente@test.com')
-    await page.locator('input[name="password"]').fill('definitely-wrong-password')
     const submit = page.getByRole('button', { name: 'Iniciar sesión' })
     await expect(submit).toBeEnabled({ timeout: 10_000 })
+    await page.locator('input[name="email"]').fill('cliente@test.com')
+    await page.locator('input[name="password"]').fill('definitely-wrong-password')
     await submit.click()
     // Stay on /login and show an inline error message. We don't pin the
     // exact wording — just that something user-facing surfaces.

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -21,10 +21,10 @@ export async function loginAs(page: Page, user: TestUser) {
   // the login page is a server component and hydration can take >5s on cold
   // dev-mode runners (GitHub-hosted, first request).
   await page.goto('/login', { waitUntil: 'commit' })
-  await page.locator('input[name="email"]').pressSequentially(user.email)
-  await page.locator('input[name="password"]').fill(user.password)
   const submit = page.getByRole('button', { name: 'Iniciar sesión' })
   await expect(submit).toBeEnabled({ timeout: 10_000 })
+  await page.locator('input[name="email"]').fill(user.email)
+  await page.locator('input[name="password"]').fill(user.password)
   await Promise.all([
     page.waitForURL(url => !url.pathname.startsWith('/login'), { timeout: 20_000 }),
     submit.click(),

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -97,11 +97,36 @@ export function LoginForm({ callbackUrl = '/' }: LoginFormProps) {
     if (opts.totp) payload.totpCode = opts.totp
     if (opts.remember) payload.rememberDevice = '1'
 
-    const result = await signIn('credentials', {
-      ...payload,
-      redirect: false,
-      callbackUrl: safeCallbackUrl,
-    })
+    const signInWithRetry = async () => {
+      let lastError: unknown = null
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          return await signIn('credentials', {
+            ...payload,
+            redirect: false,
+            callbackUrl: safeCallbackUrl,
+          })
+        } catch (error) {
+          lastError = error
+          if (attempt === 0) {
+            await new Promise(resolve => setTimeout(resolve, 250))
+            continue
+          }
+        }
+      }
+
+      throw lastError ?? new Error('signIn failed')
+    }
+
+    let result
+    try {
+      result = await signInWithRetry()
+    } catch {
+      setError(t('login.error.generic'))
+      setLoading(false)
+      return
+    }
 
     if (result?.error) {
       setError(t('login.error.invalidCredentials'))


### PR DESCRIPTION
Stabilizes the smoke suite by:
- waiting for login hydration before filling fields
- filling login fields deterministically in the auth helper
- handling transient signIn failures in LoginForm

Validated with:
- npx tsc -p tsconfig.json --noEmit --pretty false
- node --import tsx --test test/features/orders-checkout.test.ts test/contracts/loading-states.test.ts
- E2E_BASE_URL=http://localhost:3001 npx playwright test e2e/auth.spec.ts --project=chromium --reporter=line