### PR TITLE
perf(images): loading=lazy in VendorHeroUpload cover+logo

### DIFF
--- a/src/components/vendor/VendorHeroUpload.tsx
+++ b/src/components/vendor/VendorHeroUpload.tsx
@@ -128,7 +128,13 @@ export function VendorHeroUpload({
           {hasCover ? (
             <>
               {/* eslint-disable-next-line @next/next/no-img-element -- vendor cover URL is from arbitrary storage (Vercel Blob, local uploads); routing it through next/image would force domain allow-list updates on every new tenant */}
-              <img src={coverValue} alt="" className="h-full w-full object-cover" />
+              <img
+                src={coverValue}
+                alt=""
+                className="h-full w-full object-cover"
+                loading="lazy"
+                decoding="async"
+              />
               <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 text-sm font-medium text-white opacity-0 transition group-hover:bg-black/40 group-hover:opacity-100 group-focus-visible:bg-black/40 group-focus-visible:opacity-100">
                 <span className="inline-flex items-center gap-1.5">
                   <CameraIcon className="h-4 w-4" />
@@ -175,7 +181,13 @@ export function VendorHeroUpload({
             {hasLogo ? (
               <>
                 {/* eslint-disable-next-line @next/next/no-img-element -- vendor logo URL is from arbitrary storage; same reason as the cover above */}
-                <img src={logoValue} alt="" className="h-full w-full object-cover" />
+                <img
+                  src={logoValue}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                />
                 <span className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition group-hover:bg-black/45 group-hover:opacity-100 group-focus-visible:bg-black/45 group-focus-visible:opacity-100">
                   <CameraIcon className="h-5 w-5 text-white" />
                 </span>


### PR DESCRIPTION
## Summary
- Add \`loading=\"lazy\"\` + \`decoding=\"async\"\` to vendor cover and logo \`<img>\` tags
- These are raw \`<img>\` (not next/image) by design — URLs come from arbitrary tenant storage (Vercel Blob, etc.) and routing through next/image would require domain allow-list updates per tenant (see existing eslint-disable comments)
- Cover is in the vendor profile editor, often below the initial fold

## Changed
- [src/components/vendor/VendorHeroUpload.tsx:131](src/components/vendor/VendorHeroUpload.tsx#L131): cover img
- [src/components/vendor/VendorHeroUpload.tsx:178](src/components/vendor/VendorHeroUpload.tsx#L178): logo img

## Test plan
- [x] Type-check
- [ ] Manual: open vendor profile editor on Slow 3G, verify cover/logo defer load until visible
- [ ] No regression in upload preview flow

Closes #784 · Part of #779