### PR TITLE
obs: long-task RUM + dynamic Sentry sampling on checkout

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -8,6 +8,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { sentryConfig } from '@/lib/sentry/config'
+import { buildTracesSampler } from '@/lib/sentry/sampler'
 import { scrubSentryEvent } from '@/lib/sentry/scrubber'
 
 if (sentryConfig) {
@@ -15,7 +16,7 @@ if (sentryConfig) {
     dsn: sentryConfig.dsn,
     environment: sentryConfig.environment,
     release: sentryConfig.release,
-    tracesSampleRate: sentryConfig.tracesSampleRate,
+    tracesSampler: buildTracesSampler(sentryConfig.tracesSampleRate),
     replaysSessionSampleRate: sentryConfig.replaysSessionSampleRate,
     replaysOnErrorSampleRate: sentryConfig.replaysOnErrorSampleRate,
     sendDefaultPii: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,6 +6,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { sentryConfig } from '@/lib/sentry/config'
+import { buildTracesSampler } from '@/lib/sentry/sampler'
 import { scrubSentryEvent } from '@/lib/sentry/scrubber'
 
 if (sentryConfig) {
@@ -13,7 +14,7 @@ if (sentryConfig) {
     dsn: sentryConfig.dsn,
     environment: sentryConfig.environment,
     release: sentryConfig.release,
-    tracesSampleRate: sentryConfig.tracesSampleRate,
+    tracesSampler: buildTracesSampler(sentryConfig.tracesSampleRate),
     // Send default PII is OFF — we rely on explicit opt-in via
     // Sentry.setUser({ id }) to add the internal id, nothing else.
     sendDefaultPii: false,

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -1,29 +1,25 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useReportWebVitals } from 'next/web-vitals'
 import { capturePostHog, isPostHogEnabled } from '@/lib/posthog'
 
 /**
- * Pipes Core Web Vitals from Next's built-in reporter into PostHog so we
- * get real p75 LCP / INP / CLS / TTFB / FCP from production users — not
- * just lab numbers from Lighthouse synthetic runs.
- *
- * Why this component exists:
- *   - Before this, the repo had no runtime perf telemetry. A regression
- *     that landed between Lighthouse runs (or on a page that Lighthouse
- *     doesn't hit) was invisible until a user complained.
- *   - PostHog is already wired up (see `src/lib/posthog.ts`). Reusing it
- *     avoids a second SDK for the same job and gives us the existing
- *     session/identification plumbing for free.
+ * Pipes Core Web Vitals and long-task telemetry into PostHog so we get
+ * real p75 LCP / INP / CLS / TTFB / FCP — plus main-thread jank — from
+ * production users, not just lab numbers from Lighthouse synthetic runs.
  *
  * Event shape:
  *   `$web_vitals` with `{ name, value, rating, id, delta, navigationType }`.
- *   The `$` prefix marks these as PostHog-internal events so they group
- *   cleanly in dashboards without polluting business event lists.
+ *   `$long_task` with `{ duration, startTime, path }` for tasks ≥100ms.
+ *   100ms noise floor: anything shorter is invisible to users on mid-tier
+ *   mobile and would flood PostHog ingest.
  *
  * Sampling is handled at the PostHog project level — don't add sampling
  * here or p75 math downstream will be biased.
  */
+const LONG_TASK_NOISE_FLOOR_MS = 100
+
 export function WebVitalsReporter() {
   useReportWebVitals(metric => {
     if (!isPostHogEnabled()) return
@@ -37,6 +33,32 @@ export function WebVitalsReporter() {
       path: typeof window !== 'undefined' ? window.location.pathname : undefined,
     })
   })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!isPostHogEnabled()) return
+    if (typeof PerformanceObserver === 'undefined') return
+
+    let observer: PerformanceObserver | null = null
+    try {
+      observer = new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration < LONG_TASK_NOISE_FLOOR_MS) continue
+          capturePostHog('$long_task', {
+            duration: Math.round(entry.duration),
+            startTime: Math.round(entry.startTime),
+            path: window.location.pathname,
+          })
+        }
+      })
+      observer.observe({ type: 'longtask', buffered: true })
+    } catch {
+      // Browser doesn't support longtask — Safari <16, older Firefox.
+      // Silent no-op; Core Web Vitals still ship.
+    }
+
+    return () => observer?.disconnect()
+  }, [])
 
   return null
 }

--- a/src/generated
+++ b/src/generated
@@ -1,1 +1,0 @@
-/home/whisper/marketplace/src/generated

--- a/src/generated
+++ b/src/generated
@@ -1,0 +1,1 @@
+/home/whisper/marketplace/src/generated

--- a/src/lib/sentry/sampler.ts
+++ b/src/lib/sentry/sampler.ts
@@ -1,0 +1,43 @@
+/**
+ * Dynamic Sentry trace sampling (#771).
+ *
+ * Checkout is the highest-stakes flow (revenue, idempotency, Stripe round-trips)
+ * and 10% global sampling is too sparse to diagnose tail-latency regressions
+ * before they bleed conversion. We bump the rate specifically for checkout
+ * routes and let everything else fall back to the base rate.
+ *
+ * Keep this file tiny — it's imported on both client and server.
+ */
+
+const CHECKOUT_PATTERNS = [
+  /\/checkout(?:\/|$)/,
+  /\/api\/checkout(?:\/|$)/,
+  /\/api\/orders(?:\/|$)/,
+  /\/api\/stripe(?:\/|$)/,
+]
+
+const CHECKOUT_SAMPLE_RATE = 0.25
+
+interface SamplingContext {
+  name?: string
+  request?: { url?: string }
+  transactionContext?: { name?: string }
+}
+
+function matchesCheckout(context: SamplingContext): boolean {
+  const candidates = [
+    context.name,
+    context.transactionContext?.name,
+    context.request?.url,
+  ]
+  return candidates.some(
+    value => typeof value === 'string' && CHECKOUT_PATTERNS.some(re => re.test(value))
+  )
+}
+
+export function buildTracesSampler(baseRate: number) {
+  return (context: SamplingContext): number => {
+    if (matchesCheckout(context)) return CHECKOUT_SAMPLE_RATE
+    return baseRate
+  }
+}


### PR DESCRIPTION
Block 3 of epic #762. Closes #770 #771.

## Changes
- **#770** `WebVitalsReporter` now ships `\$long_task` events (≥100ms) to PostHog via `PerformanceObserver('longtask', { buffered: true })`.
- **#771** Sentry `tracesSampler` replaces static rate — `/checkout`, `/api/checkout`, `/api/orders`, `/api/stripe` sample at 25%; baseline elsewhere (env-configurable, default 10%).

Shared sampler helper in `src/lib/sentry/sampler.ts` keeps client + server in sync.

## Test plan
- [x] typecheck + lint clean locally
- [ ] Deploy to staging, confirm `\$long_task` events appear in PostHog with `path` property
- [ ] Sentry dashboard: confirm higher transaction density on checkout vs baseline after 24h

## Risk
Low — only adjusts sampling and adds a passive PerformanceObserver. No behavior change for users; no change to scrubber/PII handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)