### PR TITLE
obs: PostHog network events + SW analytics bridge

### DIFF
--- a/public/sw.template.js
+++ b/public/sw.template.js
@@ -148,11 +148,34 @@ function handleNavigation(event) {
       } catch {
         const cache = await caches.open(OFFLINE_CACHE)
         const cached = await cache.match(OFFLINE_URL)
-        if (cached) return cached
+        if (cached) {
+          // #793 telemetry: surface to PostHog via the client bridge
+          // how often users actually hit the offline fallback. PII-safe
+          // — only the pathname is sent, never query/fragment.
+          notifyClients({
+            type: 'analytics',
+            event: 'offline_fallback_shown',
+            props: {
+              attemptedPath: new URL(event.request.url).pathname,
+              swVersion: SW_VERSION,
+            },
+          })
+          return cached
+        }
         throw new Error('offline and no cached shell available')
       }
     })()
   )
+}
+
+function notifyClients(message) {
+  // Fire-and-forget broadcast to all controlled tabs. The bridge component
+  // forwards `type: 'analytics'` messages to PostHog.
+  self.clients.matchAll({ type: 'window' }).then((clients) => {
+    for (const client of clients) {
+      client.postMessage(message)
+    }
+  })
 }
 
 function handleStaticAsset(event) {
@@ -373,6 +396,17 @@ self.addEventListener('sync', (event) => {
           continue
         }
 
+        // #793: classify entry by URL pathname so PostHog can break down
+        // bg-sync replays per scope without exposing the raw URL.
+        const replayScope = url.pathname.startsWith('/api/cart')
+          ? url.pathname.includes('remove')
+            ? 'cart_remove'
+            : 'cart_add'
+          : url.pathname.includes('favorite')
+            ? 'favorite_toggle'
+            : 'other'
+        const ageMs = now - entry.createdAt
+
         try {
           const response = await fetch(entry.url, {
             method: entry.method,
@@ -382,9 +416,21 @@ self.addEventListener('sync', (event) => {
 
           if (response.ok || response.status === 409) {
             store.delete(entry.id)
+            notifyClients({
+              type: 'analytics',
+              event: 'bg_sync_replay',
+              props: { scope: replayScope, outcome: 'success', ageMs },
+            })
+          } else {
+            notifyClients({
+              type: 'analytics',
+              event: 'bg_sync_replay',
+              props: { scope: replayScope, outcome: 'failure', ageMs },
+            })
           }
         } catch {
-          // Network still down — leave in queue.
+          // Network still down — leave in queue. No analytics event
+          // here because we'll retry; only emit on terminal outcomes.
         }
       }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { CartHydrationProvider } from '@/components/buyer/CartHydrationProvider'
 import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
 import OfflineIndicator from '@/components/pwa/OfflineIndicator'
+import { SwAnalyticsBridge } from '@/components/pwa/SwAnalyticsBridge'
 import { BuildBadge } from '@/components/system/BuildBadge'
 import { UpdateAvailableBanner } from '@/components/system/UpdateAvailableBanner'
 
@@ -102,6 +103,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <WebVitalsReporter />
               <PwaRegister />
               <OfflineIndicator />
+              <SwAnalyticsBridge />
               <CartHydrationProvider />
               <UpdateAvailableBanner />
               {children}

--- a/src/components/pwa/SwAnalyticsBridge.tsx
+++ b/src/components/pwa/SwAnalyticsBridge.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+// Receives postMessage events from the service worker and forwards them
+// to PostHog. PostHog can't run inside the SW context (no window /
+// no document), so the SW posts a structured message and the client
+// re-emits it via the regular trackAnalyticsEvent path. This keeps a
+// single PII-scrubbing surface and keeps the SW free of analytics deps.
+//
+// Message shape (must match what public/sw.js posts):
+//   { type: 'analytics', event: string, props: Record<string, unknown> }
+//
+// Anything else is ignored — defensive against future SW message types.
+
+import { useEffect } from 'react'
+import { trackAnalyticsEvent } from '@/lib/analytics'
+
+interface AnalyticsMessage {
+  type: 'analytics'
+  event: string
+  props?: Record<string, unknown>
+}
+
+const isAnalyticsMessage = (data: unknown): data is AnalyticsMessage => {
+  if (!data || typeof data !== 'object') return false
+  const m = data as Record<string, unknown>
+  return m.type === 'analytics' && typeof m.event === 'string'
+}
+
+export function SwAnalyticsBridge(): null {
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return
+    const handler = (event: MessageEvent) => {
+      if (!isAnalyticsMessage(event.data)) return
+      trackAnalyticsEvent(event.data.event, event.data.props ?? {})
+    }
+    navigator.serviceWorker.addEventListener('message', handler)
+    return () => navigator.serviceWorker.removeEventListener('message', handler)
+  }, [])
+  return null
+}

--- a/src/lib/analytics/network-events.ts
+++ b/src/lib/analytics/network-events.ts
@@ -1,0 +1,88 @@
+// Network-resilience telemetry. PostHog events that surface what mobile
+// users experience when the network is degraded — so we can prioritize
+// future fixes with data instead of intuition.
+//
+// All these events are fail-open: if PostHog is misconfigured or down,
+// trackAnalyticsEvent is a no-op (see src/lib/analytics.ts). Never let
+// telemetry tumble user flows.
+//
+// PII RULES (mandatory): never include emails, addresses, full URLs with
+// query/path that could carry user IDs, or any token. Stick to the
+// shapes documented below.
+
+import { trackAnalyticsEvent } from '@/lib/analytics'
+
+export type NetworkErrorScope =
+  | 'cart'
+  | 'checkout'
+  | 'orders'
+  | 'favorites'
+  | 'product'
+  | 'auth'
+  | 'other'
+
+export type NetworkErrorType = 'timeout' | 'network' | 'abort' | '5xx' | 'unknown'
+
+export type EffectiveType = '4g' | '3g' | '2g' | 'slow-2g'
+
+export type BgSyncScope = 'cart_add' | 'cart_remove' | 'favorite_toggle' | 'other'
+
+interface NetworkErrorParams {
+  scope: NetworkErrorScope
+  errorType: NetworkErrorType
+  effectiveType?: EffectiveType
+  saveData?: boolean
+  retriesAttempted?: number
+}
+
+interface OfflineFallbackParams {
+  /** Path attempted (no query string, no fragment). */
+  attemptedPath: string
+  swVersion?: string
+}
+
+interface BgSyncReplayParams {
+  scope: BgSyncScope
+  outcome: 'success' | 'failure'
+  ageMs: number
+}
+
+interface PaymentRetryParams {
+  errorType: string
+  attemptNumber: number
+  /** Hashed checkoutAttemptId or null — never the raw token. */
+  checkoutAttemptHash?: string
+}
+
+interface ConnectionStateParams {
+  effectiveType?: EffectiveType
+  saveData?: boolean
+}
+
+export const trackNetworkError = (params: NetworkErrorParams): void => {
+  trackAnalyticsEvent('network_error', { ...params })
+}
+
+export const trackOfflineFallback = (params: OfflineFallbackParams): void => {
+  trackAnalyticsEvent('offline_fallback_shown', { ...params })
+}
+
+export const trackBgSyncReplay = (params: BgSyncReplayParams): void => {
+  trackAnalyticsEvent('bg_sync_replay', { ...params })
+}
+
+export const trackPaymentRetry = (params: PaymentRetryParams): void => {
+  trackAnalyticsEvent('payment_retry', { ...params })
+}
+
+export const trackConnectionSlowDetected = (params: ConnectionStateParams): void => {
+  trackAnalyticsEvent('connection_slow_detected', { ...params })
+}
+
+export const trackConnectionOffline = (): void => {
+  trackAnalyticsEvent('connection_offline', {})
+}
+
+export const trackConnectionRestored = (params: ConnectionStateParams = {}): void => {
+  trackAnalyticsEvent('connection_restored', { ...params })
+}

--- a/test/features/network-events.test.ts
+++ b/test/features/network-events.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// We can't easily stub `@/lib/analytics` from outside without a heavy
+// loader hook. Instead, swap the module's `capturePostHog` function via
+// a global probe (PostHog client is a no-op when env is missing) and
+// just assert the public-facing behavior: that each helper exists,
+// returns void, and accepts the documented param shapes without throwing.
+//
+// The real wire-up to PostHog is exercised by the existing analytics
+// tests; here we only need the contract.
+
+import {
+  trackNetworkError,
+  trackOfflineFallback,
+  trackBgSyncReplay,
+  trackPaymentRetry,
+  trackConnectionSlowDetected,
+  trackConnectionOffline,
+  trackConnectionRestored,
+} from '@/lib/analytics/network-events'
+
+test('all helpers exist and accept their documented param shapes', () => {
+  assert.equal(typeof trackNetworkError, 'function')
+  assert.equal(typeof trackOfflineFallback, 'function')
+  assert.equal(typeof trackBgSyncReplay, 'function')
+  assert.equal(typeof trackPaymentRetry, 'function')
+  assert.equal(typeof trackConnectionSlowDetected, 'function')
+  assert.equal(typeof trackConnectionOffline, 'function')
+  assert.equal(typeof trackConnectionRestored, 'function')
+})
+
+test('helpers do not throw with valid params', () => {
+  assert.doesNotThrow(() =>
+    trackNetworkError({
+      scope: 'cart',
+      errorType: 'timeout',
+      effectiveType: '3g',
+      saveData: false,
+      retriesAttempted: 2,
+    }),
+  )
+  assert.doesNotThrow(() => trackOfflineFallback({ attemptedPath: '/x', swVersion: 'abc' }))
+  assert.doesNotThrow(() => trackBgSyncReplay({ scope: 'cart_add', outcome: 'success', ageMs: 100 }))
+  assert.doesNotThrow(() =>
+    trackPaymentRetry({ errorType: 'card_declined', attemptNumber: 2 }),
+  )
+  assert.doesNotThrow(() => trackConnectionSlowDetected({ effectiveType: '2g', saveData: true }))
+  assert.doesNotThrow(() => trackConnectionOffline())
+  assert.doesNotThrow(() => trackConnectionRestored({ effectiveType: '4g' }))
+  assert.doesNotThrow(() => trackConnectionRestored())
+})
+
+test('helpers return void (fire-and-forget)', () => {
+  const result = trackNetworkError({ scope: 'other', errorType: 'unknown' })
+  assert.equal(result, undefined)
+})


### PR DESCRIPTION
## Summary
Adds the cabling for network-resilience telemetry without forcing the rest of the codebase to adopt it yet. Helpers + SW emission + tests; adoption sites are explicit follow-ups.

### Helpers (\`src/lib/analytics/network-events.ts\`)
7 typed helpers, all fail-open: \`trackNetworkError\`, \`trackOfflineFallback\`, \`trackBgSyncReplay\`, \`trackPaymentRetry\`, \`trackConnectionSlowDetected\`, \`trackConnectionOffline\`, \`trackConnectionRestored\`.

### SW bridge (\`src/components/pwa/SwAnalyticsBridge.tsx\`)
Mounted in root layout. Listens for \`type: 'analytics'\` postMessage from the service worker and forwards to PostHog via the regular \`trackAnalyticsEvent\` path (so PII scrubbing stays in one place; the SW has no analytics deps).

### SW emission (\`public/sw.template.js\`)
- \`offline_fallback_shown\` when the cached \`/offline\` shell serves a navigation. Sends \`attemptedPath\` (no query/fragment) + \`SW_VERSION\`.
- \`bg_sync_replay\` per replayed entry with \`scope\` (cart_add / cart_remove / favorite_toggle / other), \`outcome\` (success / failure) and \`ageMs\`. Failures from network-still-down do NOT emit (would create noise on every retry tick).

### Tests
3 contract tests for the helpers module. The PostHog wire-up itself is exercised by the existing analytics tests.

## Why
Without these events we have no data on how many users hit the offline fallback, which mutations get replayed, or how long bg-sync entries sit in the queue. The audit (#779) flagged this as the blocker for prioritizing later resilience work.

## Out of scope (follow-ups)
- Adopting \`trackNetworkError\` from inside #786 \`fetchWithTimeout\` retry exhaustion
- Adopting \`trackPaymentRetry\` from \`StripeCheckoutForm\` retry handler
- Adopting \`trackConnection*\` from #792 \`<ConnectionStatus/>\` component (next PR in fase 3)
- Building the PostHog "Mobile Network Health" dashboard

## Test plan
- [x] \`node --import tsx --test test/features/network-events.test.ts\` → 3/3 pass
- [x] \`scripts/build-sw.mjs\` produces a parseable \`public/sw.js\`
- [ ] Manual: throttle Offline in DevTools, navigate to a non-cached page, see \`offline_fallback_shown\` in PostHog Live Events
- [ ] Manual: enqueue a cart mutation while offline, restore network, see \`bg_sync_replay\` event

Closes #793 · Part of #779