### PR TITLE
fix(mobile): clip document overflow + hero stats + vendor search wrap

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -175,7 +175,7 @@ export default async function HomePage() {
                   </Link>
                 </div>
 
-                <div className="mt-10 grid grid-cols-3 gap-6 border-t border-white/10 pt-8">
+                <div className="mt-10 grid grid-cols-1 gap-4 border-t border-white/10 pt-8 sm:grid-cols-3 sm:gap-6">
                   {heroStats.map(s => (
                     <div key={s.labelKey}>
                       <p className="text-2xl font-bold text-white">{formatStat(s, locale, t)}</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,6 +59,10 @@ html {
   color-scheme: light;
   background: var(--background);
   scroll-behavior: smooth;
+  /* Defensive guard: if anything overflows in X, clip it instead of letting
+   * the document gain a horizontal scrollbar. `clip` (vs `hidden`) does not
+   * create a new scroll context, so position: sticky descendants keep working. */
+  overflow-x: clip;
 }
 
 html.dark {
@@ -71,6 +75,7 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), sans-serif;
   -webkit-font-smoothing: antialiased;
+  overflow-x: clip;
 }
 
 /* Safe-area insets for notch / home indicator on iOS (viewport-fit=cover). */

--- a/src/components/vendor/VendorProductListClient.tsx
+++ b/src/components/vendor/VendorProductListClient.tsx
@@ -178,7 +178,7 @@ export function VendorProductListClient({ products }: Props) {
         <>
           {/* Toolbar: search + view toggle */}
           <div className="flex items-center gap-3 flex-wrap">
-            <div className="relative flex-1 min-w-[220px]">
+            <div className="relative flex-1 min-w-0 basis-full sm:basis-auto sm:min-w-[220px]">
               <MagnifyingGlassIcon className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--muted)]" />
               <input
                 type="search"

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -343,3 +343,42 @@ test('cart page renders a mobile-only sticky checkout bar', () => {
   assert.match(source, /fixed inset-x-0 bottom-0[^"]*lg:hidden/, 'cart must render a mobile-only fixed checkout bar')
   assert.match(source, /env\(safe-area-inset-bottom\)/, 'cart sticky bar must honour the home-indicator safe area')
 })
+
+test('html and body clip horizontal overflow so a stray wide child cannot scroll the page', () => {
+  const css = read('src/app/globals.css')
+  // `overflow-x: clip` on html+body is a defensive guard: any child that
+  // escapes its container is simply clipped, never gains a horizontal
+  // scrollbar at document level. We use `clip` (not `hidden`) so that
+  // descendants with `position: sticky` keep working.
+  assert.match(
+    css,
+    /html[\s\S]*?overflow-x:\s*clip/,
+    'globals.css must clip horizontal overflow on <html>',
+  )
+  assert.match(
+    css,
+    /body[\s\S]*?overflow-x:\s*clip/,
+    'globals.css must clip horizontal overflow on <body>',
+  )
+})
+
+test('public hero stats stack on mobile instead of squeezing into 3 narrow columns', () => {
+  const source = read('src/app/(public)/page.tsx')
+  assert.match(
+    source,
+    /grid-cols-1[^"]*sm:grid-cols-3/,
+    'hero stats must use grid-cols-1 on mobile and sm:grid-cols-3 from sm+',
+  )
+})
+
+test('vendor product list search input occupies the full row on mobile', () => {
+  const source = read('src/components/vendor/VendorProductListClient.tsx')
+  // The toolbar wraps already, but the search field had a 220px floor that
+  // pushed the view-toggle group below on every mobile viewport. We now
+  // collapse the floor below sm so the search and toggle line up cleanly.
+  assert.match(
+    source,
+    /min-w-0 basis-full sm:basis-auto sm:min-w-\[220px\]/,
+    'search input must drop its 220px min-width on mobile and span the row',
+  )
+})


### PR DESCRIPTION
## Summary

Three layered fixes for the mobile horizontal-scroll problem reported on several pages:

- **Defensive guard** in [src/app/globals.css](src/app/globals.css): \`html { overflow-x: clip }\` + same on \`body\`. Prevents any stray wide child from giving the document a horizontal scrollbar. Uses \`clip\` (not \`hidden\`) so \`position: sticky\` descendants (the Header) keep working.
- **Public hero stats** ([src/app/(public)/page.tsx#L178](src/app/(public)/page.tsx#L178)): the row used \`grid-cols-3\` at all viewports → each cell ~93px wide on a 375px phone. Now \`grid-cols-1 gap-4\` on mobile, \`sm:grid-cols-3 sm:gap-6\` from sm+.
- **Vendor product list search** ([src/components/vendor/VendorProductListClient.tsx#L181](src/components/vendor/VendorProductListClient.tsx#L181)): the 220px \`min-w\` floor pushed the view-toggle group below on every mobile viewport. Now \`min-w-0 basis-full sm:basis-auto sm:min-w-[220px]\` so search spans the row on mobile and lines up with the toggle from sm+.

Three new \`mobile-ux\` contract tests anchor the changes so a refactor can't silently regress them.

### Out of scope (follow-up)

Wrapping the heavier admin grid tables (\`comisiones\` / \`envios\` / \`auditoria\` / \`notificaciones\`) in horizontal-scroll containers. Each needs a per-table \`min-width\` decision and visual review — cleaner as a separate PR. The defensive \`overflow-x: clip\` in this PR already prevents those tables from scrolling the whole page.

Pairs with #815 (Tooltip touch fallback + viewport-aware width).

## Test plan
- [x] \`npx tsx --test test/contracts/mobile-ux.test.ts\` — 32/32 pass (3 new)
- [ ] Manual at 375×667: home loads with no horizontal scrollbar; hero stats stack vertically; vendor /productos toolbar — search field fills the row, view-toggle on the next line
- [ ] Sanity: desktop \`>=sm\` renders 3-column hero stats and inline search+toggle as before
- [ ] Sticky header on home still sticks while scrolling (regression check for \`overflow-x: clip\` interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)