### PR TITLE
ux(vendor): granular loading.tsx in 4 critical vendor routes

### DIFF
--- a/src/app/(vendor)/vendor/dashboard/loading.tsx
+++ b/src/app/(vendor)/vendor/dashboard/loading.tsx
@@ -1,0 +1,47 @@
+/**
+ * Dashboard skeleton: heading + 4 stat cards + alerts banner + main panel.
+ * Matches the actual page structure so the swap on data-arrival is shift-free.
+ */
+export default function Loading() {
+  return (
+    <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        {/* Page heading */}
+        <div className="space-y-2">
+          <div className="h-8 w-1/3 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+          <div className="h-4 w-1/2 rounded bg-neutral-100 dark:bg-neutral-900" />
+        </div>
+
+        {/* Stat cards (4) */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4"
+            >
+              <div className="h-4 w-1/2 rounded bg-neutral-100 dark:bg-neutral-900" />
+              <div className="mt-3 h-7 w-2/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+              <div className="mt-2 h-3 w-1/3 rounded bg-neutral-100 dark:bg-neutral-900" />
+            </div>
+          ))}
+        </div>
+
+        {/* Recent activity / alerts panel */}
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4">
+          <div className="h-5 w-1/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="mt-4 space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <div className="h-10 w-10 shrink-0 rounded-full bg-neutral-100 dark:bg-neutral-900" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-3/4 rounded bg-neutral-100 dark:bg-neutral-900" />
+                  <div className="h-3 w-1/2 rounded bg-neutral-100 dark:bg-neutral-900" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(vendor)/vendor/liquidaciones/loading.tsx
+++ b/src/app/(vendor)/vendor/liquidaciones/loading.tsx
@@ -1,0 +1,46 @@
+/**
+ * Settlements skeleton: heading + summary cards + chart + table.
+ * Mirrors the real page (period selector hidden initially).
+ */
+export default function Loading() {
+  return (
+    <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-6">
+        <div className="h-8 w-1/3 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+
+        {/* Summary cards (3) */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4"
+            >
+              <div className="h-3 w-1/2 rounded bg-neutral-100 dark:bg-neutral-900" />
+              <div className="mt-3 h-7 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+            </div>
+          ))}
+        </div>
+
+        {/* Chart placeholder */}
+        <div className="h-64 rounded-xl border border-[var(--border)] bg-[var(--surface)]" />
+
+        {/* Settlements table */}
+        <div className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface)]">
+          <div className="border-b border-[var(--border)] px-4 py-3">
+            <div className="h-4 w-1/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+          <div className="divide-y divide-[var(--border)]">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="grid grid-cols-4 gap-4 px-4 py-3">
+                <div className="h-3 rounded bg-neutral-100 dark:bg-neutral-900" />
+                <div className="h-3 rounded bg-neutral-100 dark:bg-neutral-900" />
+                <div className="h-3 rounded bg-neutral-100 dark:bg-neutral-900" />
+                <div className="h-3 rounded bg-neutral-100 dark:bg-neutral-900" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(vendor)/vendor/pedidos/loading.tsx
+++ b/src/app/(vendor)/vendor/pedidos/loading.tsx
@@ -1,0 +1,45 @@
+/**
+ * Orders skeleton: heading + filter bar + list of order rows (10 rows).
+ * Each row mirrors the real layout — image thumb, customer + status,
+ * actions on the right — so the data-arrival paint doesn't shift.
+ */
+export default function Loading() {
+  return (
+    <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-4">
+        {/* Heading */}
+        <div className="h-8 w-1/4 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+
+        {/* Filter bar */}
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-8 w-20 rounded-full bg-neutral-100 dark:bg-neutral-900"
+            />
+          ))}
+        </div>
+
+        {/* Order rows */}
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-3"
+            >
+              <div className="h-14 w-14 shrink-0 rounded-lg bg-neutral-100 dark:bg-neutral-900" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-1/3 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="h-3 w-1/2 rounded bg-neutral-100 dark:bg-neutral-900" />
+              </div>
+              <div className="hidden flex-col items-end gap-2 sm:flex">
+                <div className="h-5 w-16 rounded-full bg-neutral-100 dark:bg-neutral-900" />
+                <div className="h-3 w-12 rounded bg-neutral-100 dark:bg-neutral-900" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(vendor)/vendor/productos/loading.tsx
+++ b/src/app/(vendor)/vendor/productos/loading.tsx
@@ -1,0 +1,34 @@
+/**
+ * Products skeleton: heading + "Add" CTA + grid of product cards.
+ * Each card mirrors the real catalog item: image, name, price, status badge.
+ */
+export default function Loading() {
+  return (
+    <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="animate-pulse space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-1/4 rounded bg-emerald-100 dark:bg-emerald-900/40" />
+          <div className="h-10 w-32 rounded-lg bg-emerald-100 dark:bg-emerald-900/40" />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface)]"
+            >
+              <div className="aspect-square w-full bg-neutral-100 dark:bg-neutral-900" />
+              <div className="space-y-2 p-3">
+                <div className="h-4 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800" />
+                <div className="flex items-center justify-between">
+                  <div className="h-5 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
+                  <div className="h-5 w-16 rounded-full bg-neutral-100 dark:bg-neutral-900" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Add 4 route-specific \`loading.tsx\` files under \`/vendor/*\` so each navigation paints a skeleton that matches its destination, not a generic fallback.

| Route | Skeleton |
|-------|----------|
| dashboard | Heading + 4 stat cards + alerts panel |
| pedidos | Heading + filter bar + 8 order rows |
| productos | Heading + Add CTA + 6-card grid |
| liquidaciones | Summary cards + chart + table |

## Why
The \`(vendor)/loading.tsx\` layout-level fallback was reused across all 19 child routes — vendors on 3G saw a 2-3s "wrong layout" between click and render. Route-specific skeletons mean the swap to real data is shift-free.

## Out of scope
ajustes/perfil/promociones/suscripciones/valoraciones keep the layout-level fallback. They're lower-traffic; revisit if metrics show otherwise.

## Test plan
- [x] Build passes (skeletons are server components, no client bundle impact)
- [ ] Manual: throttle Slow 3G in DevTools, navigate dashboard → pedidos → productos → liquidaciones, see immediate skeleton matching destination

Closes #789 · Part of #779