### PR TITLE
fix(admin): contain admin-table horizontal scroll inside the card on mobile

### DIFF
--- a/src/app/(admin)/admin/auditoria/page.tsx
+++ b/src/app/(admin)/admin/auditoria/page.tsx
@@ -98,7 +98,8 @@ export default async function AdminAuditPage({ searchParams }: PageProps) {
       </form>
 
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
-        <div className="grid grid-cols-[1.1fr_0.9fr_0.8fr_1fr_0.9fr_1.2fr] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
+       <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+        <div className="grid min-w-[840px] grid-cols-[1.1fr_0.9fr_0.8fr_1fr_0.9fr_1.2fr] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
           <span>Fecha</span>
           <span>Accion</span>
           <span>Entidad</span>
@@ -111,7 +112,7 @@ export default async function AdminAuditPage({ searchParams }: PageProps) {
             const actor = usersById.get(log.actorId)
 
             return (
-              <div key={log.id} className="grid grid-cols-[1.1fr_0.9fr_0.8fr_1fr_0.9fr_1.2fr] gap-4 px-5 py-4 text-sm">
+              <div key={log.id} className="grid min-w-[840px] grid-cols-[1.1fr_0.9fr_0.8fr_1fr_0.9fr_1.2fr] gap-4 px-5 py-4 text-sm">
                 <div>
                   <p className="font-medium text-[var(--foreground)]">{formatDate(log.createdAt, { dateStyle: 'medium', timeStyle: 'short' })}</p>
                   <p className="text-xs text-[var(--muted)]">{log.entityId}</p>
@@ -148,6 +149,7 @@ export default async function AdminAuditPage({ searchParams }: PageProps) {
             </p>
           )}
         </div>
+       </div>
       </div>
     </div>
   )

--- a/src/app/(admin)/admin/comisiones/page.tsx
+++ b/src/app/(admin)/admin/comisiones/page.tsx
@@ -120,7 +120,8 @@ export default async function AdminCommissionRulesPage() {
       </form>
 
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
-        <div className="grid grid-cols-[1fr_1fr_0.8fr_0.8fr_0.9fr_0.9fr_auto] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
+       <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+        <div className="grid min-w-[820px] grid-cols-[1fr_1fr_0.8fr_0.8fr_0.9fr_0.9fr_auto] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
           <span>Ámbito</span>
           <span>Fallback</span>
           <span>Tipo</span>
@@ -137,7 +138,7 @@ export default async function AdminCommissionRulesPage() {
             const hasConflict = rule.isActive && activeConflictKeys.has(conflictKey)
 
             return (
-              <div key={rule.id} className="grid grid-cols-[1fr_1fr_0.8fr_0.8fr_0.9fr_0.9fr_auto] gap-4 px-5 py-4 text-sm items-start">
+              <div key={rule.id} className="grid min-w-[820px] grid-cols-[1fr_1fr_0.8fr_0.8fr_0.9fr_0.9fr_auto] gap-4 px-5 py-4 text-sm items-start">
                 <div>
                   <p className="font-medium text-[var(--foreground)]">{vendor?.displayName ?? category?.name ?? 'Global manual'}</p>
                   <p className="text-xs text-[var(--muted)]">
@@ -171,6 +172,7 @@ export default async function AdminCommissionRulesPage() {
             <p className="px-5 py-10 text-center text-sm text-[var(--muted)]">Todavía no hay reglas de comisión creadas.</p>
           )}
         </div>
+       </div>
       </div>
     </div>
   )

--- a/src/app/(admin)/admin/envios/page.tsx
+++ b/src/app/(admin)/admin/envios/page.tsx
@@ -104,7 +104,8 @@ export default async function AdminShippingPage() {
             </div>
 
             <div className="mt-4 overflow-hidden rounded-xl border border-[var(--border)]">
-              <div className="grid grid-cols-[1fr_0.8fr_0.8fr_0.8fr_auto] gap-4 border-b border-[var(--border)] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
+             <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+              <div className="grid min-w-[680px] grid-cols-[1fr_0.8fr_0.8fr_0.8fr_auto] gap-4 border-b border-[var(--border)] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
                 <span>Tarifa</span>
                 <span>Mínimo</span>
                 <span>Precio</span>
@@ -113,7 +114,7 @@ export default async function AdminShippingPage() {
               </div>
               <div className="divide-y divide-[var(--border)]">
                 {zone.rates.map(rate => (
-                  <div key={rate.id} className="grid grid-cols-[1fr_0.8fr_0.8fr_0.8fr_auto] gap-4 px-4 py-3 text-sm items-center">
+                  <div key={rate.id} className="grid min-w-[680px] grid-cols-[1fr_0.8fr_0.8fr_0.8fr_auto] gap-4 px-4 py-3 text-sm items-center">
                     <span className="font-medium text-[var(--foreground)]">{rate.name}</span>
                     <span className="text-[var(--foreground-soft)]">{rate.minOrderAmount == null ? '0,00 EUR' : formatPrice(Number(rate.minOrderAmount))}</span>
                     <span className="text-[var(--foreground-soft)]">{formatPrice(Number(rate.price))}</span>
@@ -125,6 +126,7 @@ export default async function AdminShippingPage() {
                   <p className="px-4 py-6 text-sm text-[var(--muted)]">Esta zona aún no tiene tarifas.</p>
                 )}
               </div>
+             </div>
             </div>
           </div>
         ))}
@@ -143,7 +145,8 @@ export default async function AdminShippingPage() {
           </p>
         </div>
         <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
-          <div className="grid grid-cols-[1.2fr_1fr_0.8fr_1fr_1fr_auto] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
+         <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+          <div className="grid min-w-[920px] grid-cols-[1.2fr_1fr_0.8fr_1fr_1fr_auto] gap-4 border-b border-[var(--border)] px-5 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
             <span>Pedido / Productor</span>
             <span>Estado</span>
             <span>Carrier</span>
@@ -155,7 +158,7 @@ export default async function AdminShippingPage() {
             {shipments.map(s => (
               <div
                 key={s.id}
-                className="grid grid-cols-[1.2fr_1fr_0.8fr_1fr_1fr_auto] items-start gap-4 px-5 py-3 text-sm"
+                className="grid min-w-[920px] grid-cols-[1.2fr_1fr_0.8fr_1fr_1fr_auto] items-start gap-4 px-5 py-3 text-sm"
               >
                 <div className="min-w-0">
                   <p className="truncate font-medium text-[var(--foreground)]">{s.orderNumber}</p>
@@ -201,6 +204,7 @@ export default async function AdminShippingPage() {
               </p>
             )}
           </div>
+         </div>
         </div>
       </div>
     </div>

--- a/src/app/(admin)/admin/ingestion/page.tsx
+++ b/src/app/(admin)/admin/ingestion/page.tsx
@@ -240,8 +240,8 @@ export default async function IngestionReviewQueuePage({ searchParams }: PagePro
         </CardHeader>
 
         <CardBody className="p-0">
-          <div>
-            <table className="w-full table-fixed text-sm">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+            <table className="w-full min-w-[880px] table-fixed text-sm">
               <colgroup>
                 <col />
                 <col className="w-[7rem]" />

--- a/src/app/(admin)/admin/ingestion/telegram/page.tsx
+++ b/src/app/(admin)/admin/ingestion/telegram/page.tsx
@@ -135,8 +135,8 @@ export default async function IngestionTelegramPage() {
           </p>
         </CardHeader>
         <CardBody className="p-0">
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
+            <table className="w-full min-w-[760px] text-sm">
               <thead className="bg-[var(--muted)]/40 text-left text-xs uppercase tracking-wider text-[var(--muted-foreground)]">
                 <tr>
                   <th className="px-4 py-3 font-medium">Chat</th>

--- a/src/app/(admin)/admin/notificaciones/page.tsx
+++ b/src/app/(admin)/admin/notificaciones/page.tsx
@@ -135,8 +135,8 @@ export default async function AdminNotificationsPage({ searchParams }: PageProps
 
       <section className="space-y-2">
         <h2 className="font-semibold text-[var(--foreground)]">Envíos salientes (últimos 100)</h2>
-        <div className="overflow-x-auto rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
-          <table className="min-w-full text-sm">
+        <div className="overflow-x-auto overscroll-x-contain touch-pan-x rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
+          <table className="w-full min-w-[760px] text-sm">
             <thead className="bg-[var(--surface-muted)] text-left">
               <tr>
                 <th className="px-3 py-2">Fecha</th>
@@ -186,8 +186,8 @@ export default async function AdminNotificationsPage({ searchParams }: PageProps
 
       <section className="space-y-2">
         <h2 className="font-semibold text-[var(--foreground)]">Acciones recibidas (últimas 50)</h2>
-        <div className="overflow-x-auto rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
-          <table className="min-w-full text-sm">
+        <div className="overflow-x-auto overscroll-x-contain touch-pan-x rounded-2xl border border-[var(--border)] bg-[var(--surface)]">
+          <table className="w-full min-w-[680px] text-sm">
             <thead className="bg-[var(--surface-muted)] text-left">
               <tr>
                 <th className="px-3 py-2">Fecha</th>

--- a/src/app/(admin)/admin/productos/page.tsx
+++ b/src/app/(admin)/admin/productos/page.tsx
@@ -238,8 +238,8 @@ export default async function AdminProductsPage({ searchParams }: Props) {
         </CardBody>
       </Card>
 
-      <div className="overflow-x-auto rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
-        <table className="w-full table-auto border-collapse text-sm">
+      <div className="overflow-x-auto overscroll-x-contain touch-pan-x rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
+        <table className="w-full min-w-[840px] table-auto border-collapse text-sm">
           <thead>
             <tr className="border-b border-[var(--border)] text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">
               <th className="px-5 py-3 text-left">Producto</th>

--- a/src/app/(admin)/admin/usuarios/page.tsx
+++ b/src/app/(admin)/admin/usuarios/page.tsx
@@ -183,7 +183,7 @@ export default async function AdminUsersPage({ searchParams }: PageProps) {
         </CardHeader>
 
         <CardBody className="p-0">
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto overscroll-x-contain touch-pan-x">
             <table className="min-w-[920px] w-full table-fixed text-sm">
               <colgroup>
                 <col />

--- a/test/contracts/mobile-ux.test.ts
+++ b/test/contracts/mobile-ux.test.ts
@@ -95,6 +95,18 @@ test('admin tables contain horizontal overscroll and opt into touch-pan-x', () =
     'src/components/admin/AdminProducersClient.tsx',
     'src/components/admin/AdminSubscriptionsClient.tsx',
     'src/components/admin/analytics/OrdersTable.tsx',
+    // Page-level admin tables: each one has a min-w on the inner
+    // grid/table and an overflow-x-auto + touch-pan-x wrapper so
+    // mobile users get a contained scroll inside the card instead
+    // of the document growing wider than the viewport.
+    'src/app/(admin)/admin/comisiones/page.tsx',
+    'src/app/(admin)/admin/auditoria/page.tsx',
+    'src/app/(admin)/admin/envios/page.tsx',
+    'src/app/(admin)/admin/notificaciones/page.tsx',
+    'src/app/(admin)/admin/ingestion/page.tsx',
+    'src/app/(admin)/admin/ingestion/telegram/page.tsx',
+    'src/app/(admin)/admin/usuarios/page.tsx',
+    'src/app/(admin)/admin/productos/page.tsx',
   ]
   for (const file of files) {
     const source = read(file)


### PR DESCRIPTION
## Summary

Continues #816. The defensive \`overflow-x: clip\` on \`html\`/\`body\` already prevents the document from gaining a scrollbar, but admin tables themselves were still being clipped (unreadable) on mobile because their grids/tables had no \`min-width\` to hold their layout open.

This PR adopts the existing admin-table contract — wrap with \`overflow-x-auto overscroll-x-contain touch-pan-x\` and give the inner grid/table an explicit \`min-w-[NNNNpx]\` — across the page-level admin tables that did not yet follow it:

- \`/admin/comisiones\` — 7-column grid, \`min-w-[820px]\`
- \`/admin/auditoria\` — 6-column grid, \`min-w-[840px]\`
- \`/admin/envios\` — shipping rates per zone (\`min-w-[680px]\`) + generated-shipments grid (\`min-w-[920px]\`)
- \`/admin/notificaciones\` — deliveries (\`min-w-[760px]\`) + actions (\`min-w-[680px]\`)
- \`/admin/ingestion\` — review queue (\`min-w-[880px]\`)
- \`/admin/ingestion/telegram\` — chat sync (\`min-w-[760px]\`)
- \`/admin/usuarios\` — added \`overscroll-x-contain touch-pan-x\` to the existing wrapper (already had \`min-w-[920px]\`)
- \`/admin/productos\` — added wrapper classes + \`min-w-[840px]\` floor

Per-table min-widths chosen to fit column labels + reasonable cell content without wrapping awkwardly. \`overscroll-x-contain\` keeps the inner pan from chaining to an iOS document-level back-swipe.

The \`mobile-ux\` contract test now asserts the wrapper class on the 8 new pages too — total 12 admin tables under the contract.

Pairs with #815 (Tooltip touch fallback) and #816 (global \`overflow-x: clip\` + hero/vendor toolbar). Closes the mobile-UX audit loop.

## Test plan
- [x] \`npx tsx --test test/contracts/mobile-ux.test.ts\` — 32/32 pass (8 new wrapper assertions)
- [ ] Manual at 375×667 (iPhone SE) on each touched page: scrolling the table horizontally inside the card works, document does not back-swipe, header stays sticky
- [ ] Sanity desktop: cards render unchanged at \`>= md\` widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)