### PR TITLE
feat(ux): ConnectionStatus banner + adaptive image quality

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import { getServerLocale } from '@/i18n/server'
 import PwaRegister from '@/components/pwa/PwaRegister'
 import OfflineIndicator from '@/components/pwa/OfflineIndicator'
 import { SwAnalyticsBridge } from '@/components/pwa/SwAnalyticsBridge'
+import { ConnectionStatus } from '@/components/pwa/ConnectionStatus'
 import { BuildBadge } from '@/components/system/BuildBadge'
 import { UpdateAvailableBanner } from '@/components/system/UpdateAvailableBanner'
 
@@ -104,6 +105,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <PwaRegister />
               <OfflineIndicator />
               <SwAnalyticsBridge />
+              <ConnectionStatus />
               <CartHydrationProvider />
               <UpdateAvailableBanner />
               {children}

--- a/src/components/catalog/SafeImage.tsx
+++ b/src/components/catalog/SafeImage.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import Image from 'next/image'
 import { PhotoIcon } from '@heroicons/react/24/outline'
+import { getAdaptiveImageQuality } from '@/lib/connection'
 
 interface SafeImageProps {
   src?: string | null
@@ -12,11 +13,18 @@ interface SafeImageProps {
   className?: string
   sizes?: string
   priority?: boolean
+  /** Override the auto-derived quality. Use only when you have a strong
+   *  reason (logo, hero, branding asset that must look the same on 2G). */
+  quality?: number
 }
 
 /**
- * Safely renders images with proper fallback handling
- * Used throughout the app for product images
+ * Safely renders images with proper fallback handling. Automatically
+ * adapts next/image `quality` to the user's connection (#792) — slow
+ * networks ship lighter assets, Save-Data is respected. Pass an
+ * explicit `quality` prop to opt out (logos, hero images, etc.).
+ *
+ * Used throughout the app for product images.
  */
 export function SafeImage({
   src,
@@ -26,9 +34,15 @@ export function SafeImage({
   className,
   sizes,
   priority = false,
+  quality,
 }: SafeImageProps) {
   const [hasError, setHasError] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
+
+  // Derive once per mount. We deliberately don't re-derive on connection
+  // change events: switching the quality mid-render would re-fetch every
+  // image, defeating the purpose. Refresh = re-derive.
+  const effectiveQuality = useMemo(() => quality ?? getAdaptiveImageQuality(), [quality])
 
   if (!src || hasError) {
     return (
@@ -60,6 +74,7 @@ export function SafeImage({
         onError={() => setHasError(true)}
         onLoadingComplete={() => setIsLoading(false)}
         priority={priority}
+        quality={effectiveQuality}
       />
     </>
   )

--- a/src/components/pwa/ConnectionStatus.tsx
+++ b/src/components/pwa/ConnectionStatus.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+// User-visible banner that surfaces 3 connection states:
+//   1. Offline — persistent until back online.
+//   2. Slow connection (effectiveType 2g/slow-2g) — auto-dismiss 5s.
+//   3. Save-Data enabled — auto-dismiss 5s.
+//
+// Also drives the connection_* PostHog events (#793) so we have data
+// on how often each state actually fires for real users.
+//
+// Implementation notes:
+// - Banner is sticky-top with z-index above the header but below modals.
+// - Respects `env(safe-area-inset-top)` so it doesn't sit under the iOS notch.
+// - Defensive against Safari (no NetworkInformation API) — only shows the
+//   offline banner there.
+
+import { useEffect, useState } from 'react'
+import { subscribeConnection, type EffectiveType } from '@/lib/connection'
+import {
+  trackConnectionOffline,
+  trackConnectionRestored,
+  trackConnectionSlowDetected,
+} from '@/lib/analytics/network-events'
+
+type BannerKind = 'offline' | 'slow' | 'savedata' | null
+
+const AUTO_DISMISS_MS = 5_000
+
+export function ConnectionStatus(): React.ReactElement | null {
+  const [kind, setKind] = useState<BannerKind>(null)
+  // Track previous state so we can fire `connection_restored` only on
+  // the actual offline → online transition, not on every change tick.
+  const [wasOffline, setWasOffline] = useState(false)
+
+  useEffect(() => {
+    let dismissTimer: ReturnType<typeof setTimeout> | undefined
+
+    const unsubscribe = subscribeConnection(({ effectiveType, saveData, online }) => {
+      if (dismissTimer) clearTimeout(dismissTimer)
+
+      if (!online) {
+        setKind('offline')
+        if (!wasOffline) {
+          trackConnectionOffline()
+          setWasOffline(true)
+        }
+        return
+      }
+
+      if (wasOffline) {
+        trackConnectionRestored({ effectiveType: effectiveType as EffectiveType | undefined })
+        setWasOffline(false)
+      }
+
+      if (saveData) {
+        setKind('savedata')
+        trackConnectionSlowDetected({ effectiveType: effectiveType as EffectiveType | undefined, saveData: true })
+        dismissTimer = setTimeout(() => setKind(null), AUTO_DISMISS_MS)
+        return
+      }
+
+      if (effectiveType === '2g' || effectiveType === 'slow-2g') {
+        setKind('slow')
+        trackConnectionSlowDetected({ effectiveType: effectiveType as EffectiveType, saveData: false })
+        dismissTimer = setTimeout(() => setKind(null), AUTO_DISMISS_MS)
+        return
+      }
+
+      setKind(null)
+    })
+
+    return () => {
+      unsubscribe()
+      if (dismissTimer) clearTimeout(dismissTimer)
+    }
+  }, [wasOffline])
+
+  if (kind === null) return null
+
+  const label =
+    kind === 'offline'
+      ? 'Estás sin conexión. Algunas acciones se sincronizarán al volver.'
+      : kind === 'slow'
+        ? 'Conexión lenta. Algunas funciones pueden tardar.'
+        : 'Modo ahorro de datos activo. Mostramos imágenes en menor calidad.'
+
+  const tone =
+    kind === 'offline'
+      ? 'bg-amber-100 text-amber-900 dark:bg-amber-950/50 dark:text-amber-200'
+      : 'bg-sky-100 text-sky-900 dark:bg-sky-950/50 dark:text-sky-200'
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`sticky top-0 z-30 w-full px-4 py-2 text-sm font-medium ${tone}`}
+      style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top))' }}
+    >
+      {label}
+    </div>
+  )
+}

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,0 +1,86 @@
+// Connection-aware utilities. Wraps `navigator.connection` (Network
+// Information API) with graceful fallback for browsers that don't
+// support it (Safari, Firefox at the time of writing).
+//
+// All functions are safe to call on the server (return undefined) and
+// in browsers without the API.
+
+export type EffectiveType = '4g' | '3g' | '2g' | 'slow-2g'
+
+interface NetworkInformation extends EventTarget {
+  readonly effectiveType?: EffectiveType
+  readonly saveData?: boolean
+  readonly downlink?: number
+  readonly rtt?: number
+}
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: NetworkInformation
+  mozConnection?: NetworkInformation
+  webkitConnection?: NetworkInformation
+}
+
+const getConnection = (): NetworkInformation | undefined => {
+  if (typeof navigator === 'undefined') return undefined
+  const nav = navigator as NavigatorWithConnection
+  return nav.connection ?? nav.mozConnection ?? nav.webkitConnection
+}
+
+export const getEffectiveType = (): EffectiveType | undefined => {
+  return getConnection()?.effectiveType
+}
+
+export const isSaveDataEnabled = (): boolean => {
+  return getConnection()?.saveData === true
+}
+
+export const isSlowConnection = (): boolean => {
+  const t = getEffectiveType()
+  return t === '2g' || t === 'slow-2g'
+}
+
+/**
+ * Subscribe to connection changes. Returns an unsubscribe function.
+ * Calls `cb` once immediately with the current state, then on every
+ * `change` event from `navigator.connection`.
+ */
+export const subscribeConnection = (
+  cb: (info: { effectiveType?: EffectiveType; saveData: boolean; online: boolean }) => void,
+): (() => void) => {
+  const conn = getConnection()
+  const emit = () =>
+    cb({
+      effectiveType: conn?.effectiveType,
+      saveData: conn?.saveData === true,
+      online: typeof navigator === 'undefined' ? true : navigator.onLine,
+    })
+
+  emit()
+
+  const handler = () => emit()
+  conn?.addEventListener?.('change', handler)
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', handler)
+    window.addEventListener('offline', handler)
+  }
+  return () => {
+    conn?.removeEventListener?.('change', handler)
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('online', handler)
+      window.removeEventListener('offline', handler)
+    }
+  }
+}
+
+/**
+ * Returns the recommended next/image quality (0-100) for the current
+ * connection. Used by adaptive image components to ship lighter assets
+ * on slow networks without hardcoding the policy in every callsite.
+ */
+export const getAdaptiveImageQuality = (): number => {
+  if (isSaveDataEnabled()) return 50
+  const t = getEffectiveType()
+  if (t === '2g' || t === 'slow-2g') return 50
+  if (t === '3g') return 70
+  return 85 // 4g+ or unknown — Next default is 75, we go a touch higher.
+}

--- a/test/features/connection.test.ts
+++ b/test/features/connection.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Stub navigator.connection per-test by writing onto globalThis.
+// The lib reads navigator at call time, not at import time, so this works.
+const setConnection = (info: { effectiveType?: string; saveData?: boolean } | undefined) => {
+  if (typeof globalThis.navigator === 'undefined') {
+    ;(globalThis as unknown as { navigator: unknown }).navigator = {}
+  }
+  ;(globalThis.navigator as unknown as { connection?: unknown }).connection = info
+}
+
+import {
+  getEffectiveType,
+  isSaveDataEnabled,
+  isSlowConnection,
+  getAdaptiveImageQuality,
+} from '@/lib/connection'
+
+test('getEffectiveType returns the value when API present', () => {
+  setConnection({ effectiveType: '3g' })
+  assert.equal(getEffectiveType(), '3g')
+})
+
+test('getEffectiveType returns undefined when API absent', () => {
+  setConnection(undefined)
+  assert.equal(getEffectiveType(), undefined)
+})
+
+test('isSaveDataEnabled true / false / undefined', () => {
+  setConnection({ saveData: true })
+  assert.equal(isSaveDataEnabled(), true)
+  setConnection({ saveData: false })
+  assert.equal(isSaveDataEnabled(), false)
+  setConnection(undefined)
+  assert.equal(isSaveDataEnabled(), false)
+})
+
+test('isSlowConnection only true on 2g / slow-2g', () => {
+  setConnection({ effectiveType: '4g' })
+  assert.equal(isSlowConnection(), false)
+  setConnection({ effectiveType: '3g' })
+  assert.equal(isSlowConnection(), false)
+  setConnection({ effectiveType: '2g' })
+  assert.equal(isSlowConnection(), true)
+  setConnection({ effectiveType: 'slow-2g' })
+  assert.equal(isSlowConnection(), true)
+  setConnection(undefined)
+  assert.equal(isSlowConnection(), false)
+})
+
+test('getAdaptiveImageQuality matches the policy table', () => {
+  setConnection({ saveData: true })
+  assert.equal(getAdaptiveImageQuality(), 50)
+
+  setConnection({ effectiveType: 'slow-2g' })
+  assert.equal(getAdaptiveImageQuality(), 50)
+
+  setConnection({ effectiveType: '2g' })
+  assert.equal(getAdaptiveImageQuality(), 50)
+
+  setConnection({ effectiveType: '3g' })
+  assert.equal(getAdaptiveImageQuality(), 70)
+
+  setConnection({ effectiveType: '4g' })
+  assert.equal(getAdaptiveImageQuality(), 85)
+
+  setConnection(undefined)
+  assert.equal(getAdaptiveImageQuality(), 85)
+})


### PR DESCRIPTION
## Summary
The app now adapts to the user's network speed and tells them explicitly when their connection is degraded — replacing "app feels broken" with "I know my network is slow."

**Base: \`main\`. Depends on #809 (network-events helpers)** — those telemetry helpers are imported by the new banner.

## What ships

### \`src/lib/connection.ts\`
Native wrappers around the Network Information API with graceful fallback for Safari / Firefox:
- \`getEffectiveType\` / \`isSaveDataEnabled\` / \`isSlowConnection\`
- \`subscribeConnection\` — stream of changes with unsubscribe
- \`getAdaptiveImageQuality\` — central policy: \`4g+\` → 85, \`3g\` → 70, \`2g\`/Save-Data → 50

### \`<ConnectionStatus />\` banner (mounted in root layout)
3 surfaces:
- **Offline** — persistent until back online
- **Slow connection** (\`2g\` / \`slow-2g\`) — auto-dismiss 5s
- **Save-Data** — auto-dismiss 5s

Respects \`env(safe-area-inset-top)\` so it doesn't sit under the iOS notch. \`role="status" aria-live="polite"\`. Fires the \`connection_*\` events from #809 so we get usage data on day one.

### Adaptive image quality in \`SafeImage\`
\`SafeImage\` (used everywhere for product images) now derives \`quality\` from the connection at mount. Callers can pass an explicit \`quality\` prop to opt out — used for logos / hero / branding assets that must look the same regardless of network.

Quality is derived **once per mount**, not on every connection-change event — switching mid-session would re-fetch every visible image, defeating the purpose.

### Tests
5 tests covering the helper across all connection states including \`undefined\` (the Safari fallback path).

## Test plan
- [x] \`node --import tsx --test test/features/connection.test.ts\` → 5/5 pass
- [ ] DevTools → Network → Slow 3G → reload → verify \`SafeImage\` requests use \`q=70\`
- [ ] DevTools → Network → Offline → verify amber banner persists
- [ ] DevTools → Network → throttle Slow 3G → see sky banner auto-dismiss after 5s
- [ ] iPhone X simulator: banner respects notch (top padding adapts)

Closes #792 · Part of #779