### PR TITLE
perf: quick wins block — loading states, prefetch budget, blur, lazy Stripe

### DIFF
--- a/src/app/(buyer)/carrito/loading.tsx
+++ b/src/app/(buyer)/carrito/loading.tsx
@@ -1,0 +1,31 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+      <div className="animate-pulse space-y-6">
+        <div className="h-8 w-40 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex gap-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4">
+                <div className="h-20 w-20 shrink-0 rounded-lg bg-neutral-100 dark:bg-neutral-900" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-2/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+                  <div className="h-3 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+                  <div className="h-8 w-24 rounded bg-neutral-200 dark:bg-neutral-800" />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="h-64 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5">
+            <div className="space-y-3">
+              <div className="h-4 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-10 w-full rounded bg-emerald-100 dark:bg-emerald-900/40" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(buyer)/checkout/loading.tsx
+++ b/src/app/(buyer)/checkout/loading.tsx
@@ -1,0 +1,28 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+      <div className="animate-pulse space-y-6">
+        <div className="h-10 w-full rounded-2xl bg-neutral-100 dark:bg-neutral-900" />
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <div className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6">
+            <div className="h-5 w-1/3 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="h-10 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-10 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-10 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="h-10 rounded bg-neutral-200 dark:bg-neutral-800" />
+            </div>
+            <div className="h-24 rounded bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+          <div className="space-y-3 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5">
+            <div className="h-4 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-3 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-10 w-full rounded bg-emerald-100 dark:bg-emerald-900/40" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(buyer)/checkout/pago/loading.tsx
+++ b/src/app/(buyer)/checkout/pago/loading.tsx
@@ -1,0 +1,23 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        <div className="h-10 w-full rounded-2xl bg-neutral-100 dark:bg-neutral-900" />
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-raised)] p-5">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="h-8 rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-8 rounded bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-8 rounded bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        </div>
+        <div className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6">
+          <div className="h-7 w-1/3 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+          <div className="h-80 rounded-xl bg-neutral-100 dark:bg-neutral-900" />
+          <div className="flex items-center justify-end">
+            <div className="h-11 w-40 rounded-lg bg-emerald-100 dark:bg-emerald-900/40" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(buyer)/checkout/pago/page.tsx
+++ b/src/app/(buyer)/checkout/pago/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth'
 import { redirect, notFound } from 'next/navigation'
 import { getOrderDetail } from '@/domains/orders/actions'
 import { stripeCheckoutParamsSchema, isMockClientSecret } from '@/domains/payments/checkout'
-import { StripeCheckoutForm } from '@/components/checkout/StripeCheckoutForm'
+import { StripeCheckoutFormLazy } from '@/components/checkout/StripeCheckoutFormLazy'
 import { CheckoutProgress } from '@/components/checkout/CheckoutProgress'
 import { formatPrice } from '@/lib/utils'
 import { getServerEnv } from '@/lib/env'
@@ -78,7 +78,7 @@ export default async function CheckoutPaymentPage({ searchParams }: Props) {
         </div>
       </div>
 
-      <StripeCheckoutForm
+      <StripeCheckoutFormLazy
         clientSecret={parsed.data.secret}
         orderId={order.id}
         orderNumber={order.orderNumber}

--- a/src/app/(public)/productores/[slug]/loading.tsx
+++ b/src/app/(public)/productores/[slug]/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        <div className="h-56 w-full rounded-3xl bg-neutral-100 dark:bg-neutral-900" />
+        <div className="space-y-3">
+          <div className="h-8 w-1/2 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+          <div className="h-4 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
+              <div className="aspect-square bg-neutral-100 dark:bg-neutral-900" />
+              <div className="space-y-2 p-4">
+                <div className="h-4 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-5 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/productores/loading.tsx
+++ b/src/app/(public)/productores/loading.tsx
@@ -1,0 +1,23 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        <div className="h-9 w-64 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+        <div className="h-4 w-96 max-w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+        <div className="mt-8 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)]">
+              <div className="h-44 bg-neutral-100 dark:bg-neutral-900" />
+              <div className="space-y-3 p-5">
+                <div className="h-5 w-2/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-3 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-3 w-full rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-3 w-5/6 rounded bg-neutral-200 dark:bg-neutral-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/productores/page.tsx
+++ b/src/app/(public)/productores/page.tsx
@@ -47,6 +47,7 @@ export default async function ProductoresPage() {
             <Link
               key={v.slug}
               href={`/productores/${v.slug}`}
+              prefetch={false}
               className="group overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--surface)] shadow-sm transition-all hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md dark:hover:border-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
             >
               <div className="relative h-44 overflow-hidden border-b border-[var(--border)] bg-slate-100 dark:bg-slate-900">

--- a/src/app/(public)/productos/loading.tsx
+++ b/src/app/(public)/productos/loading.tsx
@@ -1,0 +1,26 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        <div className="h-8 w-48 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+        <div className="flex flex-wrap gap-3">
+          <div className="h-10 w-32 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-10 w-28 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="flex flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
+              <div className="aspect-square bg-neutral-100 dark:bg-neutral-900" />
+              <div className="space-y-2 p-4">
+                <div className="h-4 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-3 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-5 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/catalog/ProductCard.tsx
+++ b/src/components/catalog/ProductCard.tsx
@@ -98,6 +98,7 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
     >
       <Link
         href={`/productos/${product.slug}`}
+        prefetch={false}
         className="flex flex-1 flex-col focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
       >
         <div className="relative aspect-square overflow-hidden rounded-t-2xl bg-[var(--surface-raised)]">
@@ -108,6 +109,8 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
               fill
               className="object-cover transition-transform duration-500 group-hover:scale-105"
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              placeholder="blur"
+              blurDataURL="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA0IDMnPjxmaWx0ZXIgaWQ9J2InIGNvbG9yLWludGVycG9sYXRpb24tZmlsdGVycz0nc1JHQic+PGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0nMC41Jy8+PC9maWx0ZXI+PHJlY3Qgd2lkdGg9JzEwMCUnIGhlaWdodD0nMTAwJScgZmlsbD0nI2VlZWVlZScvPjwvc3ZnPg=="
             />
           ) : (
             <div className="flex h-full items-center justify-center text-5xl opacity-30">🌿</div>
@@ -221,6 +224,7 @@ export function ProductCard({ product, locale = 'es' }: ProductCardProps) {
         <div className="flex items-center gap-2">
           <Link
             href={`/productos/${product.slug}`}
+            prefetch={false}
             className="hidden h-10 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] px-3 text-sm font-semibold text-[var(--foreground-soft)] transition hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] lg:inline-flex"
           >
             {copy.actions.viewDetail}

--- a/src/components/catalog/SafeImage.tsx
+++ b/src/components/catalog/SafeImage.tsx
@@ -11,6 +11,7 @@ interface SafeImageProps {
   fill?: boolean
   className?: string
   sizes?: string
+  priority?: boolean
 }
 
 /**
@@ -24,6 +25,7 @@ export function SafeImage({
   fill,
   className,
   sizes,
+  priority = false,
 }: SafeImageProps) {
   const [hasError, setHasError] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -57,7 +59,7 @@ export function SafeImage({
         sizes={sizes}
         onError={() => setHasError(true)}
         onLoadingComplete={() => setIsLoading(false)}
-        priority={false}
+        priority={priority}
       />
     </>
   )

--- a/src/components/checkout/StripeCheckoutFormLazy.tsx
+++ b/src/components/checkout/StripeCheckoutFormLazy.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const StripeSkeleton = () => (
+  <div className="space-y-6 rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6" aria-busy="true">
+    <div className="space-y-2">
+      <div className="h-7 w-1/3 rounded bg-emerald-100 dark:bg-emerald-900/40 animate-pulse" />
+      <div className="h-4 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800 animate-pulse" />
+    </div>
+    <div className="h-80 rounded-xl border border-[var(--border)] bg-[var(--surface-raised)] animate-pulse" />
+    <div className="flex items-center justify-end">
+      <div className="h-11 w-40 rounded-lg bg-emerald-100 dark:bg-emerald-900/40 animate-pulse" />
+    </div>
+  </div>
+)
+
+export const StripeCheckoutFormLazy = dynamic(
+  () => import('./StripeCheckoutForm').then(m => m.StripeCheckoutForm),
+  { ssr: false, loading: StripeSkeleton }
+)


### PR DESCRIPTION
Block 1 of epic #762. Closes #763 #764 #765 #766.

## Changes
- **#763** 6 `loading.tsx` skeletons for high-traffic public routes.
- **#764** `prefetch={false}` on catalog grid links (ProductCard + productores index).
- **#765** `SafeImage` now accepts `priority`; `ProductCard` image uses blur placeholder.
- **#766** `StripeCheckoutFormLazy` wrapper with `next/dynamic({ ssr: false })` splits Stripe bundle out of the `/checkout` initial chunk.

## Test plan
- [ ] `npm run typecheck` clean (done locally)
- [ ] `npm run lint` clean (done locally)
- [ ] Manual smoke: navigate productos → detail on throttled mobile; confirm skeleton shows immediately and no CLS at swap.
- [ ] Manual checkout flow end-to-end (address → pago → confirmación) with Stripe test card.
- [ ] Confirm DevTools Network on `/productos` does **not** fire `/_next/data` prefetches per card.

## Risk
Low per-change. Checkout lazy-load is the only one touching a critical path — preserved form via wrapper, same public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)