### PR TITLE
fix(ui/tooltip): touch fallback, viewport cap, side swap on <sm

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,9 @@
 /* ─── Dark mode via class (.dark en <html>) ─────────────────────────────── */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* ─── Touch devices (no hover) ──────────────────────────────────────────── */
+@custom-variant pointer-coarse (@media (hover: none));
+
 /* ─── Design tokens — Light ─────────────────────────────────────────────── */
 :root {
   --background:       #f5f2ec;

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -5,25 +5,46 @@ interface TooltipProps {
   content: React.ReactNode
   side?: 'top' | 'right' | 'bottom' | 'left'
   className?: string
+  /**
+   * If the wrapped child is not a focusable control (e.g. a plain icon span),
+   * set `interactive` so the wrapper itself becomes focusable. This is what
+   * enables the touch fallback (focus-within) on devices without hover.
+   */
+  interactive?: boolean
 }
 
 const SIDE_STYLES: Record<NonNullable<TooltipProps['side']>, string> = {
   top: 'bottom-full left-1/2 mb-2 -translate-x-1/2',
-  right: 'left-full top-1/2 ml-2 -translate-y-1/2',
+  // On <sm we collapse left/right into bottom to avoid escaping the viewport.
+  right:
+    'left-full top-1/2 ml-2 -translate-y-1/2 max-sm:left-1/2 max-sm:top-full max-sm:mt-2 max-sm:ml-0 max-sm:-translate-x-1/2 max-sm:translate-y-0',
   bottom: 'left-1/2 top-full mt-2 -translate-x-1/2',
-  left: 'right-full top-1/2 mr-2 -translate-y-1/2',
+  left:
+    'right-full top-1/2 mr-2 -translate-y-1/2 max-sm:left-1/2 max-sm:right-auto max-sm:top-full max-sm:mt-2 max-sm:mr-0 max-sm:-translate-x-1/2 max-sm:translate-y-0',
 }
 
-export function Tooltip({ children, content, side = 'top', className }: TooltipProps) {
+export function Tooltip({
+  children,
+  content,
+  side = 'top',
+  className,
+  interactive = false,
+}: TooltipProps) {
   return (
-    <span className={cn('group/tooltip relative inline-flex', className)}>
+    <span
+      className={cn('group/tooltip relative inline-flex', className)}
+      tabIndex={interactive ? 0 : undefined}
+    >
       {children}
       <span
         role="tooltip"
         className={cn(
-          'pointer-events-none absolute z-20 w-max max-w-56 rounded-lg bg-slate-950 px-2.5 py-1.5 text-center text-[11px] font-medium text-white shadow-lg',
+          // Never exceed viewport minus a 1rem gutter on each side.
+          'pointer-events-none absolute z-50 w-max max-w-[min(14rem,calc(100vw-2rem))] rounded-lg bg-slate-950 px-2.5 py-1.5 text-center text-[11px] font-medium text-white shadow-lg',
           'opacity-0 transition-opacity duration-150',
           'group-hover/tooltip:opacity-100 group-focus-within/tooltip:opacity-100',
+          // Touch (coarse pointer): suppress hover-stuck state, rely on focus only.
+          'pointer-coarse:group-hover/tooltip:opacity-0 pointer-coarse:group-focus-within/tooltip:opacity-100',
           SIDE_STYLES[side]
         )}
       >

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -350,6 +350,37 @@ test('PDP purchase panel renders a mobile-only sticky add-to-cart bar', () => {
   assert.match(source, /IntersectionObserver/, 'sticky CTA must toggle via IntersectionObserver on the inline CTA')
 })
 
+test('Tooltip primitive caps width to viewport, swaps left/right to bottom on <sm, and silences hover on touch', () => {
+  const source = read('src/components/ui/tooltip.tsx')
+  assert.match(
+    source,
+    /max-w-\[min\(14rem,calc\(100vw-2rem\)\)\]/,
+    'tooltip width must be capped to viewport minus a 1rem gutter so it never escapes on narrow screens',
+  )
+  assert.match(
+    source,
+    /max-sm:left-1\/2[\s\S]*max-sm:top-full/,
+    'side="right" must collapse to bottom on <sm to avoid escaping the right edge',
+  )
+  assert.match(
+    source,
+    /max-sm:left-1\/2[\s\S]*max-sm:top-full[\s\S]*max-sm:left-1\/2[\s\S]*max-sm:top-full/,
+    'side="left" must also collapse to bottom on <sm',
+  )
+  assert.match(
+    source,
+    /pointer-coarse:group-hover\/tooltip:opacity-0/,
+    'on touch (hover: none) the hover-stuck state must be suppressed so tooltips do not linger after a tap',
+  )
+
+  const css = read('src/app/globals.css')
+  assert.match(
+    css,
+    /@custom-variant pointer-coarse \(@media \(hover: none\)\)/,
+    'globals.css must declare the pointer-coarse custom variant the Tooltip relies on',
+  )
+})
+
 test('cart page renders a mobile-only sticky checkout bar', () => {
   const source = read('src/components/buyer/CartPageClient.tsx')
   assert.match(source, /fixed inset-x-0 bottom-0[^"]*lg:hidden/, 'cart must render a mobile-only fixed checkout bar')


### PR DESCRIPTION
## Summary

- Tooltips no longer get \"stuck\" after a tap on touch devices: a new \`pointer-coarse\` custom variant (\`@media (hover: none)\`) suppresses the hover-only opacity rule so touch users only see tooltips via focus-within.
- \`side=\"right\"\` / \`side=\"left\"\` collapse to \`bottom\` on \`<sm\` via \`max-sm:\` classes — fixes the ProductFiltersPanel certification info tooltip that escaped the right edge on phones.
- Tooltip width capped to \`min(14rem, calc(100vw - 2rem))\` so it never exceeds the viewport minus a 1rem gutter (224px was 60% of an iPhone SE).
- z-index bumped \`z-20 → z-50\` so tooltips sit above the sticky header (z-40).
- New \`interactive\` prop lets call-sites that wrap a non-focusable child opt the wrapper into \`tabIndex=0\`.

Single primitive at [src/components/ui/tooltip.tsx](src/components/ui/tooltip.tsx) is consumed by ProductCard, ProductFiltersPanel and AutoTranslatedBadge — fixing the root fixes all four touchpoints. Recharts tooltips in admin charts are unaffected and tracked as a follow-up.

Anchored by a new \`mobile-ux\` contract test that asserts the width cap, the left/right → bottom swap, the pointer-coarse hover suppression and the custom variant declaration.

## Test plan
- [x] \`npx tsx --test test/contracts/mobile-ux.test.ts\` — 30/30 pass (incl. new tooltip contract)
- [ ] Manual at 375×667 (iPhone SE) on dev tunnel: tap a ProductCard cert badge — tooltip appears, does not escape right edge, dismisses on tap-elsewhere
- [ ] Manual: open /productos filters drawer on mobile, tap the cert info icon — tooltip appears below, not to the right
- [ ] Sanity: hover behaviour unchanged on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)