### PR TITLE
feat(idempotency): adoption — createPromotion + advanceFulfillment (#788 PR-B)

### DIFF
--- a/src/domains/promotions/actions.ts
+++ b/src/domains/promotions/actions.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { getActionSession } from '@/lib/action-session'
 import { isVendor } from '@/lib/roles'
 import { safeRevalidatePath } from '@/lib/revalidate'
+import { withIdempotency } from '@/lib/idempotency'
 
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
@@ -42,65 +43,75 @@ type PromotionInput = z.infer<typeof promotionSchema>
  * Creates a new promotion for the authenticated vendor. The promotion is
  * dormant until phase 2 of the RFC wires it into checkout — this endpoint
  * only persists the intent.
+ *
+ * `idempotencyToken` is optional (legacy callers without it still work);
+ * when provided, double-submit on a flaky network is deduped at the
+ * IdempotencyKey level (#788).
  */
-export async function createPromotion(input: PromotionInput) {
-  const { vendor } = await requireVendor()
+export async function createPromotion(input: PromotionInput, idempotencyToken?: string) {
+  const { vendor, session } = await requireVendor()
   const data = promotionSchema.parse(input)
 
-  // Normalize the code: empty string → null so the unique index is not tripped
-  // by two NULL-ish codes colliding on the empty string.
-  const code = data.code && data.code.length > 0 ? data.code.toUpperCase() : null
+  const doCreate = async () => {
+    // Normalize the code: empty string → null so the unique index is not tripped
+    // by two NULL-ish codes colliding on the empty string.
+    const code = data.code && data.code.length > 0 ? data.code.toUpperCase() : null
 
-  if (code) {
-    const existing = await db.promotion.findFirst({
-      where: { vendorId: vendor.id, code },
-      select: { id: true },
-    })
-    if (existing) {
-      throw new Error('Ya tienes otra promoción con ese código')
+    if (code) {
+      const existing = await db.promotion.findFirst({
+        where: { vendorId: vendor.id, code },
+        select: { id: true },
+      })
+      if (existing) {
+        throw new Error('Ya tienes otra promoción con ese código')
+      }
     }
-  }
 
-  // Scope ownership: product/category must belong to the same vendor (product)
-  // or exist at all (category — categories are global).
-  if (data.scope === 'PRODUCT' && data.productId) {
-    const product = await db.product.findFirst({
-      where: { id: data.productId, vendorId: vendor.id, deletedAt: null },
-      select: { id: true },
+    // Scope ownership: product/category must belong to the same vendor (product)
+    // or exist at all (category — categories are global).
+    if (data.scope === 'PRODUCT' && data.productId) {
+      const product = await db.product.findFirst({
+        where: { id: data.productId, vendorId: vendor.id, deletedAt: null },
+        select: { id: true },
+      })
+      if (!product) throw new Error('Producto no encontrado')
+    }
+    if (data.scope === 'CATEGORY' && data.categoryId) {
+      const category = await db.category.findUnique({
+        where: { id: data.categoryId },
+        select: { id: true },
+      })
+      if (!category) throw new Error('Categoría no encontrada')
+    }
+
+    const value = data.kind === 'FREE_SHIPPING' ? 0 : data.value
+
+    const promotion = await db.promotion.create({
+      data: {
+        vendorId: vendor.id,
+        name: data.name,
+        code,
+        kind: data.kind,
+        value,
+        scope: data.scope,
+        productId: data.scope === 'PRODUCT' ? data.productId ?? null : null,
+        categoryId: data.scope === 'CATEGORY' ? data.categoryId ?? null : null,
+        minSubtotal: data.minSubtotal ?? null,
+        maxRedemptions: data.maxRedemptions ?? null,
+        perUserLimit: data.perUserLimit ?? 1,
+        startsAt: new Date(data.startsAt),
+        endsAt: new Date(data.endsAt),
+      },
     })
-    if (!product) throw new Error('Producto no encontrado')
-  }
-  if (data.scope === 'CATEGORY' && data.categoryId) {
-    const category = await db.category.findUnique({
-      where: { id: data.categoryId },
-      select: { id: true },
-    })
-    if (!category) throw new Error('Categoría no encontrada')
+
+    safeRevalidatePath('/vendor/promociones')
+    return promotion
   }
 
-  const value =
-    data.kind === 'FREE_SHIPPING' ? 0 : data.value
-
-  const promotion = await db.promotion.create({
-    data: {
-      vendorId: vendor.id,
-      name: data.name,
-      code,
-      kind: data.kind,
-      value,
-      scope: data.scope,
-      productId: data.scope === 'PRODUCT' ? data.productId ?? null : null,
-      categoryId: data.scope === 'CATEGORY' ? data.categoryId ?? null : null,
-      minSubtotal: data.minSubtotal ?? null,
-      maxRedemptions: data.maxRedemptions ?? null,
-      perUserLimit: data.perUserLimit ?? 1,
-      startsAt: new Date(data.startsAt),
-      endsAt: new Date(data.endsAt),
-    },
-  })
-
-  safeRevalidatePath('/vendor/promociones')
-  return promotion
+  if (idempotencyToken) {
+    return withIdempotency('promotion.create', idempotencyToken, session.user.id, doCreate)
+  }
+  return doCreate()
 }
 
 /**

--- a/src/domains/vendors/actions.ts
+++ b/src/domains/vendors/actions.ts
@@ -408,13 +408,18 @@ const VALID_TRANSITIONS: Partial<Record<FulfillmentStatus, FulfillmentStatus>> =
 /**
  * Advances a fulfillment to the next state.
  * Validates the transition is legal.
+ *
+ * `idempotencyToken` (#788) prevents a vendor's double-tap on a flaky
+ * mobile network from producing two transitions (e.g. PENDING → CONFIRMED
+ * twice firing two SHIPPED notifications). Optional for legacy callers.
  */
 export async function advanceFulfillment(
   fulfillmentId: string,
   trackingNumber?: string,
-  carrier?: string
+  carrier?: string,
+  idempotencyToken?: string,
 ) {
-  const { vendor } = await requireVendor()
+  const { vendor, session } = await requireVendor()
 
   const fulfillment = await db.vendorFulfillment.findFirst({
     where: { id: fulfillmentId, vendorId: vendor.id },
@@ -424,6 +429,7 @@ export async function advanceFulfillment(
   const nextStatus = VALID_TRANSITIONS[fulfillment.status]
   if (!nextStatus) throw new Error(`No se puede avanzar desde el estado ${fulfillment.status}`)
 
+  const doAdvance = async () => {
   await db.$transaction(async tx => {
     await tx.vendorFulfillment.update({
       where: { id: fulfillmentId },
@@ -466,6 +472,17 @@ export async function advanceFulfillment(
   }
 
   safeRevalidatePath('/vendor/pedidos')
+  }
+
+  if (idempotencyToken) {
+    return withIdempotency(
+      'fulfillment.advance',
+      idempotencyToken,
+      session.user.id,
+      doAdvance,
+    )
+  }
+  return doAdvance()
 }
 
 async function notifyBuyerFulfillmentShipped(


### PR DESCRIPTION
## Summary
PR-B of 2 for #788. Applies the \`withIdempotency()\` wrapper from #807 (PR-A) to 2 additional server actions to validate the pattern beyond the \`createProduct\` proof of concept.

**Base branch: \`feat/idempotency-foundation\` (#807).** Will be re-targeted to \`main\` once PR-A merges.

## Forms protected

### \`createPromotion\` — scope \`promotion.create\`
Double-tap on /vendor/promociones/nuevo (current behavior on flaky 3G) used to be able to create 2 rows with the same name. Now the second tap throws \`AlreadyProcessedError\`.

### \`advanceFulfillment\` — scope \`fulfillment.advance\`
The riskier one. Each transition fires:
- A Postgres transaction (fulfillment + maybe parent order status)
- Sometimes a SHIPPED notification via the dispatcher (#570 — both Telegram + web push)

A double-tap previously could fire 2 SHIPPED notifications. Now mutually excluded by the idempotency token.

## Forms intentionally NOT migrated

- \`updateVendorProfile\` — edits a single vendor record. Idempotent by design (a second update with different data MUST run). Wrapping here would be wrong.
- \`submitForReview\` — the guard \`status: { in: ['DRAFT', 'REJECTED'] }\` prevents the second submit on its own.
- \`updateProduct\` — same argument as \`updateVendorProfile\`.

The decision rule encoded in [docs/idempotency.md](docs/idempotency.md): wrap only forms that **create** resources or trigger **side-effecting transitions**, not forms that overwrite a single resource.

## Out of scope (follow-up)

End-to-end wiring of the client forms (PromotionForm, FulfillmentActions) — these need to:
1. Receive an \`idempotencyToken\` prop
2. Capture in \`useRef\`
3. Pass to the action call

The pages calling those forms also need \`force-dynamic\`. ~5 components, separate PR.

## Test plan
- [x] Type-check (no new errors introduced; pre-existing Prisma generation noise unrelated)
- [x] Action signatures backwards-compatible (token is optional)
- [ ] After client wiring: manual double-tap on flaky network produces single resource

Closes #788 (combined with PR-A #807) · Part of #779