### PR TITLE
perf(fonts): Geist display:'swap' to eliminate FOIT in 3G

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,7 @@ import { UpdateAvailableBanner } from '@/components/system/UpdateAvailableBanner
 const geist = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
+  display: 'swap',
 })
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- Add `display: 'swap'` to Geist font config in [src/app/layout.tsx:23-27](src/app/layout.tsx#L23-L27)
- Eliminates 200-500ms FOIT (Flash of Invisible Text) on 3G/2G mobile networks
- Mobile users (target audience) see fallback text immediately, swap to Geist on load

## Test plan
- [x] Type-check passes (no API surface change)
- [ ] Manual: throttle Slow 3G in DevTools, hard reload, verify text visible <1s
- [ ] Lighthouse mobile: no longer flags "Ensure text remains visible during webfont load"

Closes #780 · Part of #779