### PR TITLE
perf(admin): server-paginate producers overview

### DIFF
--- a/src/app/(admin)/admin/productores/page.tsx
+++ b/src/app/(admin)/admin/productores/page.tsx
@@ -1,11 +1,39 @@
 import type { Metadata } from 'next'
 import { AdminProducersClient } from '@/components/admin/AdminProducersClient'
-import { getProducersOverview } from '@/domains/admin/producers'
+import {
+  getProducersOverview,
+  PRODUCER_SORT_KEYS,
+  PRODUCER_STATUS_FILTERS,
+  type ProducerSortKey,
+  type ProducerStatusFilter,
+} from '@/domains/admin/producers'
 
 export const metadata: Metadata = { title: 'Productores | Admin' }
 export const revalidate = 30
 
-export default async function AdminVendorsPage() {
-  const data = await getProducersOverview()
+interface PageProps {
+  searchParams: Promise<{
+    page?: string
+    q?: string
+    status?: string
+    sort?: string
+  }>
+}
+
+export default async function AdminVendorsPage({ searchParams }: PageProps) {
+  const sp = await searchParams
+  const pageNum = Number(sp.page)
+  const statusCandidate = sp.status as ProducerStatusFilter | undefined
+  const sortCandidate = sp.sort as ProducerSortKey | undefined
+  const data = await getProducersOverview({
+    page: Number.isFinite(pageNum) && pageNum > 0 ? Math.floor(pageNum) : 1,
+    search: sp.q ?? '',
+    status: PRODUCER_STATUS_FILTERS.includes(statusCandidate as ProducerStatusFilter)
+      ? statusCandidate
+      : undefined,
+    sort: PRODUCER_SORT_KEYS.includes(sortCandidate as ProducerSortKey)
+      ? sortCandidate
+      : undefined,
+  })
   return <AdminProducersClient data={data} />
 }

--- a/src/components/admin/AdminProducersClient.tsx
+++ b/src/components/admin/AdminProducersClient.tsx
@@ -1,31 +1,23 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useState, useTransition } from 'react'
 import Link from 'next/link'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useT, useI18n } from '@/i18n'
 import type { TranslationKeys } from '@/i18n/locales'
 import { AdminStatusBadge } from '@/components/admin/AdminStatusBadge'
 import { VendorModerationActions } from '@/components/admin/VendorModerationActions'
 import { getVendorStatusTone } from '@/domains/admin/overview'
-import type { EnrichedProducer, ProducersOverview } from '@/domains/admin/producers'
+import {
+  PRODUCER_SORT_KEYS,
+  PRODUCER_STATUS_FILTERS,
+  type EnrichedProducer,
+  type ProducerStatusFilter,
+  type ProducersOverview,
+} from '@/domains/admin/producers'
 import type { VendorStatus } from '@/generated/prisma/enums'
 
-const PAGE_SIZE = 20
-
-type StatusFilter = 'ALL' | VendorStatus
-type SortKey = 'revenueDesc' | 'revenueAsc' | 'recent' | 'lastSeen' | 'name' | 'orders'
-
-const STATUS_FILTERS: StatusFilter[] = [
-  'ALL',
-  'ACTIVE',
-  'APPLYING',
-  'PENDING_DOCS',
-  'SUSPENDED_TEMP',
-  'SUSPENDED_PERM',
-  'REJECTED',
-]
-
-const SORT_OPTIONS: SortKey[] = ['revenueDesc', 'revenueAsc', 'recent', 'lastSeen', 'name', 'orders']
+const SEARCH_DEBOUNCE_MS = 250
 
 interface Props {
   data: ProducersOverview
@@ -64,9 +56,7 @@ function relativeFromNow(
   if (!iso) return { label: t('adminProducers.lastSeen.never'), tone: 'slate' }
   const diffMs = Date.now() - new Date(iso).getTime()
   const minutes = Math.floor(diffMs / 60000)
-  if (minutes < 60) {
-    return { label: t('adminProducers.lastSeen.justNow'), tone: 'emerald' }
-  }
+  if (minutes < 60) return { label: t('adminProducers.lastSeen.justNow'), tone: 'emerald' }
   const hours = Math.floor(minutes / 60)
   if (hours < 24) {
     return {
@@ -149,67 +139,62 @@ function StatCard({
 export function AdminProducersClient({ data }: Props) {
   const t = useT()
   const { locale } = useI18n()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParamsRO = useSearchParams()
+  const [isNavigating, startTransition] = useTransition()
 
-  const [search, setSearch] = useState('')
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL')
-  const [sort, setSort] = useState<SortKey>('revenueDesc')
-  const [page, setPage] = useState(1)
+  // Keep search input local for snappy typing; debounce into the URL so
+  // each keystroke doesn't trigger a server roundtrip. Seeded from the
+  // server's normalised params so the input is the source of truth after
+  // a full reload.
+  const [searchInput, setSearchInput] = useState(data.params.search)
 
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase()
-    let out = data.producers
-    if (statusFilter !== 'ALL') {
-      out = out.filter(p => p.status === statusFilter)
-    }
-    if (q) {
-      out = out.filter(p =>
-        p.displayName.toLowerCase().includes(q) ||
-        p.email.toLowerCase().includes(q) ||
-        (p.location?.toLowerCase().includes(q) ?? false)
-      )
-    }
-    const sorted = [...out]
-    switch (sort) {
-      case 'revenueDesc':
-        sorted.sort((a, b) => b.revenue - a.revenue)
-        break
-      case 'revenueAsc':
-        sorted.sort((a, b) => a.revenue - b.revenue)
-        break
-      case 'recent':
-        sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-        break
-      case 'lastSeen':
-        sorted.sort((a, b) => (b.lastSeenAt ?? '').localeCompare(a.lastSeenAt ?? ''))
-        break
-      case 'name':
-        sorted.sort((a, b) => a.displayName.localeCompare(b.displayName))
-        break
-      case 'orders':
-        sorted.sort((a, b) => b.ordersCount - a.ordersCount)
-        break
-    }
-    return sorted
-  }, [data.producers, search, statusFilter, sort])
+  // Keep the input in sync when the parent re-renders with different
+  // normalised params (e.g. after a back/forward navigation).
+  useEffect(() => {
+    setSearchInput(data.params.search)
+  }, [data.params.search])
 
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
-  const safePage = Math.min(page, totalPages)
-  const pageStart = (safePage - 1) * PAGE_SIZE
-  const pageItems = filtered.slice(pageStart, pageStart + PAGE_SIZE)
+  // Debounced URL write for the search box. Other controls commit
+  // immediately since they click-fire rather than type-fire.
+  useEffect(() => {
+    const trimmed = searchInput.trim()
+    if (trimmed === data.params.search) return
+    const handle = setTimeout(() => {
+      updateParams({ q: trimmed || undefined, page: undefined })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput])
+
+  function updateParams(patch: Partial<Record<'q' | 'status' | 'sort' | 'page', string | undefined>>) {
+    const params = new URLSearchParams(searchParamsRO?.toString() ?? '')
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined || value === '') params.delete(key)
+      else params.set(key, value)
+    }
+    const query = params.toString()
+    const href = query ? `${pathname}?${query}` : pathname
+    startTransition(() => router.replace(href, { scroll: false }))
+  }
 
   function statusLabel(s: VendorStatus): string {
     return t(`adminProducers.status.${s}` as TranslationKeys)
   }
 
-  function filterLabel(f: StatusFilter): string {
+  function filterLabel(f: ProducerStatusFilter): string {
     if (f === 'ALL') return t('adminProducers.filter.all')
     return statusLabel(f)
   }
 
-  function statusCount(f: StatusFilter): number {
+  function statusCount(f: ProducerStatusFilter): number {
     if (f === 'ALL') return data.globals.total
     return data.statusCounts[f] ?? 0
   }
+
+  const { pageItems, pagination, params, globals } = data
+  const pageStart = (pagination.page - 1) * pagination.pageSize
 
   return (
     <div className="space-y-6">
@@ -221,48 +206,43 @@ export function AdminProducersClient({ data }: Props) {
         <p className="mt-1 text-sm text-[var(--muted)]">{t('adminProducers.subtitle')}</p>
       </div>
 
-      {/* KPI cards */}
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <StatCard
           label={t('adminProducers.kpi.gmv')}
-          value={fmtCurrency(data.globals.gmv, locale)}
+          value={fmtCurrency(globals.gmv, locale)}
           hint={t('adminProducers.kpi.gmvHint')}
           accent="emerald"
         />
         <StatCard
           label={t('adminProducers.kpi.orders')}
-          value={fmtNumber(data.globals.orders, locale)}
+          value={fmtNumber(globals.orders, locale)}
           hint={t('adminProducers.kpi.ordersHint')}
           accent="blue"
         />
         <StatCard
           label={t('adminProducers.kpi.active')}
-          value={fmtNumber(data.globals.active, locale)}
-          hint={t('adminProducers.kpi.totalHint').replace('{count}', String(data.globals.total))}
+          value={fmtNumber(globals.active, locale)}
+          hint={t('adminProducers.kpi.totalHint').replace('{count}', String(globals.total))}
           accent="emerald"
         />
         <StatCard
           label={t('adminProducers.kpi.pending')}
-          value={fmtNumber(data.globals.pendingReview, locale)}
-          hint={t('adminProducers.kpi.suspendedHint').replace(
-            '{count}',
-            String(data.globals.suspended)
-          )}
+          value={fmtNumber(globals.pendingReview, locale)}
+          hint={t('adminProducers.kpi.suspendedHint').replace('{count}', String(globals.suspended))}
           accent="amber"
         />
       </div>
 
-      {/* Filter row */}
-      <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+      <div
+        className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm"
+        aria-busy={isNavigating}
+      >
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex-1">
             <input
               type="search"
-              value={search}
-              onChange={e => {
-                setSearch(e.target.value)
-                setPage(1)
-              }}
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
               placeholder={t('adminProducers.search.placeholder')}
               className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-light)] focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
             />
@@ -273,14 +253,11 @@ export function AdminProducersClient({ data }: Props) {
             </label>
             <select
               id="producers-sort"
-              value={sort}
-              onChange={e => {
-                setSort(e.target.value as SortKey)
-                setPage(1)
-              }}
+              value={params.sort}
+              onChange={e => updateParams({ sort: e.target.value, page: undefined })}
               className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-sm text-[var(--foreground)] focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
             >
-              {SORT_OPTIONS.map(opt => (
+              {PRODUCER_SORT_KEYS.map(opt => (
                 <option key={opt} value={opt}>
                   {t(`adminProducers.sort.${opt}` as TranslationKeys)}
                 </option>
@@ -289,16 +266,13 @@ export function AdminProducersClient({ data }: Props) {
           </div>
         </div>
         <div className="mt-3 flex flex-wrap gap-2">
-          {STATUS_FILTERS.map(f => {
-            const active = statusFilter === f
+          {PRODUCER_STATUS_FILTERS.map(f => {
+            const active = params.status === f
             return (
               <button
                 key={f}
                 type="button"
-                onClick={() => {
-                  setStatusFilter(f)
-                  setPage(1)
-                }}
+                onClick={() => updateParams({ status: f === 'ALL' ? undefined : f, page: undefined })}
                 className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition ${
                   active
                     ? 'border-emerald-500 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
@@ -315,7 +289,6 @@ export function AdminProducersClient({ data }: Props) {
         </div>
       </div>
 
-      {/* Table */}
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
         <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
           <table className="w-full min-w-[1100px] text-sm">
@@ -340,7 +313,7 @@ export function AdminProducersClient({ data }: Props) {
               {pageItems.length === 0 && (
                 <tr>
                   <td colSpan={10} className="px-4 py-12 text-center text-sm text-[var(--muted)]">
-                    {filtered.length === 0 && data.producers.length > 0
+                    {pagination.totalFiltered === 0 && globals.total > 0
                       ? t('adminProducers.noResults')
                       : t('adminProducers.empty')}
                   </td>
@@ -349,31 +322,37 @@ export function AdminProducersClient({ data }: Props) {
             </tbody>
           </table>
         </div>
-        {/* Pagination */}
-        {filtered.length > PAGE_SIZE && (
+        {pagination.totalFiltered > pagination.pageSize && (
           <div className="flex items-center justify-between gap-3 border-t border-[var(--border)] bg-[var(--background)] px-4 py-3 text-xs text-[var(--muted)]">
             <span>
               {t('adminProducers.pagination.range')
                 .replace('{from}', String(pageStart + 1))
-                .replace('{to}', String(Math.min(pageStart + PAGE_SIZE, filtered.length)))
-                .replace('{total}', String(filtered.length))}
+                .replace(
+                  '{to}',
+                  String(Math.min(pageStart + pagination.pageSize, pagination.totalFiltered))
+                )
+                .replace('{total}', String(pagination.totalFiltered))}
             </span>
             <div className="flex items-center gap-2">
               <button
                 type="button"
-                disabled={safePage <= 1}
-                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={pagination.page <= 1}
+                onClick={() => updateParams({ page: String(Math.max(1, pagination.page - 1)) })}
                 className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] disabled:opacity-40"
               >
                 {t('adminProducers.pagination.prev')}
               </button>
               <span>
-                {safePage} / {totalPages}
+                {pagination.page} / {pagination.totalPages}
               </span>
               <button
                 type="button"
-                disabled={safePage >= totalPages}
-                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={pagination.page >= pagination.totalPages}
+                onClick={() =>
+                  updateParams({
+                    page: String(Math.min(pagination.totalPages, pagination.page + 1)),
+                  })
+                }
                 className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] disabled:opacity-40"
               >
                 {t('adminProducers.pagination.next')}
@@ -439,7 +418,10 @@ function ProducerRow({
       </td>
       <td className="px-4 py-3">
         <div className="flex flex-col items-start gap-1">
-          <AdminStatusBadge label={t(`adminProducers.status.${p.status}` as TranslationKeys)} tone={getVendorStatusTone(p.status)} />
+          <AdminStatusBadge
+            label={t(`adminProducers.status.${p.status}` as TranslationKeys)}
+            tone={getVendorStatusTone(p.status)}
+          />
           <span className="text-[10px] text-[var(--muted-light)]">
             {p.stripeOnboarded
               ? t('adminProducers.stripe.complete')
@@ -453,9 +435,7 @@ function ProducerRow({
       <td className="px-4 py-3 text-right tabular-nums text-[var(--foreground)]">
         {p.ordersCount}
         <span className="ml-1 text-xs text-[var(--muted-light)]">
-          · {p.productsCount}
-          {' '}
-          {t('adminProducers.col.products')}
+          · {p.productsCount} {t('adminProducers.col.products')}
         </span>
       </td>
       <td className="px-4 py-3">
@@ -463,10 +443,7 @@ function ProducerRow({
           <div className="min-w-0">
             <p className="truncate font-medium text-[var(--foreground)]">{p.topProduct.name}</p>
             <p className="text-xs text-[var(--muted)]">
-              {t('adminProducers.topProduct.units').replace(
-                '{count}',
-                String(p.topProduct.unitsSold)
-              )}
+              {t('adminProducers.topProduct.units').replace('{count}', String(p.topProduct.unitsSold))}
             </p>
           </div>
         ) : (

--- a/src/components/admin/AdminProducersClient.tsx
+++ b/src/components/admin/AdminProducersClient.tsx
@@ -14,7 +14,7 @@ import {
   type EnrichedProducer,
   type ProducerStatusFilter,
   type ProducersOverview,
-} from '@/domains/admin/producers'
+} from '@/domains/admin/producers-schema'
 import type { VendorStatus } from '@/generated/prisma/enums'
 
 const SEARCH_DEBOUNCE_MS = 250

--- a/src/domains/admin/producers-schema.ts
+++ b/src/domains/admin/producers-schema.ts
@@ -1,0 +1,86 @@
+import type { VendorStatus } from '@/generated/prisma/enums'
+
+// Types + enum lists for the admin producers page. Isolated from
+// producers.ts (which imports `db` and is therefore server-only) so the
+// client component can import these without Turbopack trying to pull
+// pg / fs into the browser bundle.
+
+export const DEFAULT_PAGE_SIZE = 20
+
+export const PRODUCER_STATUS_FILTERS = [
+  'ALL',
+  'ACTIVE',
+  'APPLYING',
+  'PENDING_DOCS',
+  'SUSPENDED_TEMP',
+  'SUSPENDED_PERM',
+  'REJECTED',
+] as const
+export type ProducerStatusFilter = (typeof PRODUCER_STATUS_FILTERS)[number]
+
+export const PRODUCER_SORT_KEYS = [
+  'revenueDesc',
+  'revenueAsc',
+  'recent',
+  'lastSeen',
+  'name',
+  'orders',
+] as const
+export type ProducerSortKey = (typeof PRODUCER_SORT_KEYS)[number]
+
+export interface ProducerSparkPoint {
+  day: string
+  revenue: number
+}
+
+export interface EnrichedProducer {
+  id: string
+  slug: string
+  displayName: string
+  email: string
+  status: VendorStatus
+  description: string | null
+  location: string | null
+  logo: string | null
+  productsCount: number
+  stripeOnboarded: boolean
+  avgRating: number | null
+  totalReviews: number
+  createdAt: string
+  revenue: number
+  ordersCount: number
+  topProduct: { id: string; name: string; unitsSold: number } | null
+  lastSeenAt: string | null
+  sparkline: number[]
+}
+
+export interface ProducersOverviewParams {
+  page?: number
+  search?: string
+  status?: ProducerStatusFilter
+  sort?: ProducerSortKey
+}
+
+export interface ProducersOverview {
+  pageItems: EnrichedProducer[]
+  pagination: {
+    page: number
+    pageSize: number
+    totalFiltered: number
+    totalPages: number
+  }
+  params: {
+    search: string
+    status: ProducerStatusFilter
+    sort: ProducerSortKey
+  }
+  globals: {
+    total: number
+    active: number
+    pendingReview: number
+    suspended: number
+    gmv: number
+    orders: number
+  }
+  statusCounts: Record<VendorStatus, number>
+}

--- a/src/domains/admin/producers.ts
+++ b/src/domains/admin/producers.ts
@@ -14,6 +14,29 @@ const BILLED_STATUSES = [
 
 const SPARKLINE_DAYS = 14
 
+export const DEFAULT_PAGE_SIZE = 20
+
+export const PRODUCER_STATUS_FILTERS = [
+  'ALL',
+  'ACTIVE',
+  'APPLYING',
+  'PENDING_DOCS',
+  'SUSPENDED_TEMP',
+  'SUSPENDED_PERM',
+  'REJECTED',
+] as const
+export type ProducerStatusFilter = (typeof PRODUCER_STATUS_FILTERS)[number]
+
+export const PRODUCER_SORT_KEYS = [
+  'revenueDesc',
+  'revenueAsc',
+  'recent',
+  'lastSeen',
+  'name',
+  'orders',
+] as const
+export type ProducerSortKey = (typeof PRODUCER_SORT_KEYS)[number]
+
 export interface ProducerSparkPoint {
   day: string
   revenue: number
@@ -40,8 +63,26 @@ export interface EnrichedProducer {
   sparkline: number[]
 }
 
+export interface ProducersOverviewParams {
+  page?: number
+  search?: string
+  status?: ProducerStatusFilter
+  sort?: ProducerSortKey
+}
+
 export interface ProducersOverview {
-  producers: EnrichedProducer[]
+  pageItems: EnrichedProducer[]
+  pagination: {
+    page: number
+    pageSize: number
+    totalFiltered: number
+    totalPages: number
+  }
+  params: {
+    search: string
+    status: ProducerStatusFilter
+    sort: ProducerSortKey
+  }
   globals: {
     total: number
     active: number
@@ -85,8 +126,29 @@ function toNumber(value: string | number | bigint | null | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
-export async function getProducersOverview(): Promise<ProducersOverview> {
+export function normalizeProducersOverviewParams(
+  raw: ProducersOverviewParams | undefined
+): Required<Omit<ProducersOverviewParams, 'page'>> & { page: number; pageSize: number } {
+  const pageSize = DEFAULT_PAGE_SIZE
+  const page = Math.max(1, Math.floor(raw?.page ?? 1))
+  const search = (raw?.search ?? '').trim()
+  const status: ProducerStatusFilter = PRODUCER_STATUS_FILTERS.includes(
+    raw?.status as ProducerStatusFilter
+  )
+    ? (raw!.status as ProducerStatusFilter)
+    : 'ALL'
+  const sort: ProducerSortKey = PRODUCER_SORT_KEYS.includes(raw?.sort as ProducerSortKey)
+    ? (raw!.sort as ProducerSortKey)
+    : 'revenueDesc'
+  return { page, pageSize, search, status, sort }
+}
+
+export async function getProducersOverview(
+  rawParams: ProducersOverviewParams = {}
+): Promise<ProducersOverview> {
   await requireAdmin()
+  const params = normalizeProducersOverviewParams(rawParams)
+
   const [vendors, statusGroups, revenueRows, topProductRows, lastSeenRows, sparkRows] = await Promise.all([
     db.vendor.findMany({
       orderBy: { createdAt: 'desc' },
@@ -168,7 +230,6 @@ export async function getProducersOverview(): Promise<ProducersOverview> {
     lastSeenByVendor.set(row.vendorId, row.lastSeenAt ? row.lastSeenAt.toISOString() : null)
   }
 
-  // Build a 14-day index → 0 for each vendor, then fill from sparkRows.
   const today = new Date()
   today.setUTCHours(0, 0, 0, 0)
   const dayKeys: string[] = []
@@ -190,7 +251,7 @@ export async function getProducersOverview(): Promise<ProducersOverview> {
     arr[idx] = toNumber(row.revenue)
   }
 
-  const producers: EnrichedProducer[] = vendors.map(v => {
+  const allEnriched: EnrichedProducer[] = vendors.map(v => {
     const rev = revenueByVendor.get(v.id)
     return {
       id: v.id,
@@ -214,6 +275,47 @@ export async function getProducersOverview(): Promise<ProducersOverview> {
     }
   })
 
+  // Apply filter → sort → paginate server-side so the client only ever
+  // deserialises the visible page (~20 rows) instead of the whole table.
+  const searchLower = params.search.toLowerCase()
+  const filtered = allEnriched.filter(p => {
+    if (params.status !== 'ALL' && p.status !== params.status) return false
+    if (!searchLower) return true
+    return (
+      p.displayName.toLowerCase().includes(searchLower) ||
+      p.email.toLowerCase().includes(searchLower) ||
+      (p.location?.toLowerCase().includes(searchLower) ?? false)
+    )
+  })
+
+  const sorted = [...filtered]
+  switch (params.sort) {
+    case 'revenueDesc':
+      sorted.sort((a, b) => b.revenue - a.revenue)
+      break
+    case 'revenueAsc':
+      sorted.sort((a, b) => a.revenue - b.revenue)
+      break
+    case 'recent':
+      sorted.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      break
+    case 'lastSeen':
+      sorted.sort((a, b) => (b.lastSeenAt ?? '').localeCompare(a.lastSeenAt ?? ''))
+      break
+    case 'name':
+      sorted.sort((a, b) => a.displayName.localeCompare(b.displayName))
+      break
+    case 'orders':
+      sorted.sort((a, b) => b.ordersCount - a.ordersCount)
+      break
+  }
+
+  const totalFiltered = sorted.length
+  const totalPages = Math.max(1, Math.ceil(totalFiltered / params.pageSize))
+  const safePage = Math.min(params.page, totalPages)
+  const pageStart = (safePage - 1) * params.pageSize
+  const pageItems = sorted.slice(pageStart, pageStart + params.pageSize)
+
   const statusCounts: Record<VendorStatus, number> = {
     APPLYING: 0,
     PENDING_DOCS: 0,
@@ -226,19 +328,30 @@ export async function getProducersOverview(): Promise<ProducersOverview> {
     statusCounts[g.status] = g._count._all
   }
 
-  const gmv = producers.reduce((acc, p) => acc + p.revenue, 0)
-  const orders = producers.reduce((acc, p) => acc + p.ordersCount, 0)
+  const gmv = allEnriched.reduce((acc, p) => acc + p.revenue, 0)
+  const orders = allEnriched.reduce((acc, p) => acc + p.ordersCount, 0)
 
   return {
-    producers,
-    statusCounts,
+    pageItems,
+    pagination: {
+      page: safePage,
+      pageSize: params.pageSize,
+      totalFiltered,
+      totalPages,
+    },
+    params: {
+      search: params.search,
+      status: params.status,
+      sort: params.sort,
+    },
     globals: {
-      total: producers.length,
+      total: allEnriched.length,
       active: statusCounts.ACTIVE,
       pendingReview: statusCounts.APPLYING + statusCounts.PENDING_DOCS,
       suspended: statusCounts.SUSPENDED_TEMP + statusCounts.SUSPENDED_PERM,
       gmv,
       orders,
     },
+    statusCounts,
   }
 }

--- a/src/domains/admin/producers.ts
+++ b/src/domains/admin/producers.ts
@@ -1,6 +1,31 @@
+import 'server-only'
 import { db } from '@/lib/db'
 import type { VendorStatus } from '@/generated/prisma/enums'
 import { requireAdmin } from '@/lib/auth-guard'
+import {
+  DEFAULT_PAGE_SIZE,
+  PRODUCER_SORT_KEYS,
+  PRODUCER_STATUS_FILTERS,
+  type EnrichedProducer,
+  type ProducerSortKey,
+  type ProducerStatusFilter,
+  type ProducersOverview,
+  type ProducersOverviewParams,
+} from './producers-schema'
+
+// Re-export the schema surface so existing callers (page.tsx, tests) keep
+// their single-file import path while the DB-free types live in a sibling
+// module the client can safely import.
+export {
+  DEFAULT_PAGE_SIZE,
+  PRODUCER_SORT_KEYS,
+  PRODUCER_STATUS_FILTERS,
+  type EnrichedProducer,
+  type ProducerSortKey,
+  type ProducerStatusFilter,
+  type ProducersOverview,
+  type ProducersOverviewParams,
+}
 
 // Order statuses that count as "billed revenue" for a producer.
 // REFUNDED/CANCELLED are intentionally excluded.
@@ -13,86 +38,6 @@ const BILLED_STATUSES = [
 ] as const
 
 const SPARKLINE_DAYS = 14
-
-export const DEFAULT_PAGE_SIZE = 20
-
-export const PRODUCER_STATUS_FILTERS = [
-  'ALL',
-  'ACTIVE',
-  'APPLYING',
-  'PENDING_DOCS',
-  'SUSPENDED_TEMP',
-  'SUSPENDED_PERM',
-  'REJECTED',
-] as const
-export type ProducerStatusFilter = (typeof PRODUCER_STATUS_FILTERS)[number]
-
-export const PRODUCER_SORT_KEYS = [
-  'revenueDesc',
-  'revenueAsc',
-  'recent',
-  'lastSeen',
-  'name',
-  'orders',
-] as const
-export type ProducerSortKey = (typeof PRODUCER_SORT_KEYS)[number]
-
-export interface ProducerSparkPoint {
-  day: string
-  revenue: number
-}
-
-export interface EnrichedProducer {
-  id: string
-  slug: string
-  displayName: string
-  email: string
-  status: VendorStatus
-  description: string | null
-  location: string | null
-  logo: string | null
-  productsCount: number
-  stripeOnboarded: boolean
-  avgRating: number | null
-  totalReviews: number
-  createdAt: string
-  revenue: number
-  ordersCount: number
-  topProduct: { id: string; name: string; unitsSold: number } | null
-  lastSeenAt: string | null
-  sparkline: number[]
-}
-
-export interface ProducersOverviewParams {
-  page?: number
-  search?: string
-  status?: ProducerStatusFilter
-  sort?: ProducerSortKey
-}
-
-export interface ProducersOverview {
-  pageItems: EnrichedProducer[]
-  pagination: {
-    page: number
-    pageSize: number
-    totalFiltered: number
-    totalPages: number
-  }
-  params: {
-    search: string
-    status: ProducerStatusFilter
-    sort: ProducerSortKey
-  }
-  globals: {
-    total: number
-    active: number
-    pendingReview: number
-    suspended: number
-    gmv: number
-    orders: number
-  }
-  statusCounts: Record<VendorStatus, number>
-}
 
 interface RevenueRow {
   vendorId: string

--- a/test/integration/orders-auth-audit.test.ts
+++ b/test/integration/orders-auth-audit.test.ts
@@ -141,7 +141,7 @@ test('admin loaders accept SUPERADMIN sessions', async () => {
   const orders = await getAdminOrdersPageData({})
   assert.ok(Array.isArray(orders.orders))
   const producers = await getProducersOverview()
-  assert.ok(Array.isArray(producers.producers))
+  assert.ok(Array.isArray(producers.pageItems))
   const promos = await getPromotionsOverview()
   assert.ok(Array.isArray(promos.promotions))
   const subs = await getSubscriptionsOverview()


### PR DESCRIPTION
Closes #768 (part of epic #762).

Moves filter / sort / pagination of the admin producers table from the client to the server. The page now only ships ~20 rows per request instead of the full enriched producer list — scales cleanly beyond a few hundred producers.

## Changes
- `getProducersOverview` accepts `{ page, search, status, sort }` and returns `{ pageItems, pagination, params, globals, statusCounts }`. Old `producers` field renamed to `pageItems`.
- `/admin/productores` reads `searchParams`, passes them down, revalidates every 30s.
- `AdminProducersClient` is now URL-driven: search (debounced 250ms), status chips, sort selector and pagination all commit to query params via `router.replace` + `startTransition`. Filters survive reload.
- Integration test updated to the renamed field.

## Why aggregate queries stay full-scan

The enrichment (revenue, top product, sparkline, last seen) already aggregates by vendorId — narrowing by page would add SQL complexity for zero win under a few thousand producers. The real payload reduction is the RSC props shipped to the browser.

## Test plan
- [x] typecheck + lint clean
- [ ] Manually verify filters / sort / pagination drive URL + server query
- [ ] Back/forward restores filter state
- [ ] `/admin/productores?page=2&q=foo&status=ACTIVE&sort=name` loads correctly on cold navigation
- [ ] Integration suite passes

## Risk
Medium — admin-only surface, covered by smoke only indirectly. Contract change in `getProducersOverview` is internal; only known callers updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)