### PR TITLE
feat(lib): fetchWithTimeout helper

### DIFF
--- a/src/lib/fetch-with-timeout.ts
+++ b/src/lib/fetch-with-timeout.ts
@@ -1,0 +1,65 @@
+// fetch() in JavaScript has no default timeout — a stalled connection on a
+// degraded mobile network can hang indefinitely. Wrap fetch with an
+// AbortController that aborts after `timeoutMs` and surface the timeout
+// as a typed error so callers (and Sentry breadcrumbs / error mappers)
+// can distinguish it from a generic network failure.
+
+export class FetchTimeoutError extends Error {
+  readonly url: string
+  readonly timeoutMs: number
+
+  constructor(url: string, timeoutMs: number) {
+    super(`Fetch timed out after ${timeoutMs}ms: ${url}`)
+    this.name = 'FetchTimeoutError'
+    this.url = url
+    this.timeoutMs = timeoutMs
+  }
+}
+
+export interface FetchWithTimeoutOptions extends RequestInit {
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 8_000
+
+export async function fetchWithTimeout(
+  input: string | URL | Request,
+  options: FetchWithTimeoutOptions = {},
+): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: externalSignal, ...init } = options
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  // Compose with an externally-provided signal so callers can still cancel
+  // (e.g. React strict-mode unmount, route abort). If the external signal
+  // is already aborted at call time, mirror that immediately.
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort()
+    } else {
+      externalSignal.addEventListener('abort', () => controller.abort(), { once: true })
+    }
+  }
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } catch (err) {
+    // The AbortError shape is the same regardless of who aborted; we
+    // distinguish "we timed out" from "caller cancelled" by checking
+    // whether the external signal was the cause.
+    const isAbort = err instanceof Error && err.name === 'AbortError'
+    if (isAbort && !externalSignal?.aborted) {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+      throw new FetchTimeoutError(url, timeoutMs)
+    }
+    throw err
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/test/features/fetch-with-timeout.test.ts
+++ b/test/features/fetch-with-timeout.test.ts
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchWithTimeout, FetchTimeoutError } from '@/lib/fetch-with-timeout'
+
+const originalFetch = globalThis.fetch
+
+function withMockFetch(impl: typeof fetch, fn: () => Promise<void>) {
+  return async () => {
+    globalThis.fetch = impl as typeof fetch
+    try {
+      await fn()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  }
+}
+
+test(
+  'resolves normally when fetch responds before timeout',
+  withMockFetch(
+    async () => new Response('ok', { status: 200 }),
+    async () => {
+      const res = await fetchWithTimeout('https://example.test/x', { timeoutMs: 1000 })
+      assert.equal(res.status, 200)
+      assert.equal(await res.text(), 'ok')
+    },
+  ),
+)
+
+test(
+  'throws FetchTimeoutError when timeout fires before response',
+  withMockFetch(
+    (_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        // Respect the AbortSignal that fetchWithTimeout passes us.
+        const signal = (init as RequestInit)?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      }),
+    async () => {
+      await assert.rejects(
+        () => fetchWithTimeout('https://example.test/slow', { timeoutMs: 25 }),
+        (err: unknown) => {
+          assert.ok(err instanceof FetchTimeoutError, 'expected FetchTimeoutError')
+          assert.equal((err as FetchTimeoutError).timeoutMs, 25)
+          assert.match((err as FetchTimeoutError).url, /slow/)
+          return true
+        },
+      )
+    },
+  ),
+)
+
+test(
+  'composes external signal: caller cancellation propagates without becoming a timeout error',
+  withMockFetch(
+    (_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = (init as RequestInit)?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      }),
+    async () => {
+      const externalController = new AbortController()
+      const promise = fetchWithTimeout('https://example.test/x', {
+        timeoutMs: 5_000,
+        signal: externalController.signal,
+      })
+      externalController.abort()
+      await assert.rejects(promise, (err: unknown) => {
+        assert.ok(err instanceof Error)
+        // Caller-driven aborts surface as the original AbortError, NOT as
+        // FetchTimeoutError — the distinction matters for retry policy.
+        assert.equal((err as Error).name, 'AbortError')
+        assert.ok(!(err instanceof FetchTimeoutError))
+        return true
+      })
+    },
+  ),
+)
+
+test(
+  'pre-aborted external signal aborts the fetch immediately',
+  withMockFetch(
+    (_url, init) => {
+      const signal = (init as RequestInit)?.signal as AbortSignal | undefined
+      // The composed controller should already be aborted by the time
+      // fetch is called, so reject synchronously like a real fetch would.
+      if (signal?.aborted) {
+        const err = new Error('aborted')
+        err.name = 'AbortError'
+        return Promise.reject(err)
+      }
+      return Promise.resolve(new Response('ok'))
+    },
+    async () => {
+      const externalController = new AbortController()
+      externalController.abort()
+      await assert.rejects(
+        () =>
+          fetchWithTimeout('https://example.test/x', {
+            timeoutMs: 5_000,
+            signal: externalController.signal,
+          }),
+        (err: unknown) => (err as Error).name === 'AbortError',
+      )
+    },
+  ),
+)


### PR DESCRIPTION
## Summary
- Add \`src/lib/fetch-with-timeout.ts\` — fetch wrapped with AbortController and a typed \`FetchTimeoutError\`
- 4 unit tests covering: success path, timeout fires, external-signal cancellation (does NOT become timeout error), pre-aborted external signal
- Default 8s timeout; composable with caller-provided AbortSignal

## Why
fetch() in JS has no default timeout. On a degraded mobile network, this can hang indefinitely. The typed error lets retry policies (#787) and Sentry breadcrumbs distinguish timeouts from generic network failures.

## Scope of this PR
Helper + tests only. Adoption in cart/orders/Stripe server actions is a follow-up — keeps the diff reviewable and unblocks #787 which depends on the error type.

## Test plan
- [x] \`node --import tsx --test test/features/fetch-with-timeout.test.ts\` → 4/4 pass
- [x] No new typecheck errors introduced (pre-existing Prisma generation issues in this worktree are unrelated)

Closes #786 · Part of #779