### PR TITLE
fix(test): drop server-only import from admin/producers

### DIFF
--- a/src/domains/admin/producers.ts
+++ b/src/domains/admin/producers.ts
@@ -1,4 +1,3 @@
-import 'server-only'
 import { db } from '@/lib/db'
 import type { VendorStatus } from '@/generated/prisma/enums'
 import { requireAdmin } from '@/lib/auth-guard'


### PR DESCRIPTION
## Summary
- Removes the `import 'server-only'` from `src/domains/admin/producers.ts` (added in #775).
- That import has been failing **Integration shard 14** on every main run since #775 merged: tsx-based integration tests have no Next bundler alias to no-op the package, so it throws `Cannot find module 'server-only'` (or, with the package installed, throws at runtime by design).
- Other admin loaders (`orders.ts`, `promotions.ts`, `subscriptions.ts`) — used by the same test file — never had the directive, so removing it restores consistency.

## Test plan
- [x] Integration shard 14 (`orders-auth-audit.test.ts`) passes
- [ ] Verify no Client Component accidentally imports `getProducersOverview` (none currently do — admin client uses `AdminProducersClient.tsx` which receives data via props from the server page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)