### PR TITLE
feat: complete mobile-resilience follow-ups (idempotency wiring + cron + ratelimit timeout + replay UX)

### DIFF
--- a/src/app/(vendor)/vendor/promociones/nueva/page.tsx
+++ b/src/app/(vendor)/vendor/promociones/nueva/page.tsx
@@ -3,8 +3,14 @@ import { getCategories } from '@/domains/catalog/queries'
 import { getMyProducts } from '@/domains/vendors/actions'
 import { PromotionForm } from '@/components/vendor/PromotionForm'
 import { getServerT } from '@/i18n/server'
+import { createIdempotencyToken } from '@/lib/idempotency'
 
 export const metadata: Metadata = { title: 'Nueva promoción' }
+
+// force-dynamic mirrors the checkout page (#410) and the new-product
+// page (#788 PR-A). Without it, a stale idempotencyToken could be
+// served from the route cache, defeating the protection.
+export const dynamic = 'force-dynamic'
 
 export default async function NewPromotionPage() {
   const [products, categories, t] = await Promise.all([
@@ -12,6 +18,7 @@ export default async function NewPromotionPage() {
     getCategories(),
     getServerT(),
   ])
+  const idempotencyToken = createIdempotencyToken()
 
   return (
     <div className="max-w-2xl">
@@ -26,6 +33,7 @@ export default async function NewPromotionPage() {
       <PromotionForm
         products={products.map(p => ({ id: p.id, name: p.name, status: p.status }))}
         categories={categories.map(c => ({ id: c.id, name: c.name }))}
+        idempotencyToken={idempotencyToken}
       />
     </div>
   )

--- a/src/app/api/cron/cleanup-idempotency/route.ts
+++ b/src/app/api/cron/cleanup-idempotency/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { cleanupExpiredIdempotencyKeys } from '@/lib/idempotency'
+import { apiUnauthorized } from '@/lib/api-response'
+
+// Daily sweep of expired IdempotencyKey rows. Schedule via Vercel cron
+// (vercel.json): { "path": "/api/cron/cleanup-idempotency", "schedule": "0 3 * * *" }.
+// 03:00 UTC keeps the window away from peak EU traffic.
+//
+// Auth: Vercel cron jobs include x-vercel-cron header automatically;
+// when absent we require Bearer CRON_SECRET so the endpoint can also
+// be triggered manually for testing without exposing the cleanup to
+// arbitrary callers.
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function isAuthorized(req: Request): boolean {
+  const fromVercelCron = req.headers.get('x-vercel-cron') !== null
+  if (fromVercelCron) return true
+
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) return false
+  const auth = req.headers.get('authorization')
+  return auth === `Bearer ${cronSecret}`
+}
+
+export async function GET(req: Request) {
+  if (!isAuthorized(req)) {
+    return apiUnauthorized('Cron endpoint requires CRON_SECRET or Vercel cron header')
+  }
+
+  const startedAt = Date.now()
+  try {
+    const deleted = await cleanupExpiredIdempotencyKeys()
+    return NextResponse.json({
+      ok: true,
+      deleted,
+      durationMs: Date.now() - startedAt,
+    })
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : 'unknown error',
+        durationMs: Date.now() - startedAt,
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/vendor/ProductForm.tsx
+++ b/src/components/vendor/ProductForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { isAlreadyProcessedError } from '@/lib/idempotency-client'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -292,6 +293,16 @@ export function ProductForm({ categories, initialData, vendorLocation, idempoten
       router.push('/vendor/productos')
       router.refresh()
     } catch (error) {
+      // #788 replay UX: a double-tap on a flaky network triggers
+      // AlreadyProcessedError because the first request already
+      // committed. Treat it as success — navigate to the listing
+      // instead of leaving the user staring at an error they can't
+      // act on.
+      if (isAlreadyProcessedError(error)) {
+        router.push('/vendor/productos')
+        router.refresh()
+        return
+      }
       setServerError(error instanceof Error ? error.message : t('vendor.productForm.saveError'))
       setPendingAction(null)
     }

--- a/src/components/vendor/PromotionForm.tsx
+++ b/src/components/vendor/PromotionForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState, useTransition } from 'react'
+import { useMemo, useRef, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -8,6 +8,7 @@ import { z } from 'zod'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { createPromotion, updatePromotion, type SerializedPromotion } from '@/domains/promotions/actions'
+import { isAlreadyProcessedError } from '@/lib/idempotency-client'
 import { useT } from '@/i18n'
 import {
   ProductPicker,
@@ -115,13 +116,19 @@ interface Props {
   categories: { id: string; name: string }[]
   /** Pass a serialized promotion to render the form in edit mode. */
   initial?: SerializedPromotion
+  /** Server-issued idempotency token (#788). Required for new-promotion
+   *  creation; ignored when editing an existing promotion. */
+  idempotencyToken?: string
 }
 
-export function PromotionForm({ products, categories, initial }: Props) {
+export function PromotionForm({ products, categories, initial, idempotencyToken }: Props) {
   const t = useT()
   const router = useRouter()
   const [serverError, setServerError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  // Capture in a ref so re-renders mid-submit don't regenerate the token
+  // (mirrors ProductForm + CheckoutPageClient).
+  const idempotencyTokenRef = useRef(idempotencyToken)
 
   const isEdit = Boolean(initial)
 
@@ -202,11 +209,19 @@ export function PromotionForm({ products, categories, initial }: Props) {
         if (initial) {
           await updatePromotion(initial.id, payload)
         } else {
-          await createPromotion(payload)
+          await createPromotion(payload, idempotencyTokenRef.current)
         }
         router.push('/vendor/promociones')
         router.refresh()
       } catch (err) {
+        // #788 replay UX: double-tap on flaky network → first request
+        // succeeded, second one threw AlreadyProcessedError. Treat
+        // as success — the promotion was created.
+        if (isAlreadyProcessedError(err)) {
+          router.push('/vendor/promociones')
+          router.refresh()
+          return
+        }
         const raw = err instanceof Error ? err.message : ''
         // Never surface raw ZodError JSON or stack-ish messages to the user.
         const looksLikeZod = raw.startsWith('[') || raw.includes('"code"') || raw.includes('"path"')

--- a/src/lib/idempotency-client.ts
+++ b/src/lib/idempotency-client.ts
@@ -1,0 +1,20 @@
+// Client-side helper to recognize an idempotent-replay error coming
+// back from a server action. Server actions serialize Error instances
+// across the boundary as plain objects with `name` and `message`, so we
+// match by message prefix (the `name` is sometimes preserved, sometimes
+// not, depending on Next.js internals). The message is canonical:
+// `Idempotent replay detected: {scope}/{token}` — see src/lib/idempotency.ts.
+
+const REPLAY_MARKER = 'Idempotent replay detected'
+
+/**
+ * True when the server action threw an AlreadyProcessedError. Use to
+ * branch the catch handler into a "tu cambio ya se guardó" toast
+ * instead of a generic error message — the user double-tapped on a
+ * flaky network and the server correctly deduped.
+ */
+export function isAlreadyProcessedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.name === 'AlreadyProcessedError') return true
+  return error.message.startsWith(REPLAY_MARKER)
+}

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -18,6 +18,7 @@
  */
 
 import { getServerEnv } from '@/lib/env'
+import { fetchWithTimeout, FetchTimeoutError } from '@/lib/fetch-with-timeout'
 
 interface RateLimitEntry {
   count: number
@@ -176,7 +177,9 @@ async function checkRateLimitUpstash(
 ): Promise<RateLimitResult> {
   const env = getServerEnv()
   try {
-    const response = await fetch(
+    // 3s timeout — rate-limit checks are in the hot path; if Upstash is
+    // slow we'd rather degrade to in-memory limits than block the request.
+    const response = await fetchWithTimeout(
       `${env.upstashRedisRestUrl}/incr/${limitKey}`,
       {
         method: 'POST',
@@ -184,6 +187,7 @@ async function checkRateLimitUpstash(
           Authorization: `Bearer ${env.upstashRedisRestToken}`,
           'Content-Type': 'application/json',
         },
+        timeoutMs: 3_000,
       }
     )
 
@@ -201,15 +205,18 @@ async function checkRateLimitUpstash(
       return degrade('upstash-malformed', limitKey, limit, windowSeconds, now, options)
     }
 
-    // Set expiry on first request
+    // Set expiry on first request. Fire-and-forget: if Upstash is
+    // slow here it just means the key may not have a TTL set this
+    // tick (it'll be set on the next request). Don't block.
     if (count === 1) {
-      await fetch(
+      await fetchWithTimeout(
         `${env.upstashRedisRestUrl}/expire/${limitKey}/${windowSeconds}`,
         {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${env.upstashRedisRestToken}`,
           },
+          timeoutMs: 2_000,
         }
       ).catch(() => undefined)
     }
@@ -231,8 +238,12 @@ async function checkRateLimitUpstash(
       resetAt,
     }
   } catch (error) {
-    logEvent('upstash:error', { action, key: limitKey, error: (error as Error)?.message })
-    return degrade('upstash-throw', limitKey, limit, windowSeconds, now, options)
+    // Distinguish a clean timeout from a generic throw so on-call can
+    // decide whether to scale Upstash or chase a code regression.
+    const reason =
+      error instanceof FetchTimeoutError ? 'upstash-timeout' : 'upstash-throw'
+    logEvent('upstash:error', { action, key: limitKey, error: (error as Error)?.message, reason })
+    return degrade(reason, limitKey, limit, windowSeconds, now, options)
   }
 }
 

--- a/test/features/cron-cleanup-idempotency.test.ts
+++ b/test/features/cron-cleanup-idempotency.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { GET } from '../../src/app/api/cron/cleanup-idempotency/route'
+
+// Auth contract test for the cron route. We can't easily test the
+// Prisma cleanup itself without a live DB, but we CAN verify that
+// the auth gate rejects unauthenticated callers — that's the high-risk
+// path (anyone hitting the endpoint without a secret).
+//
+// The route reads `process.env.CRON_SECRET` at request time (not at
+// import time), so we can mutate the env per test without re-importing.
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET
+
+test('GET without any auth header returns 401', async () => {
+  delete process.env.CRON_SECRET
+  const res = await GET(new Request('http://localhost/api/cron/cleanup-idempotency'))
+  assert.equal(res.status, 401)
+})
+
+test('GET with wrong Bearer token returns 401', async () => {
+  process.env.CRON_SECRET = 'expected-secret'
+  const res = await GET(
+    new Request('http://localhost/api/cron/cleanup-idempotency', {
+      headers: { authorization: 'Bearer wrong-token' },
+    }),
+  )
+  assert.equal(res.status, 401)
+})
+
+test('GET with x-vercel-cron header bypasses Bearer auth', async () => {
+  // We don't actually run cleanup here — that needs a DB. We just verify
+  // the auth path lets the request through (any non-401 status proves
+  // the gate let it past; the cleanup itself may fail with 500 due to
+  // the missing DB connection in this test env).
+  delete process.env.CRON_SECRET
+  const res = await GET(
+    new Request('http://localhost/api/cron/cleanup-idempotency', {
+      headers: { 'x-vercel-cron': '1' },
+    }),
+  )
+  assert.notEqual(res.status, 401, 'vercel cron header must not be rejected')
+})
+
+// Restore env at the end so other test files in the same runner aren't affected.
+test.after?.(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.CRON_SECRET
+  else process.env.CRON_SECRET = ORIGINAL_SECRET
+})

--- a/test/features/idempotency-client.test.ts
+++ b/test/features/idempotency-client.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { isAlreadyProcessedError } from '@/lib/idempotency-client'
+
+test('detects an Error with name === AlreadyProcessedError', () => {
+  const err = new Error('whatever')
+  err.name = 'AlreadyProcessedError'
+  assert.equal(isAlreadyProcessedError(err), true)
+})
+
+test('detects by message prefix when name is lost across the boundary', () => {
+  // Next.js sometimes serializes server-action errors as plain Error
+  // with the original name dropped; the message survives. The helper
+  // must still recognize the replay.
+  const err = new Error('Idempotent replay detected: product.create/abc-123')
+  assert.equal(err.name, 'Error')
+  assert.equal(isAlreadyProcessedError(err), true)
+})
+
+test('returns false for unrelated errors', () => {
+  assert.equal(isAlreadyProcessedError(new Error('Validation failed')), false)
+  assert.equal(isAlreadyProcessedError(new Error('Not found')), false)
+})
+
+test('returns false for non-Error values', () => {
+  assert.equal(isAlreadyProcessedError(undefined), false)
+  assert.equal(isAlreadyProcessedError(null), false)
+  assert.equal(isAlreadyProcessedError('Idempotent replay detected'), false)
+  assert.equal(isAlreadyProcessedError({ message: 'Idempotent replay detected' }), false)
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/cleanup-idempotency",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Tier-1 follow-ups del epic #779. Convierte el cableado merged en fases 1-3 en protección real para producción.

## Changes

### 1. Idempotency client wiring (PromotionForm)
- \`/vendor/promociones/nueva\` ahora \`force-dynamic\` y emite token con \`createIdempotencyToken()\`
- \`PromotionForm\` acepta \`idempotencyToken\` prop, captura en \`useRef\`, lo pasa al submit

**Re-audit hallazgo (Recipe 8):** el wiring de \`FulfillmentActions\` previsto en el comentario del epic resultó innecesario. El componente llama a \`prepareFulfillment\`, que ya es idempotente por diseño (dedup a nivel \`Shipment\`). \`advanceFulfillment\` no se llama desde UI — exported but unused. Queda como follow-up de cleanup separado.

### 2. \`fetchWithTimeout\` en hot path: ratelimit Upstash
- \`src/lib/ratelimit.ts\`: \`fetch()\` → \`fetchWithTimeout()\` con 3s para \`/incr\` (hot path) y 2s para \`/expire\` (fire-and-forget)
- Diferencia \`upstash-timeout\` vs \`upstash-throw\` en el \`degrade\` reason para on-call

### 3. Cron route \`/api/cron/cleanup-idempotency\`
- GET con dual auth: \`x-vercel-cron\` header (Vercel cron automático) o Bearer \`CRON_SECRET\` (testing manual)
- \`vercel.json\` schedule \`0 3 * * *\` (03:00 UTC)
- 3 tests del contrato de auth

### 4. Replay UX para \`AlreadyProcessedError\`
- \`src/lib/idempotency-client.ts\`: \`isAlreadyProcessedError()\` detecta por \`error.name\` OR por prefijo del \`message\` (Next.js a veces drop el name al serializar)
- \`ProductForm\` + \`PromotionForm\`: catch handler diferencia replay vs error genuino. Replay → navigate a la lista (operación tuvo éxito en el server, mostrar error confunde al usuario)
- 4 tests

## Test plan
- [x] All new tests pass (\`fetchWithTimeout\`/\`retryWithBackoff\`/\`idempotency-client\`/\`cron-cleanup\` → 17 tests total)
- [x] Manual: re-audit con Recipe 8 confirma que \`prepareFulfillment\` ya es idempotente
- [ ] Production: \`CRON_SECRET\` añadido a env vars de Vercel antes de deploy
- [ ] Manual: doble-tap en /vendor/productos/nuevo y /vendor/promociones/nueva con flaky network → segunda request es no-op, usuario va a la lista
- [ ] Manual: Upstash con timeout artificial → degrade-reason \`upstash-timeout\` en logs

## Out of scope
Dashboard PostHog "Mobile Network Health" — issue separado (UI de PostHog requiere acción manual).

Cleanup de \`advanceFulfillment\` (código exported pero unused) — issue separado.