### PR TITLE
feat(errors): global-error.tsx for root layout fallback

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -86,6 +86,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
             >
               Intentar de nuevo
             </button>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- global-error renders OUTSIDE the Next.js layout/router; next/link is unsafe here */}
             <a
               href="/"
               style={{

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+// global-error.tsx captures errors from the root layout itself, where
+// error.tsx cannot reach. It must render its own <html>/<body> and avoid
+// depending on globals.css since a CSS load failure may be the very
+// reason this boundary triggered. Styles are inline.
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  const [sentryEventId, setSentryEventId] = useState<string | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const Sentry = await import('@sentry/nextjs')
+        const id = Sentry.captureException(error, {
+          tags: { 'error.digest': error.digest ?? 'unknown', 'error.boundary': 'global' },
+        })
+        if (id) setSentryEventId(id)
+      } catch {
+        // Sentry not configured — the digest is still shown below.
+      }
+    })()
+  }, [error])
+
+  return (
+    <html lang="es">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '1.5rem',
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif',
+          background: '#fff',
+          color: '#111827',
+        }}
+      >
+        <main style={{ maxWidth: '32rem', textAlign: 'center' }}>
+          <h1 style={{ fontSize: '4rem', fontWeight: 700, margin: 0, color: '#dc2626' }}>500</h1>
+          <h2 style={{ fontSize: '1.5rem', fontWeight: 600, margin: '0.5rem 0 1rem' }}>
+            Algo ha salido mal
+          </h2>
+          <p style={{ fontSize: '1rem', lineHeight: 1.5, color: '#4b5563', margin: '0 0 1.5rem' }}>
+            Ha ocurrido un error inesperado. Nuestro equipo ha sido notificado. Por favor, inténtalo
+            de nuevo.
+          </p>
+          {(error.digest || sentryEventId) && (
+            <div
+              style={{
+                marginBottom: '1.5rem',
+                padding: '0.5rem 1rem',
+                background: '#f3f4f6',
+                borderRadius: '0.5rem',
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                fontSize: '0.75rem',
+                color: '#374151',
+              }}
+            >
+              {error.digest && <p style={{ margin: 0 }}>Error ID: {error.digest}</p>}
+              {sentryEventId && <p style={{ margin: 0 }}>Trace: {sentryEventId}</p>}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+            <button
+              onClick={reset}
+              style={{
+                minHeight: '44px',
+                padding: '0.75rem 2rem',
+                background: '#059669',
+                color: '#fff',
+                border: 'none',
+                borderRadius: '0.5rem',
+                fontWeight: 600,
+                fontSize: '1rem',
+                cursor: 'pointer',
+              }}
+            >
+              Intentar de nuevo
+            </button>
+            <a
+              href="/"
+              style={{
+                minHeight: '44px',
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: '0.75rem 2rem',
+                background: '#fff',
+                color: '#059669',
+                border: '2px solid #059669',
+                borderRadius: '0.5rem',
+                fontWeight: 600,
+                fontSize: '1rem',
+                textDecoration: 'none',
+              }}
+            >
+              Volver al inicio
+            </a>
+          </div>
+        </main>
+      </body>
+    </html>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `src/app/global-error.tsx` for root layout error boundary (Next.js convention)
- Captures errors that `error.tsx` cannot reach (root layout render, hydration mismatch at root)
- Mirrors `error.tsx` UX: 500 + message + Sentry event ID + retry/home buttons
- Inline styles only (no `globals.css` dependency — CSS load failure may be the trigger)
- Spanish strings hardcoded (i18n provider may be unavailable at this level)

## Test plan
- [x] Type-check + lint
- [ ] Manual: throw Error in root layout, verify global-error.tsx renders (not blank page)
- [ ] Manual: confirm Sentry event ID appears, retry button works
- [ ] Manual: tap targets ≥44px (matches #783 standard)

Closes #781 · Part of #779