### PR TITLE
a11y: tap target ≥44×44 in IosInstallHint dismiss

### DIFF
--- a/src/components/pwa/IosInstallHint.tsx
+++ b/src/components/pwa/IosInstallHint.tsx
@@ -97,7 +97,7 @@ export default function IosInstallHint() {
           type="button"
           onClick={onDismiss}
           aria-label={t('pwa.ios.hint.dismiss')}
-          className="flex-none rounded-lg p-1 text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
+          className="inline-flex min-h-11 min-w-11 flex-none items-center justify-center rounded-lg text-[var(--muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/30"
         >
           <XMarkIcon className="h-5 w-5" />
         </button>


### PR DESCRIPTION
## Summary
- Increase IosInstallHint dismiss button hit area from 24×24px → 44×44px (WCAG 2.5.5)
- Modal close button already met the standard (no change needed)
- Re-audit confirmed other interactive icons in the codebase use min-h-11 already

## Changed
- [src/components/pwa/IosInstallHint.tsx:100](src/components/pwa/IosInstallHint.tsx#L100): `p-1` → `inline-flex min-h-11 min-w-11 items-center justify-center`

## Test plan
- [x] Type-check
- [ ] Manual: open in iOS Safari, dismiss button is easily tappable
- [ ] Inspect: button computed size ≥44×44

Closes #783 · Part of #779