### PR TITLE
feat(cart): BroadcastChannel sync between tabs

### DIFF
--- a/src/components/buyer/CartHydrationProvider.tsx
+++ b/src/components/buyer/CartHydrationProvider.tsx
@@ -7,6 +7,7 @@ import {
   loadServerCart,
   mergeLocalIntoServerCart,
 } from '@/domains/orders/cart-actions'
+import { installCartBroadcast } from '@/domains/orders/cart-broadcast'
 import {
   getCartHydrationAction,
 } from './cart-hydration-plan'
@@ -29,6 +30,13 @@ import { CART_MERGED_FLAG_KEY } from './cart-session'
 export function CartHydrationProvider() {
   const { data, status } = useSession()
   const hasHydratedRef = useRef<string | null>(null)
+
+  // #795: cross-tab cart sync. Mount once for the lifetime of the
+  // provider — installCartBroadcast is idempotent and gracefully
+  // no-ops in browsers without BroadcastChannel.
+  useEffect(() => {
+    return installCartBroadcast()
+  }, [])
 
   useEffect(() => {
     if (status !== 'authenticated') {

--- a/src/domains/orders/cart-broadcast.ts
+++ b/src/domains/orders/cart-broadcast.ts
@@ -1,0 +1,106 @@
+// Cross-tab cart sync via BroadcastChannel (#795).
+//
+// Without this, a user with /productos/foo open in two tabs adds an
+// item in tab A and tab B keeps showing the old cart until they
+// reload — a confusing UX especially on PWAs where users keep multiple
+// tabs around.
+//
+// Strategy:
+// - localStorage is the source of truth (Zustand `persist` already
+//   writes to it on every state change).
+// - This module broadcasts a SIGNAL over BroadcastChannel saying
+//   "something changed, re-read localStorage". Receivers do not trust
+//   the message payload — they re-read localStorage to avoid race
+//   conditions with the persist middleware.
+// - Each tab generates a unique SOURCE_ID at module load. Tabs ignore
+//   their own broadcasts to prevent loops.
+//
+// Browser support: all modern browsers including iOS Safari 15.4+.
+// Older Safari silently no-ops (cart still works, just no cross-tab
+// sync) — the feature degrades gracefully.
+
+'use client'
+
+import { useCartStore, type CartItem } from './cart-store'
+
+const CHANNEL_NAME = 'mp-cart-sync'
+const STORAGE_KEY = 'cart-storage'
+
+let channel: BroadcastChannel | null = null
+let sourceId = ''
+let installed = false
+
+interface BroadcastMessage {
+  sourceId: string
+  reason: 'add' | 'remove' | 'updateQty' | 'clear' | 'hydrate'
+}
+
+const isSupported = (): boolean =>
+  typeof window !== 'undefined' && typeof BroadcastChannel !== 'undefined'
+
+const readStoredItems = (): CartItem[] => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as { state?: { items?: CartItem[] } }
+    return parsed.state?.items ?? []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Set up cross-tab cart sync. Idempotent: multiple calls are no-ops
+ * after the first. Returns a cleanup function.
+ *
+ * Mount once, near the top of the client tree (CartHydrationProvider
+ * is the natural home).
+ */
+export function installCartBroadcast(): () => void {
+  if (installed || !isSupported()) return () => {}
+  installed = true
+
+  sourceId = crypto.randomUUID()
+  channel = new BroadcastChannel(CHANNEL_NAME)
+
+  // Receive: someone else changed the cart, re-hydrate from localStorage.
+  channel.addEventListener('message', (event) => {
+    const data = event.data as BroadcastMessage | undefined
+    if (!data || data.sourceId === sourceId) return
+    const items = readStoredItems()
+    useCartStore.setState({ items })
+  })
+
+  // Also re-hydrate when the tab returns to foreground. Safari iOS
+  // suspends background tabs aggressively, so a BroadcastChannel
+  // message could be missed; reading localStorage on visibility flip
+  // is a cheap belt-and-braces.
+  const onVisibility = () => {
+    if (document.visibilityState !== 'visible') return
+    const items = readStoredItems()
+    const current = useCartStore.getState().items
+    if (JSON.stringify(items) !== JSON.stringify(current)) {
+      useCartStore.setState({ items })
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibility)
+
+  // Subscribe to local store mutations and broadcast every change.
+  // Zustand calls the listener after the new state is committed, so
+  // `persist` has already written to localStorage by the time we fire.
+  let lastSerialized = JSON.stringify(useCartStore.getState().items)
+  const unsubscribeStore = useCartStore.subscribe((state) => {
+    const serialized = JSON.stringify(state.items)
+    if (serialized === lastSerialized) return
+    lastSerialized = serialized
+    channel?.postMessage({ sourceId, reason: 'hydrate' } satisfies BroadcastMessage)
+  })
+
+  return () => {
+    unsubscribeStore()
+    document.removeEventListener('visibilitychange', onVisibility)
+    channel?.close()
+    channel = null
+    installed = false
+  }
+}

--- a/test/features/cart-broadcast.test.ts
+++ b/test/features/cart-broadcast.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Smoke test: installCartBroadcast should be importable, idempotent,
+// and graceful when BroadcastChannel is missing (the Safari < 15.4
+// fallback path). We don't exercise the full cross-tab flow here —
+// that requires a browser environment with two windows. The
+// install/cleanup contract is what we care about for unit-level
+// regression coverage.
+
+import { installCartBroadcast } from '@/domains/orders/cart-broadcast'
+
+test('installCartBroadcast returns a cleanup function in environments without BroadcastChannel', () => {
+  // In the Node test runner there's no BroadcastChannel global by
+  // default — the `isSupported()` check should bail out and return a
+  // no-op cleanup.
+  const cleanup = installCartBroadcast()
+  assert.equal(typeof cleanup, 'function')
+  // Calling cleanup must not throw.
+  assert.doesNotThrow(() => cleanup())
+})
+
+test('multiple installs are idempotent (no duplicate listeners)', () => {
+  const a = installCartBroadcast()
+  const b = installCartBroadcast()
+  assert.equal(typeof a, 'function')
+  assert.equal(typeof b, 'function')
+  assert.doesNotThrow(() => {
+    a()
+    b()
+  })
+})


### PR DESCRIPTION
## Summary
Cross-tab cart sync via \`BroadcastChannel\`. A user with the marketplace open in two tabs now sees both carts stay consistent without reloading.

**Base: \`main\`. Depends on #810** (rebase target after #810 merges).

## Strategy
- \`localStorage\` is the source of truth (Zustand \`persist\` already writes there on every change).
- \`BroadcastChannel\` carries a SIGNAL ("something changed, re-read localStorage"), not the payload — avoids race conditions with the persist middleware.
- Each tab generates a unique \`sourceId\` at module load and ignores its own broadcasts (no loops).
- \`visibilitychange\` listener re-hydrates when a backgrounded tab returns to the foreground — Safari iOS suspends background tabs aggressively and could miss broadcasts.

## Files
- \`src/domains/orders/cart-broadcast.ts\` — \`installCartBroadcast()\` returns a cleanup function. Idempotent. Gracefully no-ops on Safari < 15.4 (cart still works, just no cross-tab sync).
- \`CartHydrationProvider\` — mounts the broadcast in a separate \`useEffect\`. Independent of the auth-merge flow; works for anonymous users too.

## Test plan
- [x] \`node --import tsx --test test/features/cart-broadcast.test.ts\` → 2/2 pass (install + idempotency contract)
- [ ] Manual cross-tab: open /productos/X in 2 tabs, add item in A, see it appear in B within ~100ms
- [ ] Manual: same flow with B in background, then bring B foreground → cart hydrates from localStorage
- [ ] Manual on Safari without BroadcastChannel: cart works, no errors

## Out of scope
The full cross-tab flow needs a browser environment with two windows — not unit-testable. Manual tests in the test plan cover the regression.

Closes #795 · Part of #779